### PR TITLE
Allow also odd-order butterworth filters

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -7,6 +7,11 @@ jobs:
     name: Check test and lint Linux
     runs-on: ubuntu-latest
     container: ubuntu:20.04
+
+    env:
+      # for apt-get: otherwise installing tzdata gets stuck asking about the time zone.
+      DEBIAN_FRONTEND: noninteractive
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -15,7 +20,7 @@ jobs:
         run: apt-get update
 
       - name: Install utils
-        run: apt-get install curl wget -y
+        run: apt-get install build-essential curl wget -y
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -6,7 +6,7 @@ jobs:
   check_lint_linux:
     name: Check test and lint Linux
     runs-on: ubuntu-latest
-    container: ubuntu:19.10
+    container: ubuntu:20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/src/biquadcombo.rs
+++ b/src/biquadcombo.rs
@@ -169,7 +169,7 @@ pub fn validate_config(conf: &config::BiquadComboParameters) -> Res<()> {
             if *freq <= 0.0 {
                 return Err(config::ConfigError::new("Frequency must be > 0").into());
             }
-            if *order % 2 > 0 {
+            if *order <= 0 {
                 return Err(
                     config::ConfigError::new("Butterworth order must be larger than zero").into(),
                 );


### PR DESCRIPTION
Hi Henrik

Found your project through faktiskt.io and tried it out a bit.
Very nice! Managed to build it on Linux according to the instructions and run it with Alsa and a 5.1 channel SoundBlaster SB1095 USB sound interface.

Found a little bug though when I tried to create a fifth order butterworth filter:
The check for Butterworth filters order only allowed even-order filters.
Jag gissar att det är den ökända "cut-'n-paste-katten" som varit framme om man jämför med LR-filtrets kontroll. ;)