### PR TITLE
Optimize mutexes

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install PulseAudio
         run: DEBIAN_FRONTEND="noninteractive" sudo apt-get install libpulse0 libpulse-dev -y
 
+      - name: Install Jack
+        run: DEBIAN_FRONTEND="noninteractive" sudo apt-get install libjack-dev -y
+
       - name: Install OpenSSL
         run: sudo apt-get install openssl libssl-dev -y
 
@@ -37,16 +40,17 @@ jobs:
       - name: Run cargo check nodefault
         run: cargo check --no-default-features
 
-      - name: Run cargo test with pulse-backend
-        run: cargo test --features pulse-backend
+      - name: Run cargo test with all supported backends
+        run: cargo test --features bluez-backend,cpal-backend,jack-backend,pulse-backend,
+
+      - name: Run cargo test with all optional features
+        run: cargo test --features 32bit,debug,fftw,secure-websocket
 
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
         run: cargo clippy -- -D warnings
-
-
 
   check_test_arm:
     name: Check and test Linux arm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ New features:
   - Shibata and ShibataLow 88.2, 96 and 192.
 
 Changes:
-- Optimize cpu load of dithering and delay filters.
+- Optimize cpu load in general, and of dithering and delay filters in particular.
 - Uniform dithering renamed to Flat.
 - Simple dithering renamed to HighPass, implements a Wannamaker high passed triangular dither.
 - Shibata441 and Shibata48 dither higher precision and smoother curve.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ cpal = { version = "0.13.3", optional = true }
 #rawsample = { git = "https://github.com/HEnquist/rawsample", branch = "main" }
 rawsample = "0.2.0"
 circular-queue = "0.2.6"
+parking_lot = { version = "0.12.1", features = ["hardware-lock-elision"] }
 
 [build-dependencies]
 version_check = "0.9"

--- a/src/audiodevice.rs
+++ b/src/audiodevice.rs
@@ -27,7 +27,7 @@ use rubato::{
 use std::error;
 use std::fmt;
 use std::sync::mpsc;
-use std::sync::{Arc, Barrier, RwLock};
+use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::time::Instant;
 
@@ -218,7 +218,7 @@ pub trait PlaybackDevice {
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
-        playback_status: Arc<RwLock<PlaybackStatus>>,
+        playback_status: Arc<Mutex<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>>;
 }
 
@@ -230,7 +230,7 @@ pub trait CaptureDevice {
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
-        capture_status: Arc<RwLock<CaptureStatus>>,
+        capture_status: Arc<Mutex<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>>;
 }
 

--- a/src/audiodevice.rs
+++ b/src/audiodevice.rs
@@ -20,6 +20,7 @@ use crate::filedevice;
 use crate::pulsedevice;
 #[cfg(target_os = "windows")]
 use crate::wasapidevice;
+use parking_lot::RwLock;
 use rubato::{
     calculate_cutoff, FastFixedOut, FftFixedOut, PolynomialDegree, SincFixedOut,
     SincInterpolationParameters, SincInterpolationType, VecResampler, WindowFunction,
@@ -27,7 +28,7 @@ use rubato::{
 use std::error;
 use std::fmt;
 use std::sync::mpsc;
-use std::sync::{Arc, Barrier, Mutex};
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Instant;
 
@@ -218,7 +219,7 @@ pub trait PlaybackDevice {
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
-        playback_status: Arc<Mutex<PlaybackStatus>>,
+        playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>>;
 }
 
@@ -230,7 +231,7 @@ pub trait CaptureDevice {
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
-        capture_status: Arc<Mutex<CaptureStatus>>,
+        capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>>;
 }
 

--- a/src/basicfilters.rs
+++ b/src/basicfilters.rs
@@ -434,15 +434,16 @@ pub fn validate_gain_config(conf: &config::GainParameters) -> Res<()> {
 
 #[cfg(test)]
 mod tests {
+    use crate::PrcFmt;
     use crate::basicfilters::{Delay, Gain};
     use crate::filters::Filter;
 
-    fn is_close(left: f64, right: f64, maxdiff: f64) -> bool {
+    fn is_close(left: PrcFmt, right: PrcFmt, maxdiff: PrcFmt) -> bool {
         println!("{} - {}", left, right);
         (left - right).abs() < maxdiff
     }
 
-    fn compare_waveforms(left: Vec<f64>, right: Vec<f64>, maxdiff: f64) -> bool {
+    fn compare_waveforms(left: Vec<PrcFmt>, right: Vec<PrcFmt>, maxdiff: PrcFmt) -> bool {
         for (val_l, val_r) in left.iter().zip(right.iter()) {
             if !is_close(*val_l, *val_r, maxdiff) {
                 return false;

--- a/src/basicfilters.rs
+++ b/src/basicfilters.rs
@@ -434,9 +434,9 @@ pub fn validate_gain_config(conf: &config::GainParameters) -> Res<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::PrcFmt;
     use crate::basicfilters::{Delay, Gain};
     use crate::filters::Filter;
+    use crate::PrcFmt;
 
     fn is_close(left: PrcFmt, right: PrcFmt, maxdiff: PrcFmt) -> bool {
         println!("{} - {}", left, right);

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::RwLock;
+use std::sync::Mutex;
 
 //type SmpFmt = i16;
 use crate::PrcFmt;
@@ -24,7 +24,7 @@ pub struct Overrides {
 }
 
 lazy_static! {
-    pub static ref OVERRIDES: RwLock<Overrides> = RwLock::new(Overrides {
+    pub static ref OVERRIDES: Mutex<Overrides> = Mutex::new(Overrides {
         samplerate: None,
         sample_format: None,
         extra_samples: None,
@@ -1329,7 +1329,7 @@ pub fn load_config(filename: &str) -> Res<Configuration> {
 }
 
 fn apply_overrides(configuration: &mut Configuration) {
-    if let Some(rate) = OVERRIDES.read().unwrap().samplerate {
+    if let Some(rate) = OVERRIDES.lock().unwrap().samplerate {
         let cfg_rate = configuration.devices.samplerate;
         let cfg_chunksize = configuration.devices.chunksize;
 
@@ -1377,7 +1377,7 @@ fn apply_overrides(configuration: &mut Configuration) {
             }
         }
     }
-    if let Some(extra) = OVERRIDES.read().unwrap().extra_samples {
+    if let Some(extra) = OVERRIDES.lock().unwrap().extra_samples {
         debug!("Apply override for extra_samples: {}", extra);
         #[allow(unreachable_patterns)]
         match &mut configuration.devices.capture {
@@ -1390,7 +1390,7 @@ fn apply_overrides(configuration: &mut Configuration) {
             _ => {}
         }
     }
-    if let Some(chans) = OVERRIDES.read().unwrap().channels {
+    if let Some(chans) = OVERRIDES.lock().unwrap().channels {
         debug!("Apply override for capture channels: {}", chans);
         match &mut configuration.devices.capture {
             CaptureDevice::File(dev) => {
@@ -1434,7 +1434,7 @@ fn apply_overrides(configuration: &mut Configuration) {
             }
         }
     }
-    if let Some(fmt) = OVERRIDES.read().unwrap().sample_format {
+    if let Some(fmt) = OVERRIDES.lock().unwrap().sample_format {
         debug!("Apply override for capture sample format: {}", fmt);
         match &mut configuration.devices.capture {
             CaptureDevice::File(dev) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::compressor;
 use crate::filters;
 use crate::mixer;
+use parking_lot::RwLock;
 use serde::{de, Deserialize, Serialize};
 //use serde_with;
 use std::collections::HashMap;
@@ -10,7 +11,6 @@ use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
 
 //type SmpFmt = i16;
 use crate::PrcFmt;
@@ -24,7 +24,7 @@ pub struct Overrides {
 }
 
 lazy_static! {
-    pub static ref OVERRIDES: Mutex<Overrides> = Mutex::new(Overrides {
+    pub static ref OVERRIDES: RwLock<Overrides> = RwLock::new(Overrides {
         samplerate: None,
         sample_format: None,
         extra_samples: None,
@@ -1329,7 +1329,7 @@ pub fn load_config(filename: &str) -> Res<Configuration> {
 }
 
 fn apply_overrides(configuration: &mut Configuration) {
-    let overrides = OVERRIDES.lock().unwrap();
+    let overrides = OVERRIDES.read();
     if let Some(rate) = overrides.samplerate {
         let cfg_rate = configuration.devices.samplerate;
         let cfg_chunksize = configuration.devices.chunksize;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1329,7 +1329,8 @@ pub fn load_config(filename: &str) -> Res<Configuration> {
 }
 
 fn apply_overrides(configuration: &mut Configuration) {
-    if let Some(rate) = OVERRIDES.lock().unwrap().samplerate {
+    let overrides = OVERRIDES.lock().unwrap();
+    if let Some(rate) = overrides.samplerate {
         let cfg_rate = configuration.devices.samplerate;
         let cfg_chunksize = configuration.devices.chunksize;
 
@@ -1377,7 +1378,7 @@ fn apply_overrides(configuration: &mut Configuration) {
             }
         }
     }
-    if let Some(extra) = OVERRIDES.lock().unwrap().extra_samples {
+    if let Some(extra) = overrides.extra_samples {
         debug!("Apply override for extra_samples: {}", extra);
         #[allow(unreachable_patterns)]
         match &mut configuration.devices.capture {
@@ -1390,7 +1391,7 @@ fn apply_overrides(configuration: &mut Configuration) {
             _ => {}
         }
     }
-    if let Some(chans) = OVERRIDES.lock().unwrap().channels {
+    if let Some(chans) = overrides.channels {
         debug!("Apply override for capture channels: {}", chans);
         match &mut configuration.devices.capture {
             CaptureDevice::File(dev) => {
@@ -1434,7 +1435,7 @@ fn apply_overrides(configuration: &mut Configuration) {
             }
         }
     }
-    if let Some(fmt) = OVERRIDES.lock().unwrap().sample_format {
+    if let Some(fmt) = overrides.sample_format {
         debug!("Apply override for capture sample format: {}", fmt);
         match &mut configuration.devices.capture {
             CaptureDevice::File(dev) => {

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -399,6 +399,9 @@ mod tests {
         let chunk = AudioChunk::new(waveforms, 0.0, 0.0, 1, 1);
         let mut buffer = vec![0u8; 4];
         chunk_to_buffer_rawbytes(&chunk, &mut buffer, &SampleFormat::S32LE);
+        #[cfg(feature = "32bit")]
+        let expected = vec![0xD0, 0xCC, 0xCC, 0x0C];
+        #[cfg(not(feature = "32bit"))]
         let expected = vec![0xCC, 0xCC, 0xCC, 0x0C];
         assert_eq!(buffer, expected);
     }
@@ -419,6 +422,9 @@ mod tests {
         let chunk = AudioChunk::new(waveforms, 0.0, 0.0, 1, 1);
         let mut buffer = vec![0u8; 8];
         chunk_to_buffer_rawbytes(&chunk, &mut buffer, &SampleFormat::FLOAT64LE);
+        #[cfg(feature = "32bit")]
+        let expected = vec![0x00, 0x00, 0x00, 0xA0, 0x99, 0x99, 0xB9, 0x3F];
+        #[cfg(not(feature = "32bit"))]
         let expected = vec![0x9A, 0x99, 0x99, 0x99, 0x99, 0x99, 0xB9, 0x3F];
         assert_eq!(buffer, expected);
     }
@@ -491,9 +497,6 @@ mod tests {
 
     #[test]
     fn clipping_32() {
-        #[cfg(feature = "32bit")]
-        let waveforms = vec![vec![-1.0, 0.0, 2147483520.0 / 2147483648.0]; 1];
-        #[cfg(not(feature = "32bit"))]
         let waveforms = vec![vec![-1.0, 0.0, 2147483647.0 / 2147483648.0]; 1];
         let chunk = AudioChunk::new(vec![vec![-2.0, 0.0, 2.0]; 1], 0.0, 0.0, 3, 3);
         let mut buffer = vec![0u8; 3 * 4];

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -289,11 +289,11 @@ mod tests {
     use crate::config::SampleFormat;
     use crate::conversions::{buffer_to_chunk_rawbytes, chunk_to_buffer_rawbytes};
     #[cfg(feature = "cpal-backend")]
-    use crate::PrcFmt;
-    #[cfg(feature = "cpal-backend")]
-    use conversions::{
+    use crate::conversions::{
         chunk_to_queue_float, chunk_to_queue_int, queue_to_chunk_float, queue_to_chunk_int,
     };
+    #[cfg(feature = "cpal-backend")]
+    use crate::PrcFmt;
     #[cfg(feature = "cpal-backend")]
     use std::collections::VecDeque;
 

--- a/src/coreaudiodevice.rs
+++ b/src/coreaudiodevice.rs
@@ -352,7 +352,7 @@ impl PlaybackDevice for CoreaudioPlaybackDevice {
                         num_frames, data, ..
                     } = args;
                     trace!("playback cb called with {} frames", num_frames);
-                    while sample_queue.len() < (blockalign as usize * num_frames as usize) {
+                    while sample_queue.len() < (blockalign * num_frames) {
                         trace!("playback loop needs more samples, reading from channel");
                         match rx_dev.try_recv() {
                             Ok(PlaybackDeviceMessage::Data(chunk)) => {

--- a/src/cpaldevice.rs
+++ b/src/cpaldevice.rs
@@ -13,7 +13,7 @@ use rubato::VecResampler;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, Barrier, RwLock};
+use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::time;
 
@@ -201,7 +201,7 @@ impl PlaybackDevice for CpalPlaybackDevice {
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
-        playback_status: Arc<RwLock<PlaybackStatus>>,
+        playback_status: Arc<Mutex<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
         let host_cfg = self.host.clone();
@@ -287,7 +287,7 @@ impl PlaybackDevice for CpalPlaybackDevice {
                                             .store(sample_queue.len(), Ordering::Relaxed);
                                         if clipped > 0 {
                                             playback_status_clone
-                                                .write()
+                                                .lock()
                                                 .unwrap()
                                                 .clipped_samples += clipped;
                                         }
@@ -343,7 +343,7 @@ impl PlaybackDevice for CpalPlaybackDevice {
                                             .store(sample_queue.len(), Ordering::Relaxed);
                                         if clipped > 0 {
                                             playback_status_clone
-                                                .write()
+                                                .lock()
                                                 .unwrap()
                                                 .clipped_samples += clipped;
                                         }
@@ -396,13 +396,13 @@ impl PlaybackDevice for CpalPlaybackDevice {
                                             status_channel
                                                 .send(StatusMessage::SetSpeed(speed))
                                                 .unwrap();
-                                            playback_status.write().unwrap().buffer_level =
+                                            playback_status.lock().unwrap().buffer_level =
                                                 av_delay as usize;
                                         }
                                     }
                                     chunk.update_stats(&mut chunk_stats);
-                                    playback_status.write().unwrap().signal_rms.add_record_squared(chunk_stats.rms_linear());
-                                    playback_status.write().unwrap().signal_peak.add_record(chunk_stats.peak_linear());
+                                    playback_status.lock().unwrap().signal_rms.add_record_squared(chunk_stats.rms_linear());
+                                    playback_status.lock().unwrap().signal_peak.add_record(chunk_stats.peak_linear());
                                     tx_dev.send(chunk).unwrap();
                                 }
                                 Ok(AudioMessage::Pause) => {
@@ -470,7 +470,7 @@ impl CaptureDevice for CpalCaptureDevice {
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
-        capture_status: Arc<RwLock<CaptureStatus>>,
+        capture_status: Arc<Mutex<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let host_cfg = self.host.clone();
         let devname = self.devname.clone();
@@ -647,7 +647,7 @@ impl CaptureDevice for CpalCaptureDevice {
                                 _ => panic!("Unsupported sample format"),
                             };
                             averager.add_value(capture_samples);
-                            if averager.larger_than_millis(capture_status.read().unwrap().update_interval as u64)
+                            if averager.larger_than_millis(capture_status.lock().unwrap().update_interval as u64)
                             {
                                 let samples_per_sec = averager.average();
                                 averager.restart();
@@ -656,7 +656,7 @@ impl CaptureDevice for CpalCaptureDevice {
                                     "Measured sample rate is {:.1} Hz",
                                     measured_rate_f
                                 );
-                                let mut capt_stat = capture_status.write().unwrap();
+                                let mut capt_stat = capture_status.lock().unwrap();
                                 capt_stat.measured_samplerate = measured_rate_f as usize;
                                 capt_stat.signal_range = value_range as f32;
                                 capt_stat.rate_adjust = rate_adjust as f32;
@@ -686,8 +686,8 @@ impl CaptureDevice for CpalCaptureDevice {
                             }
                             chunk.update_stats(&mut chunk_stats);
                             //trace!("Capture rms {:?}, peak {:?}", chunk_stats.rms_db(), chunk_stats.peak_db());
-                            capture_status.write().unwrap().signal_rms.add_record_squared(chunk_stats.rms_linear());
-                            capture_status.write().unwrap().signal_peak.add_record(chunk_stats.peak_linear());
+                            capture_status.lock().unwrap().signal_rms.add_record_squared(chunk_stats.rms_linear());
+                            capture_status.lock().unwrap().signal_peak.add_record(chunk_stats.peak_linear());
                             value_range = chunk.maxval - chunk.minval;
                             state = silence_counter.update(value_range);
                             if state == ProcessingState::Running {
@@ -716,7 +716,7 @@ impl CaptureDevice for CpalCaptureDevice {
                                 }
                             }
                         }
-                        let mut capt_stat = capture_status.write().unwrap();
+                        let mut capt_stat = capture_status.lock().unwrap();
                         capt_stat.state = ProcessingState::Inactive;
                     }
                     Err(err) => {

--- a/src/filedevice.rs
+++ b/src/filedevice.rs
@@ -12,10 +12,11 @@ use std::io::{stdin, stdout, Write};
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::OpenOptionsExt;
 use std::sync::mpsc;
-use std::sync::{Arc, Barrier, Mutex};
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use rubato::VecResampler;
 
 #[cfg(all(target_os = "linux", feature = "bluez-backend"))]
@@ -89,7 +90,7 @@ struct CaptureParams {
     resampling_ratio: f32,
     read_bytes: usize,
     async_src: bool,
-    capture_status: Arc<Mutex<CaptureStatus>>,
+    capture_status: Arc<RwLock<CaptureStatus>>,
     stop_on_rate_change: bool,
     rate_measure_interval: f32,
 }
@@ -111,7 +112,7 @@ impl PlaybackDevice for FilePlaybackDevice {
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
-        playback_status: Arc<Mutex<PlaybackStatus>>,
+        playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let destination = self.destination.clone();
         let chunksize = self.chunksize;
@@ -158,17 +159,18 @@ impl PlaybackDevice for FilePlaybackDevice {
                                         }
                                     };
                                     chunk.update_stats(&mut chunk_stats);
-
-                                    let mut playback_status = playback_status.lock().unwrap();
-                                    if nbr_clipped > 0 {
-                                        playback_status.clipped_samples += nbr_clipped;
+                                    {
+                                        let mut playback_status = playback_status.write();
+                                        if nbr_clipped > 0 {
+                                            playback_status.clipped_samples += nbr_clipped;
+                                        }
+                                        playback_status
+                                            .signal_rms
+                                            .add_record_squared(chunk_stats.rms_linear());
+                                        playback_status
+                                            .signal_peak
+                                            .add_record(chunk_stats.peak_linear());
                                     }
-                                    playback_status
-                                        .signal_rms
-                                        .add_record_squared(chunk_stats.rms_linear());
-                                    playback_status
-                                        .signal_peak
-                                        .add_record(chunk_stats.peak_linear());
                                     trace!(
                                         "Playback signal RMS: {:?}, peak: {:?}",
                                         chunk_stats.rms_db(),
@@ -334,168 +336,163 @@ fn capture_loop(
         );
         //let read_res = read_retry(&mut file, &mut buf[0..capture_bytes_temp]);
         let read_res = file.read(&mut buf[0..bytes_to_capture_tmp]);
-        let mut chunk = {
-            let mut capture_status = params.capture_status.lock().unwrap();
-            match read_res {
-                Ok(ReadResult::EndOfFile(bytes)) => {
-                    bytes_read = bytes;
-                    nbr_bytes_read += bytes;
-                    if bytes > 0 {
-                        for item in buf.iter_mut().take(bytes_to_capture).skip(bytes) {
-                            *item = 0;
-                        }
-                        debug!(
-                            "End of file, read only {} of {} bytes",
-                            bytes, bytes_to_capture
-                        );
-                        let missing =
-                            ((bytes_to_capture - bytes) as f32 * params.resampling_ratio) as usize;
-                        if extra_bytes_left > missing {
-                            bytes_read = bytes_to_capture;
-                            extra_bytes_left -= missing;
-                        } else {
-                            bytes_read +=
-                                (extra_bytes_left as f32 / params.resampling_ratio) as usize;
-                            extra_bytes_left = 0;
-                        }
+        match read_res {
+            Ok(ReadResult::EndOfFile(bytes)) => {
+                bytes_read = bytes;
+                nbr_bytes_read += bytes;
+                if bytes > 0 {
+                    for item in buf.iter_mut().take(bytes_to_capture).skip(bytes) {
+                        *item = 0;
+                    }
+                    debug!(
+                        "End of file, read only {} of {} bytes",
+                        bytes, bytes_to_capture
+                    );
+                    let missing =
+                        ((bytes_to_capture - bytes) as f32 * params.resampling_ratio) as usize;
+                    if extra_bytes_left > missing {
+                        bytes_read = bytes_to_capture;
+                        extra_bytes_left -= missing;
                     } else {
-                        debug!("Reached end of file");
-                        let extra_samples =
-                            extra_bytes_left / params.store_bytes_per_sample / params.channels;
-                        send_silence(
-                            extra_samples,
-                            params.channels,
-                            params.chunksize,
-                            &msg_channels.audio,
-                            &mut resampler,
-                        );
-                        let msg = AudioMessage::EndOfStream;
-                        msg_channels.audio.send(msg).unwrap_or(());
-                        msg_channels
-                            .status
-                            .send(StatusMessage::CaptureDone)
-                            .unwrap_or(());
-                        break;
+                        bytes_read += (extra_bytes_left as f32 / params.resampling_ratio) as usize;
+                        extra_bytes_left = 0;
                     }
-                }
-                Ok(ReadResult::Timeout(bytes)) => {
-                    bytes_read = bytes;
-                    nbr_bytes_read += bytes;
-                    if bytes > 0 {
-                        for item in buf.iter_mut().take(bytes_to_capture).skip(bytes) {
-                            *item = 0;
-                        }
-                        debug!(
-                            "Timed out after reading {} of {} bytes",
-                            bytes, bytes_to_capture
-                        );
-                        let missing =
-                            ((bytes_to_capture - bytes) as f32 * params.resampling_ratio) as usize;
-                        if extra_bytes_left > missing {
-                            bytes_read = bytes_to_capture;
-                            extra_bytes_left -= missing;
-                        } else {
-                            bytes_read +=
-                                (extra_bytes_left as f32 / params.resampling_ratio) as usize;
-                            extra_bytes_left = 0;
-                        }
-                    } else {
-                        trace!("Read timed out");
-                        let msg = AudioMessage::Pause;
-                        msg_channels.audio.send(msg).unwrap_or(());
-
-                        if !stalled {
-                            debug!("Entering stalled state");
-                            stalled = true;
-                            prev_state = state;
-                            state = ProcessingState::Stalled;
-                            params.capture_status.lock().unwrap().state = ProcessingState::Stalled;
-                        }
-                        continue;
-                    }
-                }
-                Ok(ReadResult::Complete(bytes)) => {
-                    if stalled {
-                        debug!("Leaving stalled state, resuming processing");
-                        stalled = false;
-                        state = prev_state;
-                        params.capture_status.lock().unwrap().state = state;
-                    }
-                    bytes_read = bytes;
-                    nbr_bytes_read += bytes;
-                    averager.add_value(bytes);
-
-                    {
-                        let mut capture_status = params.capture_status.lock().unwrap();
-                        if averager.larger_than_millis(capture_status.update_interval as u64) {
-                            let bytes_per_sec = averager.average();
-                            averager.restart();
-                            let measured_rate_f = bytes_per_sec
-                                / (params.channels * params.store_bytes_per_sample) as f64;
-                            trace!("Measured sample rate is {:.1} Hz", measured_rate_f);
-                            capture_status.measured_samplerate = measured_rate_f as usize;
-                            capture_status.signal_range = value_range as f32;
-                            capture_status.rate_adjust = rate_adjust as f32;
-                            capture_status.state = state;
-                        }
-                    }
-                    watcher_averager.add_value(bytes);
-                    if watcher_averager.larger_than_millis(rate_measure_interval_ms) {
-                        let bytes_per_sec = watcher_averager.average();
-                        watcher_averager.restart();
-                        let measured_rate_f = bytes_per_sec
-                            / (params.channels * params.store_bytes_per_sample) as f64;
-                        let changed = valuewatcher.check_value(measured_rate_f as f32);
-                        if changed {
-                            warn!(
-                                "sample rate change detected, last rate was {} Hz",
-                                measured_rate_f
-                            );
-                            if params.stop_on_rate_change {
-                                let msg = AudioMessage::EndOfStream;
-                                msg_channels.audio.send(msg).unwrap_or(());
-                                msg_channels
-                                    .status
-                                    .send(StatusMessage::CaptureFormatChange(
-                                        measured_rate_f as usize,
-                                    ))
-                                    .unwrap_or(());
-                                break;
-                            }
-                        }
-                        trace!("Measured sample rate is {:.1} Hz", measured_rate_f);
-                    }
-                }
-                Err(err) => {
-                    debug!("Encountered a read error");
+                } else {
+                    debug!("Reached end of file");
+                    let extra_samples =
+                        extra_bytes_left / params.store_bytes_per_sample / params.channels;
+                    send_silence(
+                        extra_samples,
+                        params.channels,
+                        params.chunksize,
+                        &msg_channels.audio,
+                        &mut resampler,
+                    );
+                    let msg = AudioMessage::EndOfStream;
+                    msg_channels.audio.send(msg).unwrap_or(());
                     msg_channels
                         .status
-                        .send(StatusMessage::CaptureError(err.to_string()))
+                        .send(StatusMessage::CaptureDone)
                         .unwrap_or(());
+                    break;
                 }
-            };
-            let chunk = buffer_to_chunk_rawbytes(
-                &buf[0..bytes_to_capture],
-                params.channels,
-                &params.sample_format,
-                bytes_read,
-                &capture_status.used_channels,
-            );
-            chunk.update_stats(&mut chunk_stats);
-            //trace!(
-            //    "Capture rms {:?}, peak {:?}",
-            //    chunk_stats.rms_db(),
-            //    chunk_stats.peak_db()
-            //);
+            }
+            Ok(ReadResult::Timeout(bytes)) => {
+                bytes_read = bytes;
+                nbr_bytes_read += bytes;
+                if bytes > 0 {
+                    for item in buf.iter_mut().take(bytes_to_capture).skip(bytes) {
+                        *item = 0;
+                    }
+                    debug!(
+                        "Timed out after reading {} of {} bytes",
+                        bytes, bytes_to_capture
+                    );
+                    let missing =
+                        ((bytes_to_capture - bytes) as f32 * params.resampling_ratio) as usize;
+                    if extra_bytes_left > missing {
+                        bytes_read = bytes_to_capture;
+                        extra_bytes_left -= missing;
+                    } else {
+                        bytes_read += (extra_bytes_left as f32 / params.resampling_ratio) as usize;
+                        extra_bytes_left = 0;
+                    }
+                } else {
+                    trace!("Read timed out");
+                    let msg = AudioMessage::Pause;
+                    msg_channels.audio.send(msg).unwrap_or(());
+
+                    if !stalled {
+                        debug!("Entering stalled state");
+                        stalled = true;
+                        prev_state = state;
+                        state = ProcessingState::Stalled;
+                        params.capture_status.write().state = ProcessingState::Stalled;
+                    }
+                    continue;
+                }
+            }
+            Ok(ReadResult::Complete(bytes)) => {
+                if stalled {
+                    debug!("Leaving stalled state, resuming processing");
+                    stalled = false;
+                    state = prev_state;
+                    params.capture_status.write().state = state;
+                }
+                bytes_read = bytes;
+                nbr_bytes_read += bytes;
+                averager.add_value(bytes);
+
+                {
+                    let capture_status = params.capture_status.upgradable_read();
+                    if averager.larger_than_millis(capture_status.update_interval as u64) {
+                        let bytes_per_sec = averager.average();
+                        averager.restart();
+                        let measured_rate_f = bytes_per_sec
+                            / (params.channels * params.store_bytes_per_sample) as f64;
+                        trace!("Measured sample rate is {:.1} Hz", measured_rate_f);
+                        let mut capture_status = RwLockUpgradableReadGuard::upgrade(capture_status); // to write lock
+                        capture_status.measured_samplerate = measured_rate_f as usize;
+                        capture_status.signal_range = value_range as f32;
+                        capture_status.rate_adjust = rate_adjust as f32;
+                        capture_status.state = state;
+                    }
+                }
+                watcher_averager.add_value(bytes);
+                if watcher_averager.larger_than_millis(rate_measure_interval_ms) {
+                    let bytes_per_sec = watcher_averager.average();
+                    watcher_averager.restart();
+                    let measured_rate_f =
+                        bytes_per_sec / (params.channels * params.store_bytes_per_sample) as f64;
+                    let changed = valuewatcher.check_value(measured_rate_f as f32);
+                    if changed {
+                        warn!(
+                            "sample rate change detected, last rate was {} Hz",
+                            measured_rate_f
+                        );
+                        if params.stop_on_rate_change {
+                            let msg = AudioMessage::EndOfStream;
+                            msg_channels.audio.send(msg).unwrap_or(());
+                            msg_channels
+                                .status
+                                .send(StatusMessage::CaptureFormatChange(measured_rate_f as usize))
+                                .unwrap_or(());
+                            break;
+                        }
+                    }
+                    trace!("Measured sample rate is {:.1} Hz", measured_rate_f);
+                }
+            }
+            Err(err) => {
+                debug!("Encountered a read error");
+                msg_channels
+                    .status
+                    .send(StatusMessage::CaptureError(err.to_string()))
+                    .unwrap_or(());
+            }
+        };
+        let mut chunk = buffer_to_chunk_rawbytes(
+            &buf[0..bytes_to_capture],
+            params.channels,
+            &params.sample_format,
+            bytes_read,
+            &params.capture_status.read().used_channels,
+        );
+        chunk.update_stats(&mut chunk_stats);
+        //trace!(
+        //    "Capture rms {:?}, peak {:?}",
+        //    chunk_stats.rms_db(),
+        //    chunk_stats.peak_db()
+        //);
+        {
+            let mut capture_status = params.capture_status.write();
             capture_status
                 .signal_rms
                 .add_record_squared(chunk_stats.rms_linear());
             capture_status
                 .signal_peak
                 .add_record(chunk_stats.peak_linear());
-            chunk
-        };
-
+        }
         value_range = chunk.maxval - chunk.minval;
         state = silence_counter.update(value_range);
         if state == ProcessingState::Running {
@@ -529,7 +526,7 @@ fn capture_loop(
             sleep_until_next(bytes_per_frame, params.capture_samplerate, bytes_to_capture);
         }
     }
-    params.capture_status.lock().unwrap().state = ProcessingState::Inactive;
+    params.capture_status.write().state = ProcessingState::Inactive;
 }
 
 /// Start a capture thread providing AudioMessages via a channel
@@ -540,7 +537,7 @@ impl CaptureDevice for FileCaptureDevice {
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
-        capture_status: Arc<Mutex<CaptureStatus>>,
+        capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let source = self.source.clone();
         let samplerate = self.samplerate;

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -20,7 +20,7 @@ use std::convert::TryInto;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::{BufRead, Read, Seek, SeekFrom};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 
 use crate::PrcFmt;
 use crate::ProcessingParameters;
@@ -361,7 +361,7 @@ impl FilterGroup {
         filter_configs: HashMap<String, config::Filter>,
         waveform_length: usize,
         sample_freq: usize,
-        processing_status: Arc<RwLock<ProcessingParameters>>,
+        processing_status: Arc<Mutex<ProcessingParameters>>,
     ) -> Self {
         debug!("Build filter group from config");
         let mut filters = Vec::<Box<dyn Filter>>::new();
@@ -459,7 +459,7 @@ impl Pipeline {
     /// Create a new pipeline from a configuration structure.
     pub fn from_config(
         conf: config::Configuration,
-        processing_status: Arc<RwLock<ProcessingParameters>>,
+        processing_status: Arc<Mutex<ProcessingParameters>>,
     ) -> Self {
         debug!("Build new pipeline");
         trace!("Pipeline config {:?}", conf.pipeline);
@@ -505,8 +505,8 @@ impl Pipeline {
                 }
             }
         }
-        let current_volume = processing_status.read().unwrap().target_volume[0];
-        let mute = processing_status.read().unwrap().mute[0];
+        let current_volume = processing_status.lock().unwrap().target_volume[0];
+        let mute = processing_status.lock().unwrap().mute[0];
         let volume = basicfilters::Volume::new(
             "default",
             conf.devices.ramp_time(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,11 @@ extern crate wasapi;
 #[macro_use]
 extern crate log;
 
+use parking_lot::RwLock;
 use serde::Serialize;
 use std::error;
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 // Sample format
 #[cfg(feature = "32bit")]
@@ -201,10 +202,10 @@ pub enum StopReason {
 
 #[derive(Clone)]
 pub struct StatusStructs {
-    pub capture: Arc<Mutex<CaptureStatus>>,
-    pub playback: Arc<Mutex<PlaybackStatus>>,
-    pub processing: Arc<Mutex<ProcessingParameters>>,
-    pub status: Arc<Mutex<ProcessingStatus>>,
+    pub capture: Arc<RwLock<CaptureStatus>>,
+    pub playback: Arc<RwLock<PlaybackStatus>>,
+    pub processing: Arc<RwLock<ProcessingParameters>>,
+    pub status: Arc<RwLock<ProcessingStatus>>,
 }
 
 impl fmt::Display for ProcessingState {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ extern crate log;
 use serde::Serialize;
 use std::error;
 use std::fmt;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 
 // Sample format
 #[cfg(feature = "32bit")]
@@ -201,10 +201,10 @@ pub enum StopReason {
 
 #[derive(Clone)]
 pub struct StatusStructs {
-    pub capture: Arc<RwLock<CaptureStatus>>,
-    pub playback: Arc<RwLock<PlaybackStatus>>,
-    pub processing: Arc<RwLock<ProcessingParameters>>,
-    pub status: Arc<RwLock<ProcessingStatus>>,
+    pub capture: Arc<Mutex<CaptureStatus>>,
+    pub playback: Arc<Mutex<PlaybackStatus>>,
+    pub processing: Arc<Mutex<ProcessingParameters>>,
+    pub status: Arc<Mutex<ProcessingStatus>>,
 }
 
 impl fmt::Display for ProcessingState {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,10 @@ use parking_lot::RwLock;
 use serde::Serialize;
 use std::error;
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, AtomicU32, Ordering},
+    Arc,
+};
 
 // Sample format
 #[cfg(feature = "32bit")]
@@ -177,11 +180,82 @@ pub struct PlaybackStatus {
     pub signal_peak: countertimer::ValueHistory,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ProcessingParameters {
-    pub target_volume: [f32; 5],
-    pub current_volume: [f32; 5],
-    pub mute: [bool; 5],
+    // Optimization: volumes are actually `f32`s, but by representing their
+    // bits as a `u32` of equal size we can use atomic operations instead of a
+    // mutex.
+    target_volume: [AtomicU32; Self::NUM_FADERS],
+    current_volume: [AtomicU32; Self::NUM_FADERS],
+    mute: [AtomicBool; Self::NUM_FADERS],
+}
+
+impl ProcessingParameters {
+    pub const NUM_FADERS: usize = 5;
+
+    pub const DEFAULT_VOLUME: f32 = 0.0;
+    pub const DEFAULT_MUTE: bool = false;
+
+    pub fn new(initial_volume: f32, initial_mute: bool) -> Self {
+        let default_volume = Self::DEFAULT_VOLUME.to_bits();
+        Self {
+            target_volume: [
+                AtomicU32::new(initial_volume.to_bits()),
+                AtomicU32::new(default_volume),
+                AtomicU32::new(default_volume),
+                AtomicU32::new(default_volume),
+                AtomicU32::new(default_volume),
+            ],
+            current_volume: [
+                AtomicU32::new(initial_volume.to_bits()),
+                AtomicU32::new(default_volume),
+                AtomicU32::new(default_volume),
+                AtomicU32::new(default_volume),
+                AtomicU32::new(default_volume),
+            ],
+            mute: [
+                AtomicBool::new(initial_mute),
+                AtomicBool::new(Self::DEFAULT_MUTE),
+                AtomicBool::new(Self::DEFAULT_MUTE),
+                AtomicBool::new(Self::DEFAULT_MUTE),
+                AtomicBool::new(Self::DEFAULT_MUTE),
+            ],
+        }
+    }
+
+    pub fn target_volume(&self, fader: usize) -> f32 {
+        f32::from_bits(self.target_volume[fader].load(Ordering::Relaxed))
+    }
+
+    pub fn set_target_volume(&self, fader: usize, target: f32) {
+        self.target_volume[fader].store(target.to_bits(), Ordering::Relaxed)
+    }
+
+    pub fn current_volume(&self, fader: usize) -> f32 {
+        f32::from_bits(self.current_volume[fader].load(Ordering::Relaxed))
+    }
+
+    pub fn set_current_volume(&self, fader: usize, current: f32) {
+        self.current_volume[fader].store(current.to_bits(), Ordering::Relaxed)
+    }
+
+    pub fn is_mute(&self, fader: usize) -> bool {
+        self.mute[fader].load(Ordering::Relaxed)
+    }
+
+    pub fn set_mute(&self, fader: usize, mute: bool) {
+        self.mute[fader].store(mute, Ordering::Relaxed)
+    }
+
+    pub fn toggle_mute(&self, fader: usize) -> bool {
+        self.mute[fader].fetch_xor(true, Ordering::Relaxed)
+    }
+}
+
+impl Default for ProcessingParameters {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_VOLUME, Self::DEFAULT_MUTE)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -204,7 +278,7 @@ pub enum StopReason {
 pub struct StatusStructs {
     pub capture: Arc<RwLock<CaptureStatus>>,
     pub playback: Arc<RwLock<PlaybackStatus>>,
-    pub processing: Arc<RwLock<ProcessingParameters>>,
+    pub processing: Arc<ProcessingParameters>,
     pub status: Arc<RwLock<ProcessingStatus>>,
 }
 

--- a/src/loudness.rs
+++ b/src/loudness.rs
@@ -1,7 +1,8 @@
 use crate::biquad;
 use crate::config;
 use crate::filters::Filter;
-use std::sync::{Arc, Mutex};
+use parking_lot::RwLock;
+use std::sync::Arc;
 
 use crate::PrcFmt;
 use crate::ProcessingParameters;
@@ -10,7 +11,7 @@ use crate::Res;
 pub struct Loudness {
     pub name: String,
     current_volume: PrcFmt,
-    processing_status: Arc<Mutex<ProcessingParameters>>,
+    processing_status: Arc<RwLock<ProcessingParameters>>,
     reference_level: f32,
     high_boost: f32,
     low_boost: f32,
@@ -30,11 +31,11 @@ impl Loudness {
         name: &str,
         conf: config::LoudnessParameters,
         samplerate: usize,
-        processing_status: Arc<Mutex<ProcessingParameters>>,
+        processing_status: Arc<RwLock<ProcessingParameters>>,
     ) -> Self {
         info!("Create loudness filter");
         let fader = conf.fader();
-        let current_volume = processing_status.lock().unwrap().target_volume[fader];
+        let current_volume = processing_status.read().target_volume[fader];
         let relboost = rel_boost(current_volume, conf.reference_level);
         let active = relboost > 0.01;
         let highshelf_conf = config::BiquadParameters::Highshelf(config::ShelfSteepness::Slope {
@@ -73,7 +74,7 @@ impl Filter for Loudness {
     }
 
     fn process_waveform(&mut self, waveform: &mut [PrcFmt]) -> Res<()> {
-        let shared_vol = self.processing_status.lock().unwrap().current_volume[self.fader];
+        let shared_vol = self.processing_status.read().current_volume[self.fader];
 
         // Volume setting changed
         if (shared_vol - self.current_volume as f32).abs() > 0.01 {
@@ -118,7 +119,7 @@ impl Filter for Loudness {
         } = conf
         {
             self.fader = conf.fader();
-            let current_volume = self.processing_status.lock().unwrap().current_volume[self.fader];
+            let current_volume = self.processing_status.read().current_volume[self.fader];
             let relboost = rel_boost(current_volume, conf.reference_level);
             self.active = relboost > 0.001;
             let highshelf_conf =

--- a/src/loudness.rs
+++ b/src/loudness.rs
@@ -1,7 +1,7 @@
 use crate::biquad;
 use crate::config;
 use crate::filters::Filter;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex};
 
 use crate::PrcFmt;
 use crate::ProcessingParameters;
@@ -10,7 +10,7 @@ use crate::Res;
 pub struct Loudness {
     pub name: String,
     current_volume: PrcFmt,
-    processing_status: Arc<RwLock<ProcessingParameters>>,
+    processing_status: Arc<Mutex<ProcessingParameters>>,
     reference_level: f32,
     high_boost: f32,
     low_boost: f32,
@@ -30,11 +30,11 @@ impl Loudness {
         name: &str,
         conf: config::LoudnessParameters,
         samplerate: usize,
-        processing_status: Arc<RwLock<ProcessingParameters>>,
+        processing_status: Arc<Mutex<ProcessingParameters>>,
     ) -> Self {
         info!("Create loudness filter");
         let fader = conf.fader();
-        let current_volume = processing_status.read().unwrap().target_volume[fader];
+        let current_volume = processing_status.lock().unwrap().target_volume[fader];
         let relboost = rel_boost(current_volume, conf.reference_level);
         let active = relboost > 0.01;
         let highshelf_conf = config::BiquadParameters::Highshelf(config::ShelfSteepness::Slope {
@@ -73,7 +73,7 @@ impl Filter for Loudness {
     }
 
     fn process_waveform(&mut self, waveform: &mut [PrcFmt]) -> Res<()> {
-        let shared_vol = self.processing_status.read().unwrap().current_volume[self.fader];
+        let shared_vol = self.processing_status.lock().unwrap().current_volume[self.fader];
 
         // Volume setting changed
         if (shared_vol - self.current_volume as f32).abs() > 0.01 {
@@ -118,7 +118,7 @@ impl Filter for Loudness {
         } = conf
         {
             self.fader = conf.fader();
-            let current_volume = self.processing_status.read().unwrap().current_volume[self.fader];
+            let current_volume = self.processing_status.lock().unwrap().current_volume[self.fader];
             let relboost = rel_boost(current_volume, conf.reference_level);
             self.active = relboost > 0.001;
             let highshelf_conf =

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -2,8 +2,9 @@ use crate::audiodevice::*;
 use crate::config;
 use crate::filters;
 use crate::ProcessingParameters;
+use parking_lot::RwLock;
 use std::sync::mpsc;
-use std::sync::{Arc, Barrier, Mutex};
+use std::sync::{Arc, Barrier};
 use std::thread;
 
 pub fn run_processing(
@@ -12,7 +13,7 @@ pub fn run_processing(
     tx_pb: mpsc::SyncSender<AudioMessage>,
     rx_cap: mpsc::Receiver<AudioMessage>,
     rx_pipeconf: mpsc::Receiver<(config::ConfigChange, config::Configuration)>,
-    processing_status: Arc<Mutex<ProcessingParameters>>,
+    processing_status: Arc<RwLock<ProcessingParameters>>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let mut pipeline = filters::Pipeline::from_config(conf_proc, processing_status.clone());

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -2,7 +2,6 @@ use crate::audiodevice::*;
 use crate::config;
 use crate::filters;
 use crate::ProcessingParameters;
-use parking_lot::RwLock;
 use std::sync::mpsc;
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -13,10 +12,10 @@ pub fn run_processing(
     tx_pb: mpsc::SyncSender<AudioMessage>,
     rx_cap: mpsc::Receiver<AudioMessage>,
     rx_pipeconf: mpsc::Receiver<(config::ConfigChange, config::Configuration)>,
-    processing_status: Arc<RwLock<ProcessingParameters>>,
+    processing_params: Arc<ProcessingParameters>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
-        let mut pipeline = filters::Pipeline::from_config(conf_proc, processing_status.clone());
+        let mut pipeline = filters::Pipeline::from_config(conf_proc, processing_params.clone());
         debug!("build filters, waiting to start processing loop");
         barrier_proc.wait();
         debug!("Processing loop starts now!");
@@ -62,7 +61,7 @@ pub fn run_processing(
                     config::ConfigChange::Pipeline | config::ConfigChange::MixerParameters => {
                         debug!("Rebuilding pipeline.");
                         let new_pipeline =
-                            filters::Pipeline::from_config(new_config, processing_status.clone());
+                            filters::Pipeline::from_config(new_config, processing_params.clone());
                         pipeline = new_pipeline;
                     }
                     config::ConfigChange::FilterParameters {

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -3,7 +3,7 @@ use crate::config;
 use crate::filters;
 use crate::ProcessingParameters;
 use std::sync::mpsc;
-use std::sync::{Arc, Barrier, RwLock};
+use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 
 pub fn run_processing(
@@ -12,7 +12,7 @@ pub fn run_processing(
     tx_pb: mpsc::SyncSender<AudioMessage>,
     rx_cap: mpsc::Receiver<AudioMessage>,
     rx_pipeconf: mpsc::Receiver<(config::ConfigChange, config::Configuration)>,
-    processing_status: Arc<RwLock<ProcessingParameters>>,
+    processing_status: Arc<Mutex<ProcessingParameters>>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
         let mut pipeline = filters::Pipeline::from_config(conf_proc, processing_status.clone());

--- a/src/pulsedevice.rs
+++ b/src/pulsedevice.rs
@@ -8,9 +8,10 @@ use crate::config;
 use crate::config::SampleFormat;
 use crate::conversions::{buffer_to_chunk_rawbytes, chunk_to_buffer_rawbytes};
 use crate::countertimer;
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use rubato::VecResampler;
 use std::sync::mpsc;
-use std::sync::{Arc, Barrier, Mutex};
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -133,7 +134,7 @@ impl PlaybackDevice for PulsePlaybackDevice {
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
-        playback_status: Arc<Mutex<PlaybackStatus>>,
+        playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
         let samplerate = self.samplerate;
@@ -196,7 +197,7 @@ impl PlaybackDevice for PulsePlaybackDevice {
                                     };
                                     chunk.update_stats(&mut chunk_stats);
                                     {
-                                        let mut playback_status = playback_status.lock().unwrap();
+                                        let mut playback_status = playback_status.write();
                                         if conversion_result.1 > 0 {
                                             playback_status.clipped_samples += conversion_result.1;
                                         }
@@ -271,7 +272,7 @@ impl CaptureDevice for PulseCaptureDevice {
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
-        capture_status: Arc<Mutex<CaptureStatus>>,
+        capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
         let samplerate = self.samplerate;
@@ -369,39 +370,39 @@ impl CaptureDevice for PulseCaptureDevice {
                             sleep_until_next(&last_instant, bytes_per_frame, samplerate, capture_bytes);
                             let read_res = pulsedevice.read(&mut buf[0..capture_bytes]);
                             last_instant = Instant::now();
-                            let mut chunk = {
-                                let mut capture_status = capture_status.lock().unwrap();
-                                match read_res {
-                                    Ok(()) => {
-                                        averager.add_value(capture_bytes);
-                                        if averager.larger_than_millis(capture_status.update_interval as u64) {
-                                            let bytes_per_sec = averager.average();
-                                            averager.restart();
-                                            let measured_rate_f = bytes_per_sec / (channels * store_bytes_per_sample) as f64;
-                                            trace!(
-                                                "Measured sample rate is {:.1} Hz, signal RMS is {:?}",
-                                                measured_rate_f,
-                                                capture_status.signal_rms.last(),
-                                            );
-                                            capture_status.measured_samplerate = measured_rate_f as usize;
-                                            capture_status.signal_range = value_range as f32;
-                                            capture_status.rate_adjust = rate_adjust as f32;
-                                            capture_status.state = state;
-                                        }
+                            match read_res {
+                                Ok(()) => {
+                                    averager.add_value(capture_bytes);
+                                    let capture_status = capture_status.upgradable_read();
+                                    if averager.larger_than_millis(capture_status.update_interval as u64) {
+                                        let bytes_per_sec = averager.average();
+                                        averager.restart();
+                                        let measured_rate_f = bytes_per_sec / (channels * store_bytes_per_sample) as f64;
+                                        trace!(
+                                            "Measured sample rate is {:.1} Hz, signal RMS is {:?}",
+                                            measured_rate_f,
+                                            capture_status.signal_rms.last(),
+                                        );
+                                        let mut capture_status = RwLockUpgradableReadGuard::upgrade(capture_status); // to write lock
+                                        capture_status.measured_samplerate = measured_rate_f as usize;
+                                        capture_status.signal_range = value_range as f32;
+                                        capture_status.rate_adjust = rate_adjust as f32;
+                                        capture_status.state = state;
                                     }
-                                    Err(err) => {
-                                        status_channel
-                                            .send(StatusMessage::CaptureError(err.to_string().unwrap_or("Unknown capture error".to_string())))
-                                            .unwrap();
-                                    }
-                                };
-                                let chunk = buffer_to_chunk_rawbytes(&buf[0..capture_bytes],channels, &sample_format, capture_bytes, &capture_status.used_channels);
-                                chunk.update_stats(&mut chunk_stats);
+                                }
+                                Err(err) => {
+                                    status_channel
+                                        .send(StatusMessage::CaptureError(err.to_string().unwrap_or("Unknown capture error".to_string())))
+                                        .unwrap();
+                                }
+                            };
+                            let mut chunk = buffer_to_chunk_rawbytes(&buf[0..capture_bytes],channels, &sample_format, capture_bytes, &capture_status.read().used_channels);
+                            chunk.update_stats(&mut chunk_stats);
+                            {
+                                let mut capture_status = capture_status.write();
                                 capture_status.signal_rms.add_record_squared(chunk_stats.rms_linear());
                                 capture_status.signal_peak.add_record(chunk_stats.peak_linear());
-                                chunk
-                            };
-
+                            }
                             //trace!("Capture signal rms {:?}, peak {:?}", chunk_stats.rms_db(), chunk_stats.peak_db());
                             value_range = chunk.maxval - chunk.minval;
                             state = silence_counter.update(value_range);
@@ -431,7 +432,7 @@ impl CaptureDevice for PulseCaptureDevice {
                                 }
                             }
                         }
-                        capture_status.lock().unwrap().state = ProcessingState::Inactive;
+                        capture_status.write().state = ProcessingState::Inactive;
                     }
                     Err(err) => {
                         let send_result = status_channel

--- a/src/socketserver.rs
+++ b/src/socketserver.rs
@@ -744,16 +744,12 @@ fn handle_command(
             })
         }
         WsCommand::SetUpdateInterval(nbr) => {
-            shared_data_inst
-                .capture_status
-                .lock()
-                .unwrap()
-                .update_interval = nbr;
-            shared_data_inst
-                .playback_status
-                .lock()
-                .unwrap()
-                .update_interval = nbr;
+            {
+                let mut captstat = shared_data_inst.capture_status.lock().unwrap();
+                let mut playstat = shared_data_inst.playback_status.lock().unwrap();
+                captstat.update_interval = nbr;
+                playstat.update_interval = nbr;
+            }
             Some(WsReply::SetUpdateInterval {
                 result: WsResult::Ok,
             })

--- a/src/wasapidevice.rs
+++ b/src/wasapidevice.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::mpsc;
-use std::sync::{Arc, Barrier, RwLock};
+use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
 use std::time::Duration;
 use wasapi;
@@ -555,7 +555,7 @@ impl PlaybackDevice for WasapiPlaybackDevice {
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
-        playback_status: Arc<RwLock<PlaybackStatus>>,
+        playback_status: Arc<Mutex<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
         let exclusive = self.exclusive;
@@ -705,18 +705,18 @@ impl PlaybackDevice for WasapiPlaybackDevice {
                                     status_channel
                                         .send(StatusMessage::SetSpeed(speed))
                                         .unwrap_or(());
-                                    playback_status.write().unwrap().buffer_level =
+                                    playback_status.lock().unwrap().buffer_level =
                                         av_delay as usize;
                                 }
                             }
                             chunk.update_stats(&mut chunk_stats);
                             playback_status
-                                .write()
+                                .lock()
                                 .unwrap()
                                 .signal_rms
                                 .add_record_squared(chunk_stats.rms_linear());
                             playback_status
-                                .write()
+                                .lock()
                                 .unwrap()
                                 .signal_peak
                                 .add_record(chunk_stats.peak_linear());
@@ -740,7 +740,7 @@ impl PlaybackDevice for WasapiPlaybackDevice {
                                 }
                             }
                             if conversion_result.1 > 0 {
-                                playback_status.write().unwrap().clipped_samples +=
+                                playback_status.lock().unwrap().clipped_samples +=
                                     conversion_result.1;
                             }
                         }
@@ -845,7 +845,7 @@ impl CaptureDevice for WasapiCaptureDevice {
         barrier: Arc<Barrier>,
         status_channel: mpsc::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
-        capture_status: Arc<RwLock<CaptureStatus>>,
+        capture_status: Arc<Mutex<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let exclusive = self.exclusive;
         let loopback = self.loopback;
@@ -1050,10 +1050,10 @@ impl CaptureDevice for WasapiCaptureDevice {
                             channels,
                             &sample_format,
                             capture_bytes,
-                            &capture_status.read().unwrap().used_channels,
+                            &capture_status.lock().unwrap().used_channels,
                         );
                         averager.add_value(capture_frames);
-                        if averager.larger_than_millis(capture_status.read().unwrap().update_interval as u64)
+                        if averager.larger_than_millis(capture_status.lock().unwrap().update_interval as u64)
                         {
                             let samples_per_sec = averager.average();
                             averager.restart();
@@ -1062,7 +1062,7 @@ impl CaptureDevice for WasapiCaptureDevice {
                                 "Measured sample rate is {:.1} Hz",
                                 measured_rate_f
                             );
-                            let mut capture_status = capture_status.write().unwrap();
+                            let mut capture_status = capture_status.lock().unwrap();
                             capture_status.measured_samplerate = measured_rate_f as usize;
                             capture_status.signal_range = value_range as f32;
                             capture_status.rate_adjust = rate_adjust as f32;
@@ -1091,8 +1091,8 @@ impl CaptureDevice for WasapiCaptureDevice {
                         }
                         chunk.update_stats(&mut chunk_stats);
                         //trace!("Capture rms {:?}, peak {:?}", chunk_stats.rms_db(), chunk_stats.peak_db());
-                        capture_status.write().unwrap().signal_rms.add_record_squared(chunk_stats.rms_linear());
-                        capture_status.write().unwrap().signal_peak.add_record(chunk_stats.peak_linear());
+                        capture_status.lock().unwrap().signal_rms.add_record_squared(chunk_stats.rms_linear());
+                        capture_status.lock().unwrap().signal_peak.add_record(chunk_stats.peak_linear());
                         value_range = chunk.maxval - chunk.minval;
                         state = silence_counter.update(value_range);
                         if state == ProcessingState::Running {
@@ -1125,7 +1125,7 @@ impl CaptureDevice for WasapiCaptureDevice {
                 stop_signal.store(true, Ordering::Relaxed);
                 debug!("Wait for inner capture thread to exit");
                 innerhandle.join().unwrap_or(());
-                let mut capt_stat = capture_status.write().unwrap();
+                let mut capt_stat = capture_status.lock().unwrap();
                 capt_stat.state = ProcessingState::Inactive;
             })?;
         Ok(Box::new(handle))

--- a/src/wasapidevice.rs
+++ b/src/wasapidevice.rs
@@ -686,47 +686,50 @@ impl PlaybackDevice for WasapiPlaybackDevice {
                     }
                     match channel.recv() {
                         Ok(AudioMessage::Audio(chunk)) => {
-                            buffer_avg.add_value(buffer_fill.load(Ordering::Relaxed) as f64);
-                            if adjust && timer.larger_than_millis((1000.0 * adjust_period) as u64) {
-                                if let Some(av_delay) = buffer_avg.average() {
-                                    let speed = calculate_speed(
-                                        av_delay,
-                                        target_level,
-                                        adjust_period,
-                                        samplerate as u32,
-                                    );
-                                    timer.restart();
-                                    buffer_avg.restart();
-                                    debug!(
-                                        "Current buffer level {:.1}, set capture rate to {:.4}%",
-                                        av_delay,
-                                        100.0 * speed
-                                    );
-                                    status_channel
-                                        .send(StatusMessage::SetSpeed(speed))
-                                        .unwrap_or(());
-                                    playback_status.lock().unwrap().buffer_level =
-                                        av_delay as usize;
-                                }
-                            }
-                            chunk.update_stats(&mut chunk_stats);
-                            playback_status
-                                .lock()
-                                .unwrap()
-                                .signal_rms
-                                .add_record_squared(chunk_stats.rms_linear());
-                            playback_status
-                                .lock()
-                                .unwrap()
-                                .signal_peak
-                                .add_record(chunk_stats.peak_linear());
                             let mut buf =
                                 vec![
                                     0u8;
                                     channels * chunk.frames * sample_format.bytes_per_sample()
                                 ];
-                            conversion_result =
-                                chunk_to_buffer_rawbytes(&chunk, &mut buf, &sample_format);
+                            buffer_avg.add_value(buffer_fill.load(Ordering::Relaxed) as f64);
+                            {
+                                let mut playback_status = playback_status.lock().unwrap();
+                                if adjust && timer.larger_than_millis((1000.0 * adjust_period) as u64) {
+                                    if let Some(av_delay) = buffer_avg.average() {
+                                        let speed = calculate_speed(
+                                            av_delay,
+                                            target_level,
+                                            adjust_period,
+                                            samplerate as u32,
+                                        );
+                                        timer.restart();
+                                        buffer_avg.restart();
+                                        debug!(
+                                            "Current buffer level {:.1}, set capture rate to {:.4}%",
+                                            av_delay,
+                                            100.0 * speed
+                                        );
+                                        status_channel
+                                            .send(StatusMessage::SetSpeed(speed))
+                                            .unwrap_or(());
+                                        playback_status.buffer_level =
+                                            av_delay as usize;
+                                    }
+                                }
+                                conversion_result =
+                                    chunk_to_buffer_rawbytes(&chunk, &mut buf, &sample_format);
+                                chunk.update_stats(&mut chunk_stats);
+                                if conversion_result.1 > 0 {
+                                    playback_status.clipped_samples +=
+                                        conversion_result.1;
+                                }
+                                playback_status
+                                    .signal_rms
+                                    .add_record_squared(chunk_stats.rms_linear());
+                                playback_status
+                                    .signal_peak
+                                    .add_record(chunk_stats.peak_linear());
+                            }
                             match tx_dev.send(PlaybackDeviceMessage::Data(buf)) {
                                 Ok(_) => {}
                                 Err(err) => {
@@ -738,10 +741,6 @@ impl PlaybackDevice for WasapiPlaybackDevice {
                                     );
                                     break;
                                 }
-                            }
-                            if conversion_result.1 > 0 {
-                                playback_status.lock().unwrap().clipped_samples +=
-                                    conversion_result.1;
                             }
                         }
                         Ok(AudioMessage::Pause) => {
@@ -1045,54 +1044,58 @@ impl CaptureDevice for WasapiCaptureDevice {
                         for element in data_buffer.iter_mut().take(capture_bytes) {
                             *element = data_queue.pop_front().unwrap();
                         }
-                        let mut chunk = buffer_to_chunk_rawbytes(
-                            &data_buffer[0..capture_bytes],
-                            channels,
-                            &sample_format,
-                            capture_bytes,
-                            &capture_status.lock().unwrap().used_channels,
-                        );
-                        averager.add_value(capture_frames);
-                        if averager.larger_than_millis(capture_status.lock().unwrap().update_interval as u64)
-                        {
-                            let samples_per_sec = averager.average();
-                            averager.restart();
-                            let measured_rate_f = samples_per_sec;
-                            debug!(
-                                "Measured sample rate is {:.1} Hz",
-                                measured_rate_f
-                            );
+                        let mut chunk = {
                             let mut capture_status = capture_status.lock().unwrap();
-                            capture_status.measured_samplerate = measured_rate_f as usize;
-                            capture_status.signal_range = value_range as f32;
-                            capture_status.rate_adjust = rate_adjust as f32;
-                            capture_status.state = state;
-                        }
-                        watcher_averager.add_value(capture_frames);
-                        if watcher_averager.larger_than_millis(rate_measure_interval)
-                        {
-                            let samples_per_sec = watcher_averager.average();
-                            watcher_averager.restart();
-                            let measured_rate_f = samples_per_sec;
-                            debug!(
-                                "Measured sample rate is {:.1} Hz",
-                                measured_rate_f
-                            );
-                            let changed = valuewatcher.check_value(measured_rate_f as f32);
-                            if changed {
-                                warn!("sample rate change detected, last rate was {} Hz", measured_rate_f);
-                                if stop_on_rate_change {
-                                    let msg = AudioMessage::EndOfStream;
-                                    channel.send(msg).unwrap_or(());
-                                    status_channel.send(StatusMessage::CaptureFormatChange(measured_rate_f as usize)).unwrap_or(());
-                                    break;
+                            averager.add_value(capture_frames);
+                            if averager.larger_than_millis(capture_status.update_interval as u64)
+                            {
+                                let samples_per_sec = averager.average();
+                                averager.restart();
+                                let measured_rate_f = samples_per_sec;
+                                debug!(
+                                    "Measured sample rate is {:.1} Hz",
+                                    measured_rate_f
+                                );
+                                capture_status.measured_samplerate = measured_rate_f as usize;
+                                capture_status.signal_range = value_range as f32;
+                                capture_status.rate_adjust = rate_adjust as f32;
+                                capture_status.state = state;
+                            }
+                            watcher_averager.add_value(capture_frames);
+                            if watcher_averager.larger_than_millis(rate_measure_interval)
+                            {
+                                let samples_per_sec = watcher_averager.average();
+                                watcher_averager.restart();
+                                let measured_rate_f = samples_per_sec;
+                                debug!(
+                                    "Measured sample rate is {:.1} Hz",
+                                    measured_rate_f
+                                );
+                                let changed = valuewatcher.check_value(measured_rate_f as f32);
+                                if changed {
+                                    warn!("sample rate change detected, last rate was {} Hz", measured_rate_f);
+                                    if stop_on_rate_change {
+                                        let msg = AudioMessage::EndOfStream;
+                                        channel.send(msg).unwrap_or(());
+                                        status_channel.send(StatusMessage::CaptureFormatChange(measured_rate_f as usize)).unwrap_or(());
+                                        break;
+                                    }
                                 }
                             }
-                        }
-                        chunk.update_stats(&mut chunk_stats);
-                        //trace!("Capture rms {:?}, peak {:?}", chunk_stats.rms_db(), chunk_stats.peak_db());
-                        capture_status.lock().unwrap().signal_rms.add_record_squared(chunk_stats.rms_linear());
-                        capture_status.lock().unwrap().signal_peak.add_record(chunk_stats.peak_linear());
+                            let chunk = buffer_to_chunk_rawbytes(
+                                &data_buffer[0..capture_bytes],
+                                channels,
+                                &sample_format,
+                                capture_bytes,
+                                &capture_status.used_channels,
+                            );
+                            chunk.update_stats(&mut chunk_stats);
+                            //trace!("Capture rms {:?}, peak {:?}", chunk_stats.rms_db(), chunk_stats.peak_db());
+                            capture_status.signal_rms.add_record_squared(chunk_stats.rms_linear());
+                            capture_status.signal_peak.add_record(chunk_stats.peak_linear());
+                            chunk
+                        };
+
                         value_range = chunk.maxval - chunk.minval;
                         state = silence_counter.update(value_range);
                         if state == ProcessingState::Running {
@@ -1125,8 +1128,7 @@ impl CaptureDevice for WasapiCaptureDevice {
                 stop_signal.store(true, Ordering::Relaxed);
                 debug!("Wait for inner capture thread to exit");
                 innerhandle.join().unwrap_or(());
-                let mut capt_stat = capture_status.lock().unwrap();
-                capt_stat.state = ProcessingState::Inactive;
+                capture_status.lock().unwrap().state = ProcessingState::Inactive;
             })?;
         Ok(Box::new(handle))
     }


### PR DESCRIPTION
This PR is a first pass at optimising cpu load and latency under concurrency. I have marked it as draft because some questions and testing remain.

Previously, most mutexes were (a) `RwLock`s and (b) frequently locked-and-unlocked. This PR does the following:

1. Replace the `RwLock`s with `Mutex`es. `RwLock`s bring more complexity and overhead that is warranted only in the case of few writers and many (!) readers. Here, readers are not so many and we can do with a standard `Mutex` and much less overhead.

    I have considered `parking_lot` as a faster-than-std mutex, but now think of staying with `std::sync::Mutex`. Since Rust 1.62 there is a new `Mutex` implementation on Linux that is faster than `parking_lot` when contended, and in one benchmark only 89-249 µs slower than `parking_lot` when slightly or uncontended. Other platforms have likewise had their `std::Mutex` improved: https://github.com/rust-lang/rust/issues/93740

2. Instead of locking-and-unlocking all the time, acquire a single lock to do all reads and writes, then release the lock as soon as possible. I think this strikes a nice balance, offering lower cpu usage at slightly higher contention.

   It also ensures that the update of statistics (which is what many of the mutexes are actually about) is consistent: average and peak values, and clipped sample counting, is updated atomically where before a read *could* have returned a partial update. This is probably academic, but nice to have anyway. In some cases with two mutexes, I made sure two lock both mutexes to start a "transaction" and ensure a consistent state between them.

3. I have also added CI actions to test all backends and optional features, and fixed a couple of issues along the way. This is otherwise unrelated to this PR; let me know if you want to take it out.

The improvement is not earth-shattering, but ticks off a few percentage points of cpu usage and may improve latency a little.

I see opportunities for some further optimisations, like doing less buffer allocations while holding a lock, and can do those as a second pass in different PRs as I starting going on a file-by-file basis.

**Questions:**

- I can work on replacing the `std::sync::mpsc` channels with `crossbeam-channel`, but coincidence has it that `crossbeam-channel` will become the default `std::sync::mpsc` implementation as of Rust 1.67, which is targeted for release end of January 2023.

  I propose that we _either_ move everything to `crossbeam-channel` (and not depend on recent Rust compilers) _or_ plan to remove it altogether. I would recommend the latter. What do you think?

- Is it conceivable that `used_channels` changes during runtime? If not, I could refactor a bit and make sure that buffer conversions are lock-free.

- In `ProcessingParameters`, there is a separate field `mute`. In `make_ramp` this is made equivalent to `-100.0`. Do you want to keep it as a separate field or would you consider removing it and in favour of `is_mute = x <= -100.0` instead? While less clean, it would pave the way to change this `Mutex` into an atomic read/write and gain some speed in a filter that's "always on".

- What would happen without the barriers? Is it only to synchronise only start-up / reload? I have not toyed with it yet but I get the feeling that it would be possible to keep the supervisor loop running and check for required states with less of a hammer :smile: I know the barrier is not used in a loop so won't harm much, so just something minor.

- Could someone verify this works well on Windows? I only have Linux and macOS devices I can compile and test on.