### PR TITLE
Add armv6 build

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -108,32 +108,23 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: arm-unknown-linux-gnueabihf
-          override: true
+          targets: arm-unknown-linux-gnueabihf
+
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build image
         run: docker build -t cross/armv6:v1 --file Dockerfile_armv6 ./
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          use-cross: true
-          args: --target arm-unknown-linux-gnueabihf
+        run: cross check --target arm-unknown-linux-gnueabihf
 
       - name: Run cargo test for arm
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          use-cross: true
-          args: --target arm-unknown-linux-gnueabihf
+        run: cross test --target arm-unknown-linux-gnueabihf
         env: 
           LD_LIBRARY_PATH: /usr/lib/arm-linux-gnueabihf
-
 
   check_test_windows:
     name: Check and test Windows

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -100,6 +100,40 @@ jobs:
       - name: Run cargo test for arm
         run: cross test --target aarch64-unknown-linux-gnu
 
+  check_test_armv6:
+    name: Check and test Linux arm v6
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: arm-unknown-linux-gnueabihf
+          override: true
+
+      - name: Build image
+        run: docker build -t cross/armv6:v1 --file Dockerfile_armv6 ./
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          use-cross: true
+          args: --target arm-unknown-linux-gnueabihf
+
+      - name: Run cargo test for arm
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          use-cross: true
+          args: --target arm-unknown-linux-gnueabihf
+        env: 
+          LD_LIBRARY_PATH: /usr/lib/arm-linux-gnueabihf
+
 
   check_test_windows:
     name: Check and test Windows

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,6 +112,42 @@ jobs:
           asset_name: camilladsp-linux-aarch64.tar.gz
           tag: ${{ github.ref }}
 
+  armv6:
+    name: Pi-Zero
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: arm-unknown-linux-gnueabihf
+          override: true
+
+      - name: Build image
+        run: docker build -t cross/armv6:v1 --file Dockerfile_armv6 ./
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          use-cross: true
+          args: --release --target arm-unknown-linux-gnueabihf
+
+      - name: Compress
+        run: tar -zcvf camilladsp.tar.gz -C target/arm-unknown-linux-gnueabihf/release camilladsp
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: camilladsp.tar.gz
+          asset_name: camilladsp-linux-armv6.tar.gz
+          tag: ${{ github.ref }}
+
   windows:
     name: Windows
     runs-on: windows-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,31 +117,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          target: arm-unknown-linux-gnueabihf
-          override: true
+          targets: arm-unknown-linux-gnueabihf
+
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build image
         run: docker build -t cross/armv6:v1 --file Dockerfile_armv6 ./
 
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          use-cross: true
-          args: --release --target arm-unknown-linux-gnueabihf
+        run: cross build --release --target arm-unknown-linux-gnueabihf
 
       - name: Compress
         run: tar -zcvf camilladsp.tar.gz -C target/arm-unknown-linux-gnueabihf/release camilladsp
 
       - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: camilladsp.tar.gz

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,12 @@
+[target.arm-unknown-linux-gnueabihf]
+image = "cross/armv6:v1"
+
+[target.arm-unknown-linux-gnueabihf.env]
+passthrough = [
+    "RUSTFLAGS",
+    "LD_LIBRARY_PATH",
+]
+
 [target.armv7-unknown-linux-gnueabihf]
 image = "cross/armv7:v1"
 

--- a/Dockerfile_armv6
+++ b/Dockerfile_armv6
@@ -1,0 +1,11 @@
+FROM rustembedded/cross:arm-unknown-linux-gnueabihf
+
+ENV PKG_CONFIG_ALLOW_CROSS 1
+ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
+
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+RUN dpkg --add-architecture armhf
+RUN apt-get update && apt-get -y install libasound2-dev:armhf libasound2:armhf
+
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"


### PR DESCRIPTION
This Pull Request adds a build for ARMv6 for use on Raspberry Pi Zero , Zero 2 etc. 

I have this running on a Zero W board here and it seems to be stable. It's also passing your tests using the CI Test workflow.

I hope you will consider merging this to add ARMv6 builds as part of your standard release, thanks!