### PR TITLE
reset StopReason when PlaybackReady

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -327,6 +327,7 @@ fn run(
                         barrier.wait();
                         debug!("Supervisor loop starts now!");
                         is_starting = false;
+                        status_structs.status.write().unwrap().stop_reason = StopReason::None;
                     }
                 }
                 StatusMessage::CaptureReady => {


### PR DESCRIPTION
Lemme know if I misunderstand the code but IMHO CaptureReady and PlaybackReady should be treated in the same way. When the loop starts the stopreason should be reset.
I don't really see the past code causing problem in reality, most probably because 1) the value is initialized to none 2) playback thread are always running before the capture thread, and by the time capture is ready, the stop reason is reset there. 
