### PR TITLE
Fix compiling with fftw

### DIFF
--- a/src/fftconv_fftw.rs
+++ b/src/fftconv_fftw.rs
@@ -102,7 +102,8 @@ pub struct FftConv {
 
 impl FftConv {
     /// Create a new FFT colvolution filter.
-    pub fn new(name: String, data_length: usize, coeffs: &[PrcFmt]) -> Self {
+    pub fn new(name: &str, data_length: usize, coeffs: &[PrcFmt]) -> Self {
+        let name = name.to_string();
         let input_buf = AlignedVec::<PrcFmt>::new(2 * data_length);
         let temp_buf = AlignedVec::<ComplexFmt>::new(data_length + 1);
         let output_buf = AlignedVec::<PrcFmt>::new(2 * data_length);
@@ -144,20 +145,23 @@ impl FftConv {
         }
     }
 
-    pub fn from_config(name: String, data_length: usize, conf: config::ConvParameters) -> Self {
+    pub fn from_config(name: &str, data_length: usize, conf: config::ConvParameters) -> Self {
         let values = match conf {
-            config::ConvParameters::Values { values, length } => {
-                filters::pad_vector(&values, length)
+            config::ConvParameters::Values { values } => values,
+            config::ConvParameters::Raw(params) => filters::read_coeff_file(
+                &params.filename,
+                &params.format(),
+                params.read_bytes_lines(),
+                params.skip_bytes_lines(),
+            )
+            .unwrap(),
+            config::ConvParameters::Wav(params) => {
+                filters::read_wav(&params.filename, params.channel()).unwrap()
             }
-            config::ConvParameters::Raw {
-                filename,
-                format,
-                read_bytes_lines,
-                skip_bytes_lines,
-            } => filters::read_coeff_file(&filename, &format, read_bytes_lines, skip_bytes_lines)
-                .unwrap(),
-            config::ConvParameters::Wav { filename, channel } => {
-                filters::read_wav(&filename, channel).unwrap()
+            config::ConvParameters::Dummy { length } => {
+                let mut values = vec![0.0; length];
+                values[0] = 1.0;
+                values
             }
         };
         FftConv::new(name, data_length, &values)
@@ -165,8 +169,8 @@ impl FftConv {
 }
 
 impl Filter for FftConv {
-    fn name(&self) -> String {
-        self.name.clone()
+    fn name(&self) -> &str {
+        &self.name
     }
 
     /// Process a waveform by FT, then multiply transform with transform of filter, and then transform back.
@@ -210,22 +214,26 @@ impl Filter for FftConv {
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
-        if let config::Filter::Conv { parameters: conf } = conf {
+        if let config::Filter::Conv {
+            parameters: conf, ..
+        } = conf
+        {
             let coeffs = match conf {
-                config::ConvParameters::Values { values, length } => {
-                    filters::pad_vector(&values, length)
+                config::ConvParameters::Values { values } => values,
+                config::ConvParameters::Raw(params) => filters::read_coeff_file(
+                    &params.filename,
+                    &params.format(),
+                    params.read_bytes_lines(),
+                    params.skip_bytes_lines(),
+                )
+                .unwrap(),
+                config::ConvParameters::Wav(params) => {
+                    filters::read_wav(&params.filename, params.channel()).unwrap()
                 }
-                config::ConvParameters::Raw {
-                    filename,
-                    format,
-                    read_bytes_lines,
-                    skip_bytes_lines,
-                } => {
-                    filters::read_coeff_file(&filename, &format, read_bytes_lines, skip_bytes_lines)
-                        .unwrap()
-                }
-                config::ConvParameters::Wav { filename, channel } => {
-                    filters::read_wav(&filename, channel).unwrap()
+                config::ConvParameters::Dummy { length } => {
+                    let mut values = vec![0.0; length];
+                    values[0] = 1.0;
+                    values
                 }
             };
 
@@ -264,22 +272,21 @@ impl Filter for FftConv {
 /// Validate a FFT convolution config.
 pub fn validate_config(conf: &config::ConvParameters) -> Res<()> {
     match conf {
-        config::ConvParameters::Values { .. } => Ok(()),
-        config::ConvParameters::Raw {
-            filename,
-            format,
-            read_bytes_lines,
-            skip_bytes_lines,
-        } => {
-            let coeffs =
-                filters::read_coeff_file(&filename, &format, *read_bytes_lines, *skip_bytes_lines)?;
+        config::ConvParameters::Values { .. } | config::ConvParameters::Dummy { .. } => Ok(()),
+        config::ConvParameters::Raw(params) => {
+            let coeffs = filters::read_coeff_file(
+                &params.filename,
+                &params.format(),
+                params.read_bytes_lines(),
+                params.skip_bytes_lines(),
+            )?;
             if coeffs.is_empty() {
                 return Err(config::ConfigError::new("Conv coefficients are empty").into());
             }
             Ok(())
         }
-        config::ConvParameters::Wav { filename, channel } => {
-            let coeffs = filters::read_wav(&filename, *channel)?;
+        config::ConvParameters::Wav(params) => {
+            let coeffs = filters::read_wav(&params.filename, params.channel())?;
             if coeffs.is_empty() {
                 return Err(config::ConfigError::new("Conv coefficients are empty").into());
             }


### PR DESCRIPTION
No longer compiled because of https://github.com/HEnquist/camilladsp/pull/253 and https://github.com/HEnquist/camilladsp/commit/5d9bb1fd8d02208ec64fecd85e80b9c449eef6da.

Maybe add a CI action with all the optionals turned on? Can add it if you'd like that.