### PR TITLE
Add metadata field to config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::filters;
 use crate::mixer;
 use serde::{de, Deserialize, Serialize};
+use serde_json::{Value};
 use serde_with;
 use std::collections::HashMap;
 use std::error;
@@ -789,6 +790,8 @@ pub struct Configuration {
     pub filters: HashMap<String, Filter>,
     #[serde(default)]
     pub pipeline: Vec<PipelineStep>,
+    #[serde(default)]
+    pub metadata: Value,
 }
 
 fn validate_nonzero_usize<'de, D>(d: D) -> Result<usize, D::Error>


### PR DESCRIPTION
Hello! Tiny PR to allow a metadata field in the config. For me this would be useful in two ways.

## Anchors. 

Im numerically challenged so I cannot remember what output 5 is without a cheat sheet. So by putting anchors at the top in the metadata it makes it really easy to change, and reason about the config further down.

```yaml
---
metadata: 
  channels:
    inL: &inL 0
    inR: &inR 1
    monitorL: &monitorL 0
    monitorR: &monitorR 1
    headphoneL: &headphoneL 2
    headphoneR: &headphoneR 3
    sub1: &sub1 4
    sub2: &sub2 5
  ....
....
mixers:
  stereo:
    channels:
      in: 2
      out: 10
    mapping:
    - dest: *headphoneL
      sources:
      - channel: *inL
    - dest: *headphoneR
      sources:
      - channel: *inR
     ...
...
```

We could ofc define the anchors directly in the mixers and re-use them further down, but I like the neatness of having it at the top.

## Putting arbitrary metadata in the config

Im building a physical control surface for my CamillaDSP setup, to allow me to quickly switch on/off headphones/monitors, disable sub1, sub2, change room correction depending on if my standup table is down or up, switches for different crossfeed configs for the headphones etc etc. The permutations of different configs has exploded, if I could add arbitrary metadata I could parse that from a ESP32 or similar and set led on/off, make sure the control surface is up to date with the config etc.


Given a active CamillaDSP config with metadata

```yaml
---
metadata: 
    ...
  enabled:
    monitors: false
    headphones: true
```

I could easily poll over websocket and do something like

```python
while True:
    current_meta = cdsp.get_config()['metadata']
    toggleLED(MONITORS_ENABLED_LED, current_meta['enabled']['monitors'])
    toggleLED(HEADPHONE_ENABLED_LED, current_meta['enabled']['headphones'])
```

Hope that makes sense.