### PR TITLE
ALSA: Replace snd_pcm_delay with snd_pcm_avail

### DIFF
--- a/src/alsadevice.rs
+++ b/src/alsadevice.rs
@@ -459,7 +459,7 @@ fn playback_loop_bytes(
                 } else {
                     None
                 };
-                trace!("PB: Avail at chunk rcvd: {:?}", avail_at_chunk_recvd);
+                //trace!("PB: Avail at chunk rcvd: {:?}", avail_at_chunk_recvd);
 
                 conversion_result =
                     chunk_to_buffer_rawbytes(&chunk, &mut buffer, &params.sample_format);


### PR DESCRIPTION
This PR aims at fixing issue #382 

Rpi 4b seems to glitch slightly when repeatedly calling snd_pcm_delay() so we replace it with snd_pcm_avail()