### PR TITLE
[WIP] Add bluez-alsa audio source support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ default = ["websocket"]
 pulse-backend = ["libpulse-simple-binding", "libpulse-binding"]
 cpal-backend = ["cpal"]
 jack-backend = ["cpal-backend", "cpal/jack"]
+bluez-backend = ["zbus"]
 32bit = []
 websocket = ["tungstenite"]
 secure-websocket = ["websocket", "native-tls", "tungstenite/native-tls"]
@@ -30,6 +31,7 @@ path = "src/bin.rs"
 alsa = "0.6.0"
 alsa-sys = "0.3.1"
 nix = "0.23"
+zbus = { version = "3.0.0", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 #coreaudio-rs = { path = "../coreaudio-rs" }

--- a/README.md
+++ b/README.md
@@ -505,6 +505,19 @@ See the "camilladsp-config" repository under [Related projects](#related-project
 
 TODO test with Jack.
 
+### BlueALSA
+BlueALSA ([bluez-alsa](https://github.com/Arkq/bluez-alsa)) is a project to receive or send audio through Bluetooth A2DP. The `Bluez` source will connect to D-Bus of BlueALSA and get the audio directly from there, avoiding instability of ALSA loopback interface. Currently only capture (a2dp-sink) is supported.
+
+```
+  capture:
+    type: Bluez
+    format: S16LE
+    channels: 2
+    dbus_path: /org/bluealsa/hci0/dev_F8_87_F1_87_BF_30/a2dpsnk/source
+    service: org.bluealsa # Optional, specify if you have more than one instance of bluealsa running
+```
+
+The dbus path can be listed from `gdbus call -y --dest org.bluealsa -o /org/bluealsa -m org.freedesktop.DBus.ObjectManager.GetManagedObjects`. You have to specify correct capture sample rate, channel count and format. These parameters can be fetched from `bluealsa-aplay -L`.
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ All the available options, or "features" are:
 - `pulse-backend`: PulseAudio support
 - `cpal-backend`: Used for Jack support (automatically enabled when needed).
 - `jack-backend`: Jack support.
+- `bluez-backend`: Bluetooth support via BlueALSA (Linux only)
 - `websocket`: Websocket server for control
 - `secure-websocket`: Enable secure websocket, also enables the `websocket` feature
 - `FFTW`: Use FFTW instead of RustFFT
@@ -506,18 +507,64 @@ See the "camilladsp-config" repository under [Related projects](#related-project
 TODO test with Jack.
 
 ### BlueALSA
-BlueALSA ([bluez-alsa](https://github.com/Arkq/bluez-alsa)) is a project to receive or send audio through Bluetooth A2DP. The `Bluez` source will connect to D-Bus of BlueALSA and get the audio directly from there, avoiding instability of ALSA loopback interface. Currently only capture (a2dp-sink) is supported.
+BlueALSA ([bluez-alsa](https://github.com/Arkq/bluez-alsa)) is a project to receive or send audio through Bluetooth A2DP.
+The `Bluez` source will connect to BlueALSA via D-Bus to get a file descriptor.
+It will then read the audio directly from there, avoiding the need to go via ALSA. 
+Currently only capture (a2dp-sink) is supported.
+BlueALSA is supported on Linux only, and requires building CamillaDSP with the `bluez-backend` Cargo feature.
 
+#### Prerequisites
+Start by installing `bluez-alsa`.
+Both Pipewire and PulseAudio will interfere with BlueALSA and must be disabled.
+The source device should be paired after disabling Pipewire or PulseAudio and enabling BlueALSA. 
+
+#### Configuration
+
+Example configuration:
 ```
+devices:
+  samplerate: 44100
+  chunksize: 4096
+  target_level: 8000
+  adjust_period: 3
+  enable_resampling: true
+  enable_rate_adjust: true
   capture:
     type: Bluez
     format: S16LE
     channels: 2
-    dbus_path: /org/bluealsa/hci0/dev_F8_87_F1_87_BF_30/a2dpsnk/source
-    service: org.bluealsa # Optional, specify if you have more than one instance of bluealsa running
+    dbus_path: /org/bluealsa/hci0/dev_A0_B1_C2_D3_E4_F5/a2dpsnk/source
+    service: org.bluealsa (*)
 ```
 
-The dbus path can be listed from `gdbus call -y --dest org.bluealsa -o /org/bluealsa -m org.freedesktop.DBus.ObjectManager.GetManagedObjects`. You have to specify correct capture sample rate, channel count and format. These parameters can be fetched from `bluealsa-aplay -L`.
+After connecting an A2DP device, for example a mobile phone, the D-Bus path can be found with this command:
+```
+gdbus call -y --dest org.bluealsa -o /org/bluealsa -m org.freedesktop.DBus.ObjectManager.GetManagedObjects
+```
+This should produce output similar to this:
+```
+({objectpath '/org/bluealsa/hci0/dev_A0_B1_C2_D3_E4_F5/a2dpsnk/source': {'org.bluealsa.PCM1': {'Device': <objectpath '/org/bluez/hci0/dev_A0_B1_C2_D3_E4_F5'>, 'Sequence': <uint32 0>, 'Transport': <'A2DP-sink'>, 'Mode': <'source'>, 'Format': <uint16 33296>, 'Channels': <byte 0x02>, 'Sampling': <uint32 44100>, 'Codec': <'AAC'>, 'CodecConfiguration': <[byte 0x80, 0x01, 0x04, 0x03, 0x5b, 0x60]>, 'Delay': <uint16 150>, 'SoftVolume': <true>, 'Volume': <uint16 32639>}}},)
+```
+The wanted path is the string after `objectpath`.
+If the output is looking like `(@a{oa{sa{sv}}} {},)`, then no A2DP source is connected or detected. 
+Connect an A2DP device and try again. If a device is already connected, try removing and pairing the device again.
+
+The `service` property can be left out to get the default. This only needs changing if there is more than one instance of BlueALSA running.
+
+You have to specify correct capture sample rate, number of channel and sample format.
+These parameters can be found with `bluealsa-aplay`: 
+```
+> bluealsa-aplay -L
+
+bluealsa:DEV=A0:B1:C2:D3:E4:F5,PROFILE=a2dp,SRV=org.bluealsa
+    MyPhone, trusted phone, capture
+    A2DP (AAC): S16_LE 2 channels 44100 Hz
+```
+
+Note that Bluetooth transfers data in chunks, and the time between chunks can vary. 
+To avoid underruns, use a large chunksize and a large target_level.
+The values in the example above are a good starting point.
+Rate adjust should also be enabled.
 
 # Configuration
 
@@ -691,6 +738,7 @@ Any parameter marked (*) in all examples in this section are optional. If they a
     * `File`
     * `Stdin` (capture only)
     * `Stdout` (playback only)
+    * `Bluez` (capture only)
     * `Jack`
     * `Wasapi`
     * `CoreAudio`

--- a/src/audiodevice.rs
+++ b/src/audiodevice.rs
@@ -550,6 +550,29 @@ pub fn get_capture_device(conf: config::Devices) -> Box<dyn CaptureDevice> {
             stop_on_rate_change: conf.stop_on_rate_change,
             rate_measure_interval: conf.rate_measure_interval,
         }),
+        #[cfg(all(target_os = "linux", feature = "bluez-backend"))]
+        config::CaptureDevice::Bluez {
+            service,
+            dbus_path,
+            channels,
+            format,
+        } => Box::new(filedevice::FileCaptureDevice {
+            source: filedevice::CaptureSource::BluezDBus(service, dbus_path),
+            samplerate: conf.samplerate,
+            enable_resampling: conf.enable_resampling,
+            capture_samplerate,
+            resampler_conf: conf.resampler_type,
+            chunksize: conf.chunksize,
+            channels,
+            sample_format: format,
+            extra_samples: 0,
+            silence_threshold: conf.silence_threshold,
+            silence_timeout: conf.silence_timeout,
+            skip_bytes: 0,
+            read_bytes: 0,
+            stop_on_rate_change: conf.stop_on_rate_change,
+            rate_measure_interval: conf.rate_measure_interval,
+        }),
         #[cfg(target_os = "macos")]
         config::CaptureDevice::CoreAudio {
             channels,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -454,6 +454,9 @@ fn main_process() -> i32 {
     if cfg!(feature = "jack-backend") {
         features.push("jack-backend");
     }
+    if cfg!(all(target_os = "linux", feature = "bluez-backend")) {
+        features.push("bluez-backend");
+    }
     if cfg!(feature = "websocket") {
         features.push("websocket");
     }

--- a/src/filedevice_bluez.rs
+++ b/src/filedevice_bluez.rs
@@ -1,0 +1,54 @@
+use std::io;
+use std::io::Read;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::Arc;
+use zbus::blocking::Connection;
+use zbus::zvariant::OwnedFd;
+use zbus::Message;
+
+use crate::filereader_nonblock::NonBlockingReader;
+
+pub struct WrappedBluezFd {
+    pipe_fd: zbus::zvariant::OwnedFd,
+    _ctrl_fd: zbus::zvariant::OwnedFd,
+    _msg: Arc<Message>,
+}
+
+impl WrappedBluezFd {
+    fn new_from_open_message(r: Arc<Message>) -> WrappedBluezFd {
+        let (pipe_fd, ctrl_fd): (OwnedFd, OwnedFd) = r.body().unwrap();
+        return WrappedBluezFd {
+            pipe_fd: pipe_fd,
+            _ctrl_fd: ctrl_fd,
+            _msg: r,
+        };
+    }
+}
+
+impl Read for WrappedBluezFd {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        nix::unistd::read(self.pipe_fd.as_raw_fd(), buf).map_err(|e| io::Error::from(e))
+    }
+}
+
+impl AsRawFd for WrappedBluezFd {
+    fn as_raw_fd(&self) -> RawFd {
+        return self.pipe_fd.as_raw_fd();
+    }
+}
+
+pub fn open_bluez_dbus_fd(
+    service: String,
+    path: String,
+    chunksize: usize,
+    samplerate: usize,
+) -> Result<Box<NonBlockingReader<WrappedBluezFd>>, zbus::Error> {
+    let conn1 = Connection::system()?;
+    let res = conn1.call_method(Some(service), path, Some("org.bluealsa.PCM1"), "Open", &())?;
+
+    let reader = Box::new(NonBlockingReader::new(
+        WrappedBluezFd::new_from_open_message(res),
+        2 * 1000 * chunksize as u64 / samplerate as u64,
+    ));
+    return Ok(reader);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ pub mod fftconv;
 pub mod fftconv_fftw;
 pub mod fifoqueue;
 pub mod filedevice;
+#[cfg(all(target_os = "linux", feature = "bluez-backend"))]
+pub mod filedevice_bluez;
 #[cfg(not(target_os = "linux"))]
 pub mod filereader;
 #[cfg(target_os = "linux")]
@@ -230,6 +232,9 @@ pub fn list_supported_devices() -> (Vec<String>, Vec<String>) {
     if cfg!(feature = "pulse-backend") {
         playbacktypes.push("Pulse".to_owned());
         capturetypes.push("Pulse".to_owned());
+    }
+    if cfg!(feature = "bluez-backend") {
+        capturetypes.push("Bluez".to_owned());
     }
     if cfg!(feature = "jack-backend") {
         playbacktypes.push("Jack".to_owned());


### PR DESCRIPTION
This adds BlueALSA audio source support.

BlueALSA ([bluez-alsa](https://github.com/Arkq/bluez-alsa)) is a project to receive or send audio through Bluetooth A2DP. In order to receive audio from it, one has to either use bluealsa-pcm ALSA plugin or kernel ALSA loopback. However, neither of these are stable: the ALSA plugin will lock up my kernel, and loopback are experiencing severe underruns (per minute). 

In order to receive audio without glitch, I added a `Bluez` capture source to read audio from the D-Bus pipe file descriptor directly. Currently, receiving audio is working.

TODO:
* Automatic detection of parameters
* Allow specifying mac address of device rather than D-Bus path
* Playback support
* Buffer level is unstable. Investigate how to get a stable buffer level.