### PR TITLE
Add truncate(true) to OpenOptions when writing state file.

### DIFF
--- a/src/statefile.rs
+++ b/src/statefile.rs
@@ -63,6 +63,7 @@ pub fn save_state(
     match std::fs::OpenOptions::new()
         .write(true)
         .create(true)
+        .truncate(true)
         .open(filename)
     {
         Ok(f) => {


### PR DESCRIPTION
I've been encountering problems with intermittent stray lines on the end of the statefile that stop CamillaDSP reading the statefile the next time it starts. It turns out the problem was the state file was being written without the "truncate" flag, meaning if the new file was shorter than the old one, characters or lines from the old statefile were still present at the end of the new file.
This PR adds the truncate flag to OpenOptions when the statefile is written, avoiding the problem.