### PR TITLE
[RFC] Improving config reload handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,12 @@ zbus = { version = "3.0.0", optional = true }
 #coreaudio-rs = { path = "../coreaudio-rs" }
 #coreaudio-rs = { git = "https://github.com/HEnquist/coreaudio-rs", tag="v0.11.1-rc1" }
 coreaudio-rs = "0.11.1"
-crossbeam-channel = "0.5"
 dispatch = "0.2.0"
 
 [target.'cfg(target_os="windows")'.dependencies]
 #wasapi = { path = "../../rust/wasapi" }
 #wasapi = { git = "https://github.com/HEnquist/wasapi-rs", branch = "win041" }
 wasapi = "0.13.0"
-crossbeam-channel = "0.5"
 windows = {version = "0.48.0", features = ["Win32_System_Threading", "Win32_Foundation"] }
 
 [dependencies]
@@ -78,6 +76,7 @@ cpal = { version = "0.13.3", optional = true }
 rawsample = "0.2.0"
 circular-queue = "0.2.6"
 parking_lot = { version = "0.12.1", features = ["hardware-lock-elision"] }
+crossbeam-channel = "0.5"
 
 [build-dependencies]
 version_check = "0.9"

--- a/src/alsadevice.rs
+++ b/src/alsadevice.rs
@@ -66,13 +66,13 @@ pub struct AlsaCaptureDevice {
 
 struct CaptureChannels {
     audio: mpsc::SyncSender<AudioMessage>,
-    status: mpsc::Sender<StatusMessage>,
+    status: crossbeam_channel::Sender<StatusMessage>,
     command: mpsc::Receiver<CommandMessage>,
 }
 
 struct PlaybackChannels {
     audio: mpsc::Receiver<AudioMessage>,
-    status: mpsc::Sender<StatusMessage>,
+    status: crossbeam_channel::Sender<StatusMessage>,
 }
 
 struct CaptureParams {
@@ -908,7 +908,7 @@ impl PlaybackDevice for AlsaPlaybackDevice {
         &mut self,
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
@@ -983,7 +983,7 @@ impl CaptureDevice for AlsaCaptureDevice {
         &mut self,
         channel: mpsc::SyncSender<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
         capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {

--- a/src/audiodevice.rs
+++ b/src/audiodevice.rs
@@ -218,7 +218,7 @@ pub trait PlaybackDevice {
         &mut self,
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>>;
 }
@@ -229,7 +229,7 @@ pub trait CaptureDevice {
         &mut self,
         channel: mpsc::SyncSender<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
         capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>>;

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -171,7 +171,7 @@ fn run(
     let (tx_pb, rx_pb) = mpsc::sync_channel(conf.devices.queuelimit());
     let (tx_cap, rx_cap) = mpsc::sync_channel(conf.devices.queuelimit());
 
-    let (tx_status, rx_status) = mpsc::channel();
+    let (tx_status, rx_status) = crossbeam_channel::unbounded();
     let tx_status_pb = tx_status.clone();
     let tx_status_cap = tx_status;
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -27,10 +27,11 @@ extern crate time;
 extern crate log;
 
 use clap::{crate_authors, crate_description, crate_version, App, AppSettings, Arg};
+use crossbeam_channel::select;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use std::env;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc;
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -38,6 +39,10 @@ use std::time::Duration;
 
 use flexi_logger::DeferredNow;
 use log::Record;
+use signal_hook::consts::signal::*;
+use signal_hook::consts::TERM_SIGNALS;
+#[cfg(not(windows))]
+use signal_hook::iterator::{exfiltrator::SignalOnly, SignalsInfo};
 use time::format_description;
 
 use camillalib::Res;
@@ -49,11 +54,12 @@ use camillalib::processing;
 #[cfg(feature = "websocket")]
 use camillalib::socketserver;
 use camillalib::statefile;
+use camillalib::ControllerMessage;
 #[cfg(feature = "websocket")]
 use std::net::IpAddr;
 
 use camillalib::{
-    list_supported_devices, CaptureStatus, CommandMessage, ExitRequest, ExitState, PlaybackStatus,
+    list_supported_devices, CaptureStatus, CommandMessage, ExitState, PlaybackStatus,
     ProcessingParameters, ProcessingState, ProcessingStatus, SharedConfigs, StatusMessage,
     StatusStructs, StopReason,
 };
@@ -61,8 +67,6 @@ use camillalib::{
 const EXIT_BAD_CONFIG: i32 = 101; // Error in config file
 const EXIT_PROCESSING_ERROR: i32 = 102; // Error from processing
 const EXIT_OK: i32 = 0; // All ok
-
-const DELAY: Duration = Duration::from_millis(100);
 
 // Time format string for logger
 const TS_S: &str = "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:6]";
@@ -110,58 +114,13 @@ pub fn custom_logger_format(
     )
 }
 
-fn new_config(
-    config_path: &Arc<Mutex<Option<String>>>,
-    new_config_shared: &Arc<Mutex<Option<config::Configuration>>>,
-) -> Res<config::Configuration> {
-    //new_config is not None, this is the one to use
-    if let Some(mut conf) = new_config_shared.lock().clone() {
-        debug!("Reload using config from websocket");
-        match config::validate_config(&mut conf, None) {
-            Ok(()) => {
-                debug!("Config valid");
-                Ok(conf)
-            }
-            Err(err) => {
-                error!("Invalid config file!");
-                error!("{}", err);
-                Err(err)
-            }
-        }
-    } else if let Some(file) = config_path.lock().clone() {
-        match config::load_config(&file) {
-            Ok(mut conf) => match config::validate_config(&mut conf, Some(&file)) {
-                Ok(()) => {
-                    debug!("Reload using config file");
-                    Ok(conf)
-                }
-                Err(err) => {
-                    error!("Invalid config file!");
-                    error!("{}", err);
-                    Err(err)
-                }
-            },
-            Err(err) => {
-                error!("Config file error:");
-                error!("{}", err);
-                Err(err)
-            }
-        }
-    } else {
-        error!("No new config supplied and no path set");
-        Err(config::ConfigError::new("No new config supplied and no path set").into())
-    }
-}
-
 fn run(
-    signal_reload: Arc<AtomicBool>,
-    signal_exit: Arc<AtomicUsize>,
     shared_configs: SharedConfigs,
-    config_path: Arc<Mutex<Option<String>>>,
     status_structs: StatusStructs,
+    rx_ctrl: crossbeam_channel::Receiver<ControllerMessage>,
 ) -> Res<ExitState> {
     let mut is_starting = true;
-    let conf = match shared_configs.new.lock().take() {
+    let conf = match shared_configs.active.lock().take() {
         Some(cfg) => cfg,
         None => {
             error!("Tried to start without config!");
@@ -188,8 +147,6 @@ fn run(
     let conf_proc = conf.clone();
 
     let mut active_config = conf;
-    //let conf_yaml = serde_yaml::to_string(&active_config).unwrap();
-    *shared_configs.active.lock() = Some(active_config.clone());
 
     // Processing thread
     processing::run_processing(
@@ -229,241 +186,222 @@ fn run(
 
     let mut pb_ready = false;
     let mut cap_ready = false;
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
-    signal_hook::flag::register(signal_hook::consts::SIGHUP, Arc::clone(&signal_reload))?;
-    signal_hook::flag::register_usize(
-        signal_hook::consts::SIGINT,
-        Arc::clone(&signal_exit),
-        ExitRequest::EXIT,
-    )?;
 
     loop {
-        if !is_starting
-            && signal_reload
-                .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-        {
-            debug!("Reloading configuration...");
-            let new_config = new_config(&config_path, &shared_configs.new);
-
-            match new_config {
-                Ok(conf) => {
-                    let comp = config::config_diff(&active_config, &conf);
-                    match comp {
-                        config::ConfigChange::Pipeline
-                        | config::ConfigChange::MixerParameters
-                        | config::ConfigChange::FilterParameters { .. } => {
-                            tx_pipeconf.send((comp, conf.clone())).unwrap();
-                            active_config = conf;
-                            {
-                                // acquire both locks first to start a "transaction"
-                                let mut act_cfg_shared = shared_configs.active.lock();
-                                let mut new_cfg_shared = shared_configs.new.lock();
-                                *act_cfg_shared = Some(active_config.clone());
-                                *new_cfg_shared = None;
+        // If startup procedure is not finished, do not process config change or exit
+        let ctrl_ch = if is_starting {
+            crossbeam_channel::never()
+        } else {
+            rx_ctrl.clone()
+        };
+        select! {
+            recv(ctrl_ch) -> msg  => {
+                match msg {
+                    Ok(ControllerMessage::ConfigChanged(new_conf)) => {
+                        let comp = config::config_diff(&active_config, &new_conf);
+                        match comp {
+                            config::ConfigChange::Pipeline
+                            | config::ConfigChange::MixerParameters
+                            | config::ConfigChange::FilterParameters { .. } => {
+                                tx_pipeconf.send((comp, *new_conf.clone())).unwrap();
+                                active_config = *new_conf;
+                                *shared_configs.active.lock() = Some(active_config.clone());
+                                let used_channels = config::used_capture_channels(&active_config);
+                                debug!("Using channels {:?}", used_channels);
+                                status_structs.capture.write().used_channels = used_channels;
+                                debug!("Sent changes to pipeline");
                             }
-                            let used_channels = config::used_capture_channels(&active_config);
-                            debug!("Using channels {:?}", used_channels);
-                            status_structs.capture.write().used_channels = used_channels;
-                            debug!("Sent changes to pipeline");
-                        }
-                        config::ConfigChange::Devices => {
-                            debug!("Devices changed, restart required.");
-                            if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                                debug!("Capture thread has already exited");
+                            config::ConfigChange::Devices => {
+                                debug!("Devices changed, restart required.");
+                                if tx_command_cap.send(CommandMessage::Exit).is_err() {
+                                    debug!("Capture thread has already exited");
+                                }
+                                trace!("Wait for pb..");
+                                pb_handle.join().unwrap();
+                                trace!("Wait for cap..");
+                                cap_handle.join().unwrap();
+                                *shared_configs.active.lock() = Some(*new_conf);
+                                trace!("All threads stopped, returning");
+                                return Ok(ExitState::Restart);
                             }
-                            trace!("Wait for pb..");
-                            pb_handle.join().unwrap();
-                            trace!("Wait for cap..");
-                            cap_handle.join().unwrap();
-                            *shared_configs.new.lock() = Some(conf);
-                            trace!("All threads stopped, returning");
-                            return Ok(ExitState::Restart);
+                            config::ConfigChange::None => {
+                                debug!("No changes in config.");
+                            }
+                        };
+                    },
+                    Ok(ControllerMessage::Stop) => {
+                        debug!("Stop requested...");
+                        if tx_command_cap.send(CommandMessage::Exit).is_err() {
+                            debug!("Capture thread has already exited");
                         }
-                        config::ConfigChange::None => {
-                            debug!("No changes in config.");
-                            *shared_configs.new.lock() = None;
+                        trace!("Wait for pb..");
+                        pb_handle.join().unwrap();
+                        trace!("Wait for cap..");
+                        cap_handle.join().unwrap();
+                        {
+                            let mut active_cfg_shared = shared_configs.active.lock();
+                            let mut prev_cfg_shared = shared_configs.previous.lock();
+                            *active_cfg_shared = None;
+                            *prev_cfg_shared = Some(active_config);
                         }
-                    };
-                }
-                Err(err) => {
-                    error!("Config file error: {}", err);
-                }
-            };
-        }
-        if !is_starting {
-            match signal_exit.load(Ordering::Relaxed) {
-                ExitRequest::EXIT => {
-                    debug!("Exit requested...");
-                    signal_exit.store(ExitRequest::NONE, Ordering::Relaxed);
-                    if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                        debug!("Capture thread has already exited");
-                    }
-                    trace!("Wait for pb..");
-                    pb_handle.join().unwrap();
-                    trace!("Wait for cap..");
-                    cap_handle.join().unwrap();
-                    *shared_configs.previous.lock() = Some(active_config);
-                    trace!("All threads stopped, exiting");
-                    return Ok(ExitState::Exit);
-                }
-                ExitRequest::STOP => {
-                    debug!("Stop requested...");
-                    signal_exit.store(ExitRequest::NONE, Ordering::Relaxed);
-                    if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                        debug!("Capture thread has already exited");
-                    }
-                    trace!("Wait for pb..");
-                    pb_handle.join().unwrap();
-                    trace!("Wait for cap..");
-                    cap_handle.join().unwrap();
-                    {
-                        let mut new_cfg_shared = shared_configs.new.lock();
-                        let mut prev_cfg_shared = shared_configs.previous.lock();
-                        *new_cfg_shared = None;
-                        *prev_cfg_shared = Some(active_config);
-                    }
-                    trace!("All threads stopped, stopping");
-                    return Ok(ExitState::Restart);
-                }
-                _ => {}
-            };
-        }
-        match rx_status.recv_timeout(DELAY) {
-            Ok(msg) => match msg {
-                StatusMessage::PlaybackReady => {
-                    debug!("Playback thread ready to start");
-                    pb_ready = true;
-                    if cap_ready {
-                        debug!("Both capture and playback ready, release barrier");
-                        barrier.wait();
-                        debug!("Supervisor loop starts now!");
-                        is_starting = false;
-                    }
-                }
-                StatusMessage::CaptureReady => {
-                    debug!("Capture thread ready to start");
-                    cap_ready = true;
-                    if pb_ready {
-                        debug!("Both capture and playback ready, release barrier");
-                        barrier.wait();
-                        debug!("Supervisor loop starts now!");
-                        is_starting = false;
-                        status_structs.status.write().stop_reason = StopReason::None;
-                    }
-                }
-                StatusMessage::PlaybackError(message) => {
-                    error!("Playback error: {}", message);
-                    if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                        debug!("Capture thread has already exited");
-                    }
-                    if is_starting {
-                        debug!("Error while starting, release barrier");
-                        barrier.wait();
-                    }
-                    debug!("Wait for capture thread to exit..");
-                    status_structs.status.write().stop_reason = StopReason::PlaybackError(message);
-                    cap_handle.join().unwrap();
-                    {
-                        let mut new_cfg_shared = shared_configs.new.lock();
-                        let mut prev_cfg_shared = shared_configs.previous.lock();
-                        *new_cfg_shared = None;
-                        *prev_cfg_shared = Some(active_config);
-                    }
-                    trace!("All threads stopped, returning");
-                    return Ok(ExitState::Restart);
-                }
-                StatusMessage::CaptureError(message) => {
-                    error!("Capture error: {}", message);
-                    if is_starting {
-                        debug!("Error while starting, release barrier");
-                        barrier.wait();
-                    }
-                    debug!("Wait for playback thread to exit..");
-                    status_structs.status.write().stop_reason = StopReason::CaptureError(message);
-                    pb_handle.join().unwrap();
-                    {
-                        let mut new_cfg_shared = shared_configs.new.lock();
-                        let mut prev_cfg_shared = shared_configs.previous.lock();
-                        *new_cfg_shared = None;
-                        *prev_cfg_shared = Some(active_config);
-                    }
-                    trace!("All threads stopped, returning");
-                    return Ok(ExitState::Restart);
-                }
-                StatusMessage::PlaybackFormatChange(rate) => {
-                    error!("Playback stopped due to external format change");
-                    if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                        debug!("Capture thread has already exited");
-                    }
-                    if is_starting {
-                        debug!("Error while starting, release barrier");
-                        barrier.wait();
-                    }
-                    debug!("Wait for capture thread to exit..");
-                    status_structs.status.write().stop_reason =
-                        StopReason::PlaybackFormatChange(rate);
-                    cap_handle.join().unwrap();
-                    {
-                        let mut new_cfg_shared = shared_configs.new.lock();
-                        let mut prev_cfg_shared = shared_configs.previous.lock();
-                        *new_cfg_shared = None;
-                        *prev_cfg_shared = Some(active_config);
-                    }
-                    trace!("All threads stopped, returning");
-                    return Ok(ExitState::Restart);
-                }
-                StatusMessage::CaptureFormatChange(rate) => {
-                    error!("Capture stopped due to external format change");
-                    if is_starting {
-                        debug!("Error while starting, release barrier");
-                        barrier.wait();
-                    }
-                    debug!("Wait for playback thread to exit..");
-                    status_structs.status.write().stop_reason =
-                        StopReason::CaptureFormatChange(rate);
-                    pb_handle.join().unwrap();
-                    {
-                        let mut new_cfg_shared = shared_configs.new.lock();
-                        let mut prev_cfg_shared = shared_configs.previous.lock();
-                        *new_cfg_shared = None;
-                        *prev_cfg_shared = Some(active_config);
-                    }
-                    trace!("All threads stopped, returning");
-                    return Ok(ExitState::Restart);
-                }
-                StatusMessage::PlaybackDone => {
-                    info!("Playback finished");
-                    {
-                        let stat = status_structs.status.upgradable_read();
-                        if stat.stop_reason == StopReason::None {
-                            RwLockUpgradableReadGuard::upgrade(stat).stop_reason = StopReason::Done;
+                        trace!("All threads stopped, stopping");
+                        return Ok(ExitState::Restart);
+                    },
+                    Ok(ControllerMessage::Exit) => {
+                        debug!("Exit requested...");
+                        if tx_command_cap.send(CommandMessage::Exit).is_err() {
+                            debug!("Capture thread has already exited");
                         }
-                    }
-                    *shared_configs.previous.lock() = Some(active_config);
-                    trace!("All threads stopped, returning");
-                    return Ok(ExitState::Restart);
-                }
-                StatusMessage::CaptureDone => {
-                    info!("Capture finished");
-                }
-                StatusMessage::SetSpeed(speed) => {
-                    debug!("SetSpeed message received");
-                    if tx_command_cap
-                        .send(CommandMessage::SetSpeed { speed })
-                        .is_err()
-                    {
-                        debug!("Capture thread has already exited");
+                        trace!("Wait for pb..");
+                        pb_handle.join().unwrap();
+                        trace!("Wait for cap..");
+                        cap_handle.join().unwrap();
+                        *shared_configs.previous.lock() = Some(active_config);
+                        trace!("All threads stopped, exiting");
+                        return Ok(ExitState::Exit);
+                    },
+                    Err(err) => {
+                        return Err(Box::new(err));
                     }
                 }
             },
-            Err(mpsc::RecvTimeoutError::Timeout) => {}
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                warn!("Capture, Playback and Processing threads have exited");
-                status_structs.status.write().stop_reason = StopReason::UnknownError(
-                    "Capture, Playback and Processing threads have exited".to_string(),
-                );
-                return Ok(ExitState::Restart);
+            recv(rx_status) -> msg => {
+                match msg {
+                    Ok(msg) => match msg {
+                        StatusMessage::PlaybackReady => {
+                            debug!("Playback thread ready to start");
+                            pb_ready = true;
+                            if cap_ready {
+                                debug!("Both capture and playback ready, release barrier");
+                                barrier.wait();
+                                debug!("Supervisor loop starts now!");
+                                is_starting = false;
+                            }
+                        }
+                        StatusMessage::CaptureReady => {
+                            debug!("Capture thread ready to start");
+                            cap_ready = true;
+                            if pb_ready {
+                                debug!("Both capture and playback ready, release barrier");
+                                barrier.wait();
+                                debug!("Supervisor loop starts now!");
+                                is_starting = false;
+                                status_structs.status.write().stop_reason = StopReason::None;
+                            }
+                        }
+                        StatusMessage::PlaybackError(message) => {
+                            error!("Playback error: {}", message);
+                            if tx_command_cap.send(CommandMessage::Exit).is_err() {
+                                debug!("Capture thread has already exited");
+                            }
+                            if is_starting {
+                                debug!("Error while starting, release barrier");
+                                barrier.wait();
+                            }
+                            debug!("Wait for capture thread to exit..");
+                            status_structs.status.write().stop_reason = StopReason::PlaybackError(message);
+                            cap_handle.join().unwrap();
+                            {
+                                let mut active_cfg_shared = shared_configs.active.lock();
+                                let mut prev_cfg_shared = shared_configs.previous.lock();
+                                *active_cfg_shared = None;
+                                *prev_cfg_shared = Some(active_config);
+                            }
+                            trace!("All threads stopped, returning");
+                            return Ok(ExitState::Restart);
+                        }
+                        StatusMessage::CaptureError(message) => {
+                            error!("Capture error: {}", message);
+                            if is_starting {
+                                debug!("Error while starting, release barrier");
+                                barrier.wait();
+                            }
+                            debug!("Wait for playback thread to exit..");
+                            status_structs.status.write().stop_reason = StopReason::CaptureError(message);
+                            pb_handle.join().unwrap();
+                            {
+                                let mut active_cfg_shared = shared_configs.active.lock();
+                                let mut prev_cfg_shared = shared_configs.previous.lock();
+                                *active_cfg_shared = None;
+                                *prev_cfg_shared = Some(active_config);
+                            }
+                            trace!("All threads stopped, returning");
+                            return Ok(ExitState::Restart);
+                        }
+                        StatusMessage::PlaybackFormatChange(rate) => {
+                            error!("Playback stopped due to external format change");
+                            if tx_command_cap.send(CommandMessage::Exit).is_err() {
+                                debug!("Capture thread has already exited");
+                            }
+                            if is_starting {
+                                debug!("Error while starting, release barrier");
+                                barrier.wait();
+                            }
+                            debug!("Wait for capture thread to exit..");
+                            status_structs.status.write().stop_reason =
+                                StopReason::PlaybackFormatChange(rate);
+                            cap_handle.join().unwrap();
+                            {
+                                let mut active_cfg_shared = shared_configs.active.lock();
+                                let mut prev_cfg_shared = shared_configs.previous.lock();
+                                *active_cfg_shared = None;
+                                *prev_cfg_shared = Some(active_config);
+                            }
+                            trace!("All threads stopped, returning");
+                            return Ok(ExitState::Restart);
+                        }
+                        StatusMessage::CaptureFormatChange(rate) => {
+                            error!("Capture stopped due to external format change");
+                            if is_starting {
+                                debug!("Error while starting, release barrier");
+                                barrier.wait();
+                            }
+                            debug!("Wait for playback thread to exit..");
+                            status_structs.status.write().stop_reason =
+                                StopReason::CaptureFormatChange(rate);
+                            pb_handle.join().unwrap();
+                            {
+                                let mut active_cfg_shared = shared_configs.active.lock();
+                                let mut prev_cfg_shared = shared_configs.previous.lock();
+                                *active_cfg_shared = None;
+                                *prev_cfg_shared = Some(active_config);
+                            }
+                            trace!("All threads stopped, returning");
+                            return Ok(ExitState::Restart);
+                        }
+                        StatusMessage::PlaybackDone => {
+                            info!("Playback finished");
+                            {
+                                let stat = status_structs.status.upgradable_read();
+                                if stat.stop_reason == StopReason::None {
+                                    RwLockUpgradableReadGuard::upgrade(stat).stop_reason = StopReason::Done;
+                                }
+                            }
+                            *shared_configs.previous.lock() = Some(active_config);
+                            trace!("All threads stopped, returning");
+                            return Ok(ExitState::Restart);
+                        }
+                        StatusMessage::CaptureDone => {
+                            info!("Capture finished");
+                        }
+                        StatusMessage::SetSpeed(speed) => {
+                            debug!("SetSpeed message received");
+                            if tx_command_cap
+                                .send(CommandMessage::SetSpeed { speed })
+                                .is_err()
+                            {
+                                debug!("Capture thread has already exited");
+                            }
+                        }
+                    },
+                    Err(err) => {
+                        warn!("Capture, Playback and Processing threads have exited: {}", err);
+                        status_structs.status.write().stop_reason = StopReason::UnknownError(
+                            "Capture, Playback and Processing threads have exited".to_string(),
+                        );
+                        return Ok(ExitState::Restart);
+                    }
+                }
             }
         }
     }
@@ -844,25 +782,80 @@ fn main_process() -> i32 {
         }
     }
 
-    let configuration = match &configname {
-        Some(path) => match config::load_validate_config(path) {
+    let (tx_command, rx_command) = crossbeam_channel::unbounded();
+    if let Some(path) = &configname {
+        match config::load_validate_config(path) {
             Ok(conf) => {
                 debug!("Config is valid");
-                Some(conf)
+                tx_command
+                    .send(ControllerMessage::ConfigChanged(Box::new(conf)))
+                    .unwrap();
             }
             Err(err) => {
                 error!("{}", err);
                 debug!("Exiting due to config error");
                 return EXIT_BAD_CONFIG;
             }
-        },
-        None => None,
-    };
+        }
+    }
+
+    let active_config_path = Arc::new(Mutex::new(configname));
+
+    let tx_command_thread = tx_command.clone();
+    let active_path_thread = active_config_path.clone();
+
+    #[cfg(not(windows))]
+    thread::spawn(move || {
+        let mut sigs = vec![SIGHUP, SIGUSR1];
+        sigs.extend(TERM_SIGNALS);
+        let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();
+        for info in &mut signals {
+            match info {
+                SIGHUP => {
+                    let path = (*active_path_thread.lock()).clone();
+                    if let Some(path) = path {
+                        match config::load_validate_config(path.as_str()) {
+                            Ok(conf) => {
+                                debug!("Config is valid");
+                                tx_command_thread
+                                    .send(ControllerMessage::ConfigChanged(Box::new(conf)))
+                                    .unwrap();
+                            }
+                            Err(err) => {
+                                error!("Config error during reload: {}", err);
+                            }
+                        };
+                    } else {
+                        error!("Config path not specified, cannot reload");
+                    }
+                }
+                SIGUSR1 => {
+                    tx_command_thread.send(ControllerMessage::Stop).unwrap();
+                }
+                _ => {
+                    tx_command_thread.send(ControllerMessage::Exit).unwrap();
+                }
+            };
+        }
+    });
+
+    #[cfg(windows)]
+    thread::spawn(move || {
+        // On windows we don't have signal_hook::iterator, so we just poll for signal...
+        const DELAY: Duration = Duration::from_millis(100);
+        let signal_exit = Arc::new(AtomicBool::new(false));
+        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&signal_exit)).unwrap();
+        loop {
+            if signal_exit.load(std::sync::atomic::Ordering::Relaxed) {
+                tx_command_thread.send(ControllerMessage::Exit).unwrap();
+                break;
+            }
+            thread::sleep(DELAY);
+        }
+    });
 
     let wait = matches.is_present("wait");
 
-    let signal_reload = Arc::new(AtomicBool::new(false));
-    let signal_exit = Arc::new(AtomicUsize::new(ExitRequest::NONE));
     let capture_status = Arc::new(RwLock::new(CaptureStatus {
         measured_samplerate: 0,
         update_interval: 1000,
@@ -892,10 +885,7 @@ fn main_process() -> i32 {
         status: processing_status.clone(),
     };
     let active_config = Arc::new(Mutex::new(None));
-    let next_config = Arc::new(Mutex::new(configuration));
     let previous_config = Arc::new(Mutex::new(None));
-
-    let active_config_path = Arc::new(Mutex::new(configname));
 
     #[cfg(feature = "websocket")]
     {
@@ -913,12 +903,10 @@ fn main_process() -> i32 {
             tx_state.try_send(()).unwrap_or(());
 
             let shared_data = socketserver::SharedData {
-                signal_reload: signal_reload.clone(),
-                signal_exit: signal_exit.clone(),
                 active_config: active_config.clone(),
-                active_config_path: active_config_path.clone(),
-                new_config: next_config.clone(),
+                active_config_path,
                 previous_config: previous_config.clone(),
+                command_sender: tx_command,
                 capture_status,
                 playback_status,
                 processing_params,
@@ -961,53 +949,53 @@ fn main_process() -> i32 {
 
     loop {
         debug!("Wait for config");
-        {
-            while next_config.lock().is_none() {
-                if !wait {
-                    debug!("No config and not in wait mode, exiting!");
+
+        loop {
+            let has_config = (*active_config.lock()).is_some();
+            let msg: Result<ControllerMessage, Box<dyn std::error::Error>> = if has_config || !wait
+            {
+                // `try_recv` is used to prevent blocking:
+                // If we already have config, we just try to drain the queue without blocking.
+                // Or, if wait flag is not permitted by user, we do not block here.
+                // If there's neither wait flag nor active config, error will occur in
+                // run() function which will cause program to exit.
+                let res = rx_command.try_recv();
+                match res {
+                    Err(crossbeam_channel::TryRecvError::Empty) => break,
+                    x => x.map_err(|e| Box::new(e) as _),
+                }
+            } else {
+                // If there's no config, and wait flag is present, we wait for the command queue to
+                // send us config or exit command.
+                rx_command.recv().map_err(|e| Box::new(e) as _)
+            };
+            match msg {
+                Ok(ControllerMessage::ConfigChanged(new_conf)) => {
+                    *active_config.lock() = Some(*new_conf);
+                    break;
+                }
+                Ok(ControllerMessage::Stop) => {
+                    *active_config.lock() = None;
+                }
+                Ok(ControllerMessage::Exit) => {
                     return EXIT_OK;
                 }
-                if signal_exit.load(Ordering::Relaxed) == ExitRequest::EXIT {
-                    // exit requested
+                Err(e) => {
+                    warn!("Error recv from cmd queue {}", e);
                     return EXIT_OK;
-                } else if signal_reload
-                    .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
-                    .is_ok()
-                {
-                    debug!("Reloading configuration...");
-                    let conf_loaded = new_config(&active_config_path, &next_config);
-                    let path = active_config_path.lock();
-                    match conf_loaded {
-                        Ok(conf) => {
-                            debug!("Loaded config file: {:?}", path);
-                            *next_config.lock() = Some(conf);
-                        }
-                        Err(err) => {
-                            error!("Could not load config: {:?}, error: {}", path, err);
-                        }
-                    }
                 }
             }
-            thread::sleep(DELAY);
         }
-        signal_reload.store(false, Ordering::Relaxed);
+
         let shared_configs = SharedConfigs {
             active: active_config.clone(),
-            new: next_config.clone(),
             previous: previous_config.clone(),
         };
 
-        debug!("Config ready");
-        let exitstatus = run(
-            signal_reload.clone(),
-            signal_exit.clone(),
-            shared_configs,
-            active_config_path.clone(),
-            status_structs.clone(),
-        );
+        debug!("Config ready, start processing");
+        let exitstatus = run(shared_configs, status_structs.clone(), rx_command.clone());
         debug!("Processing ended with status {:?}", exitstatus);
 
-        *active_config.lock() = None;
         match exitstatus {
             Err(e) => {
                 error!("({}) {}", e.to_string(), e);

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -120,15 +120,15 @@ fn run(
     rx_ctrl: crossbeam_channel::Receiver<ControllerMessage>,
 ) -> Res<ExitState> {
     let mut is_starting = true;
-    let conf = match shared_configs.active.lock().take() {
+    let mut active_config = match shared_configs.active.lock().clone() {
         Some(cfg) => cfg,
         None => {
             error!("Tried to start without config!");
             return Ok(ExitState::Exit);
         }
     };
-    let (tx_pb, rx_pb) = mpsc::sync_channel(conf.devices.queuelimit());
-    let (tx_cap, rx_cap) = mpsc::sync_channel(conf.devices.queuelimit());
+    let (tx_pb, rx_pb) = mpsc::sync_channel(active_config.devices.queuelimit());
+    let (tx_cap, rx_cap) = mpsc::sync_channel(active_config.devices.queuelimit());
 
     let (tx_status, rx_status) = crossbeam_channel::unbounded();
     let tx_status_pb = tx_status.clone();
@@ -142,11 +142,9 @@ fn run(
     let barrier_cap = barrier.clone();
     let barrier_proc = barrier.clone();
 
-    let conf_pb = conf.clone();
-    let conf_cap = conf.clone();
-    let conf_proc = conf.clone();
-
-    let mut active_config = conf;
+    let conf_pb = active_config.clone();
+    let conf_cap = active_config.clone();
+    let conf_proc = active_config.clone();
 
     // Processing thread
     processing::run_processing(

--- a/src/coreaudiodevice.rs
+++ b/src/coreaudiodevice.rs
@@ -337,7 +337,7 @@ impl PlaybackDevice for CoreaudioPlaybackDevice {
         &mut self,
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
@@ -591,7 +591,7 @@ impl CaptureDevice for CoreaudioCaptureDevice {
         &mut self,
         channel: mpsc::SyncSender<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
         capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {

--- a/src/cpaldevice.rs
+++ b/src/cpaldevice.rs
@@ -201,7 +201,7 @@ impl PlaybackDevice for CpalPlaybackDevice {
         &mut self,
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
@@ -471,7 +471,7 @@ impl CaptureDevice for CpalCaptureDevice {
         &mut self,
         channel: mpsc::SyncSender<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
         capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {

--- a/src/filedevice.rs
+++ b/src/filedevice.rs
@@ -73,7 +73,7 @@ pub struct FileCaptureDevice {
 
 struct CaptureChannels {
     audio: mpsc::SyncSender<AudioMessage>,
-    status: mpsc::Sender<StatusMessage>,
+    status: crossbeam_channel::Sender<StatusMessage>,
     command: mpsc::Receiver<CommandMessage>,
 }
 
@@ -111,7 +111,7 @@ impl PlaybackDevice for FilePlaybackDevice {
         &mut self,
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let destination = self.destination.clone();
@@ -535,7 +535,7 @@ impl CaptureDevice for FileCaptureDevice {
         &mut self,
         channel: mpsc::SyncSender<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
         capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ extern crate fftw;
 extern crate lazy_static;
 #[cfg(target_os = "macos")]
 extern crate coreaudio;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
 extern crate crossbeam_channel;
 #[cfg(target_os = "macos")]
 extern crate dispatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,13 @@ pub enum ExitState {
     Exit,
 }
 
+pub enum ControllerMessage {
+    // Config must be boxed, to prevent "large size difference between variants" warning
+    ConfigChanged(Box<config::Configuration>),
+    Stop,
+    Exit,
+}
+
 #[derive(Clone, Debug, Copy, Serialize, Eq, PartialEq)]
 pub enum ProcessingState {
     // Processing is running normally.
@@ -150,14 +157,6 @@ pub enum ProcessingState {
     Starting,
     // Capture device isnt providing data, processing is stalled.
     Stalled,
-}
-
-pub struct ExitRequest {}
-
-impl ExitRequest {
-    pub const NONE: usize = 0;
-    pub const EXIT: usize = 1;
-    pub const STOP: usize = 2;
 }
 
 #[derive(Clone, Debug)]
@@ -331,7 +330,6 @@ pub struct StatusStructs {
 pub struct SharedConfigs {
     pub active: Arc<Mutex<Option<config::Configuration>>>,
     pub previous: Arc<Mutex<Option<config::Configuration>>>,
-    pub new: Arc<Mutex<Option<config::Configuration>>>,
 }
 
 impl fmt::Display for ProcessingState {

--- a/src/pulsedevice.rs
+++ b/src/pulsedevice.rs
@@ -133,7 +133,7 @@ impl PlaybackDevice for PulsePlaybackDevice {
         &mut self,
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
@@ -270,7 +270,7 @@ impl CaptureDevice for PulseCaptureDevice {
         &mut self,
         channel: mpsc::SyncSender<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
         capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {

--- a/src/wasapidevice.rs
+++ b/src/wasapidevice.rs
@@ -598,7 +598,7 @@ impl PlaybackDevice for WasapiPlaybackDevice {
         &mut self,
         channel: mpsc::Receiver<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         playback_status: Arc<RwLock<PlaybackStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {
         let devname = self.devname.clone();
@@ -841,7 +841,7 @@ fn check_for_format_change(rx: &Receiver<DisconnectReason>) -> bool {
 }
 
 fn send_error_or_playbackformatchange(
-    tx: &mpsc::Sender<StatusMessage>,
+    tx: &crossbeam_channel::Sender<StatusMessage>,
     rx: &Receiver<DisconnectReason>,
     err: String,
 ) {
@@ -856,7 +856,7 @@ fn send_error_or_playbackformatchange(
 }
 
 fn send_error_or_captureformatchange(
-    tx: &mpsc::Sender<StatusMessage>,
+    tx: &crossbeam_channel::Sender<StatusMessage>,
     rx: &Receiver<DisconnectReason>,
     err: String,
 ) {
@@ -888,7 +888,7 @@ impl CaptureDevice for WasapiCaptureDevice {
         &mut self,
         channel: mpsc::SyncSender<AudioMessage>,
         barrier: Arc<Barrier>,
-        status_channel: mpsc::Sender<StatusMessage>,
+        status_channel: crossbeam_channel::Sender<StatusMessage>,
         command_channel: mpsc::Receiver<CommandMessage>,
         capture_status: Arc<RwLock<CaptureStatus>>,
     ) -> Res<Box<thread::JoinHandle<()>>> {


### PR DESCRIPTION
In my application there's a case where two config change message will be sent through WebSocket in a very short time. Sometimes, the second config won't take effect. We found that sending reload signal using an atomic boolean and a poll timer is not a reliable way to pass message, and may lead to race condition.

The main idea of this pull request is to remove the use of shared variable to pass reload and stop signal, and replace it with a crossbeam channel (control message channel). In the main loop, instead of polling the atomic variable with a fixed interval controlled by queue timeout, we use crossbeam::select! to simultaneously receive from the control channel and status channel, and respond to whatever event instantly (instead of having to wait for at most 100ms to respond to reload request).

When config is being changed by signal or websocket, new config is no longer passed by the `new_config` globally shared variable. Instead, it is passed through the control channel. This ensures no race condition will occur. Signals are now handled by a separate polling thread. When the signal handling thread receives a signal, it will respond by sending message to the control channel. In addition to SIGHUP, I also implemented SIGUSR1, which sends a Stop message to control thread.

I've tested the control logic by signal and websocket, and it works fine. However I'm sure I haven't covered all use cases, and it probably requires more testing. I don't have a Windows environment, so Windows support is untested.