### PR TITLE
Lookahead Limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ and the Mozilla Public License Version 2.0:
    - **[IIR](#iir)**
    - **[Dither](#dither)**
    - **[Limiter](#limiter)**
+   - **[Lookahead limiter](#lookahead-limiter)**
    - **[Difference equation](#difference-equation)**
 - **[Processors](#processors)**
    - **[Compressor](#compressor)**
@@ -2376,6 +2377,29 @@ Example:
 Parameters:
   * `soft_clip`: enable soft clipping. Set to `false` to use hard clipping. Optional, defaults to `false`.
   * `clip_limit`: the level in dB to clip at.
+
+### Lookahead Limiter
+The "LookaheadLimiter" filter is a lookahead limiter with smooth attack ramping and exponential release.
+It delays the signal by the attack time, detects peaks in advance and smoothly ramps gain reduction
+to reach the required level exactly when the peak arrives. After the peak passes, the gain
+is restored using an exponential release curve.
+
+Example:
+```
+  example_lookahead_limiter:
+    type: LookaheadLimiter
+    parameters:
+      limit: 0.0 (*)
+      attack: 2.0
+      release: 100.0
+```
+
+Parameters:
+  * `limit`: Maximum output level in dB. Optional, defaults to 0.0 dB.
+  * `attack`: Attack/lookahead time in milliseconds. This determines how far ahead the limiter looks for peaks.
+    Must be greater than 0 and less than or equal to 1000 ms.
+  * `release`: Release time in milliseconds. This controls how quickly the gain reduction is released after a peak.
+    Must be greater than or equal to 0 ms.
 
 ### Difference equation
 The "DiffEq" filter implements a generic difference equation filter with transfer function:

--- a/README.md
+++ b/README.md
@@ -2379,10 +2379,7 @@ Parameters:
   * `clip_limit`: the level in dB to clip at.
 
 ### Lookahead Limiter
-The "LookaheadLimiter" filter is a lookahead limiter with smooth attack ramping and exponential release.
-It delays the signal by the attack time, detects peaks in advance and smoothly ramps gain reduction
-to reach the required level exactly when the peak arrives. After the peak passes, the gain
-is restored using an exponential release curve.
+The "LookaheadLimiter" delays the input signal by the attack time, detects peaks in advance and ramps up gain reduction to reach the required level when the peak arrives. After the peak passes, the gain is restored using an exponential release curve.
 
 Example:
 ```
@@ -2390,6 +2387,7 @@ Example:
     type: LookaheadLimiter
     parameters:
       limit: 0.0 (*)
+      unit: ms (*)
       attack: 2.0
       release: 100.0
 ```

--- a/README.md
+++ b/README.md
@@ -2394,8 +2394,9 @@ Example:
 
 Parameters:
   * `limit`: Maximum output level in dB. Optional, defaults to 0.0 dB.
+  * `unit`: Unit for the attack and release times. Required.
   * `attack`: Attack/lookahead time in milliseconds. This determines how far ahead the limiter looks for peaks.
-    Must be greater than 0 and less than or equal to 1000 ms.
+    Must be greater than or eaqual to 0 and less than or equal to 1000 ms.
   * `release`: Release time in milliseconds. This controls how quickly the gain reduction is released after a peak.
     Must be greater than or equal to 0 ms.
 

--- a/README.md
+++ b/README.md
@@ -2396,21 +2396,23 @@ Example:
   example_lookahead_limiter:
     type: LookaheadLimiter
     parameters:
-      limit: 0.0 (*)
+      limit: 0.0
       unit: ms (*)
       attack: 2.0 (*)
-      release: 100.0
+      release: 100.0 (*)
 ```
 
 Parameters:
   * `limit`: Maximum output level in dB. Optional, defaults to 0.0 dB.
-  * `unit`: Unit for the attack and release times. Required.
+  * `unit`: Unit for the attack and release times.
+    Can be `ms`, `us`, `mm` or `samples`.
   * `attack`: Attack/lookahead/delay time. This determines how far ahead the limiter looks for peaks.
     Must be greater than or eaqual to 0 and less than or equal to 1 second.
     Input signal is delayed by this amount rounded to whole samples, as in the Delay filter without subsample.
     Gain is reduced using a linear ramp of this length.
-  * `release`: Release time in milliseconds. This controls how quickly the gain reduction is released after a peak.
-    Must be greater than or equal to 0 ms.
+  * `release`: Release time. This controls how quickly the gain reduction is released after a peak.
+    Must be greater than or equal to 0.
+    Gain is restored using an exponential curve, as in the Compressor processor.
 
 ### Difference equation
 The "DiffEq" filter implements a generic difference equation filter with transfer function:

--- a/README.md
+++ b/README.md
@@ -2396,10 +2396,10 @@ Example:
   example_lookahead_limiter:
     type: LookaheadLimiter
     parameters:
-      limit: 0.0
-      unit: ms (*)
-      attack: 2.0 (*)
-      release: 100.0 (*)
+      limit: 0.0 (*)
+      unit: ms
+      attack: 2.0
+      release: 100.0
 ```
 
 Parameters:
@@ -2407,7 +2407,7 @@ Parameters:
   * `unit`: Unit for the attack and release times.
     Can be `ms`, `us`, `mm` or `samples`.
   * `attack`: Attack/lookahead/delay time. This determines how far ahead the limiter looks for peaks.
-    Must be greater than or eaqual to 0 and less than or equal to 1 second.
+    Must be greater than or equal to 0 and less than or equal to 1 second.
     Input signal is delayed by this amount rounded to whole samples, as in the Delay filter without subsample.
     Gain is reduced using a linear ramp of this length.
   * `release`: Release time. This controls how quickly the gain reduction is released after a peak.

--- a/README.md
+++ b/README.md
@@ -2398,15 +2398,17 @@ Example:
     parameters:
       limit: 0.0 (*)
       unit: ms (*)
-      attack: 2.0
+      attack: 2.0 (*)
       release: 100.0
 ```
 
 Parameters:
   * `limit`: Maximum output level in dB. Optional, defaults to 0.0 dB.
   * `unit`: Unit for the attack and release times. Required.
-  * `attack`: Attack/lookahead time in milliseconds. This determines how far ahead the limiter looks for peaks.
-    Must be greater than or eaqual to 0 and less than or equal to 1000 ms.
+  * `attack`: Attack/lookahead/delay time. This determines how far ahead the limiter looks for peaks.
+    Must be greater than or eaqual to 0 and less than or equal to 1 second.
+    Input signal is delayed by this amount rounded to whole samples, as in the Delay filter without subsample.
+    Gain is reduced using a linear ramp of this length.
   * `release`: Release time in milliseconds. This controls how quickly the gain reduction is released after a peak.
     Must be greater than or equal to 0 ms.
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ and the Mozilla Public License Version 2.0:
    - **[IIR](#iir)**
    - **[Dither](#dither)**
    - **[Limiter](#limiter)**
+   - **[Lookahead limiter](#lookahead-limiter)**
    - **[Difference equation](#difference-equation)**
 - **[Processors](#processors)**
    - **[Compressor](#compressor)**
@@ -2386,6 +2387,29 @@ Example:
 Parameters:
   * `soft_clip`: enable soft clipping. Set to `false` to use hard clipping. Optional, defaults to `false`.
   * `clip_limit`: the level in dB to clip at.
+
+### Lookahead Limiter
+The "LookaheadLimiter" filter is a lookahead limiter with smooth attack ramping and exponential release.
+It delays the signal by the attack time, detects peaks in advance and smoothly ramps gain reduction
+to reach the required level exactly when the peak arrives. After the peak passes, the gain
+is restored using an exponential release curve.
+
+Example:
+```
+  example_lookahead_limiter:
+    type: LookaheadLimiter
+    parameters:
+      limit: 0.0 (*)
+      attack: 2.0
+      release: 100.0
+```
+
+Parameters:
+  * `limit`: Maximum output level in dB. Optional, defaults to 0.0 dB.
+  * `attack`: Attack/lookahead time in milliseconds. This determines how far ahead the limiter looks for peaks.
+    Must be greater than 0 and less than or equal to 1000 ms.
+  * `release`: Release time in milliseconds. This controls how quickly the gain reduction is released after a peak.
+    Must be greater than or equal to 0 ms.
 
 ### Difference equation
 The "DiffEq" filter implements a generic difference equation filter with transfer function:

--- a/README.md
+++ b/README.md
@@ -2404,8 +2404,9 @@ Example:
 
 Parameters:
   * `limit`: Maximum output level in dB. Optional, defaults to 0.0 dB.
+  * `unit`: Unit for the attack and release times. Required.
   * `attack`: Attack/lookahead time in milliseconds. This determines how far ahead the limiter looks for peaks.
-    Must be greater than 0 and less than or equal to 1000 ms.
+    Must be greater than or eaqual to 0 and less than or equal to 1000 ms.
   * `release`: Release time in milliseconds. This controls how quickly the gain reduction is released after a peak.
     Must be greater than or equal to 0 ms.
 

--- a/README.md
+++ b/README.md
@@ -2389,10 +2389,7 @@ Parameters:
   * `clip_limit`: the level in dB to clip at.
 
 ### Lookahead Limiter
-The "LookaheadLimiter" filter is a lookahead limiter with smooth attack ramping and exponential release.
-It delays the signal by the attack time, detects peaks in advance and smoothly ramps gain reduction
-to reach the required level exactly when the peak arrives. After the peak passes, the gain
-is restored using an exponential release curve.
+The "LookaheadLimiter" delays the input signal by the attack time, detects peaks in advance and ramps up gain reduction to reach the required level when the peak arrives. After the peak passes, the gain is restored using an exponential release curve.
 
 Example:
 ```
@@ -2400,6 +2397,7 @@ Example:
     type: LookaheadLimiter
     parameters:
       limit: 0.0 (*)
+      unit: ms (*)
       attack: 2.0
       release: 100.0
 ```

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1618,13 +1618,12 @@ pub struct LookaheadLimiterParameters {
     pub limit: PrcFmt,
     pub attack: PrcFmt,
     pub release: PrcFmt,
-    #[serde(default)]
-    pub unit: Option<TimeUnit>,
+    pub unit: TimeUnit,
 }
 
 impl LookaheadLimiterParameters {
     pub fn unit(&self) -> TimeUnit {
-        self.unit.unwrap_or(TimeUnit::Milliseconds)
+        self.unit
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1010,6 +1010,11 @@ pub enum Filter {
         description: Option<String>,
         parameters: LimiterParameters,
     },
+    LookaheadLimiter {
+        #[serde(default)]
+        description: Option<String>,
+        parameters: LookaheadLimiterParameters,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -1603,6 +1608,23 @@ pub struct LimiterParameters {
 impl LimiterParameters {
     pub fn soft_clip(&self) -> bool {
         self.soft_clip.unwrap_or_default()
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LookaheadLimiterParameters {
+    #[serde(default)]
+    pub limit: PrcFmt,
+    pub attack: PrcFmt,
+    pub release: PrcFmt,
+    #[serde(default)]
+    pub unit: Option<TimeUnit>,
+}
+
+impl LookaheadLimiterParameters {
+    pub fn unit(&self) -> TimeUnit {
+        self.unit.unwrap_or(TimeUnit::Milliseconds)
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1669,13 +1669,12 @@ pub struct LookaheadLimiterParameters {
     pub limit: PrcFmt,
     pub attack: PrcFmt,
     pub release: PrcFmt,
-    #[serde(default)]
-    pub unit: Option<TimeUnit>,
+    pub unit: TimeUnit,
 }
 
 impl LookaheadLimiterParameters {
     pub fn unit(&self) -> TimeUnit {
-        self.unit.unwrap_or(TimeUnit::Milliseconds)
+        self.unit
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1032,6 +1032,11 @@ pub enum Filter {
         description: Option<String>,
         parameters: LimiterParameters,
     },
+    LookaheadLimiter {
+        #[serde(default)]
+        description: Option<String>,
+        parameters: LookaheadLimiterParameters,
+    },
 }
 
 /// Source of convolution coefficients for the FFT convolution filter.
@@ -1654,6 +1659,23 @@ pub struct LimiterParameters {
 impl LimiterParameters {
     pub fn soft_clip(&self) -> bool {
         self.soft_clip.unwrap_or_default()
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LookaheadLimiterParameters {
+    #[serde(default)]
+    pub limit: PrcFmt,
+    pub attack: PrcFmt,
+    pub release: PrcFmt,
+    #[serde(default)]
+    pub unit: Option<TimeUnit>,
+}
+
+impl LookaheadLimiterParameters {
+    pub fn unit(&self) -> TimeUnit {
+        self.unit.unwrap_or(TimeUnit::Milliseconds)
     }
 }
 

--- a/src/filters/basicfilters.rs
+++ b/src/filters/basicfilters.rs
@@ -30,6 +30,7 @@ use crate::PrcFmt;
 use crate::ProcessingParameters;
 use crate::Res;
 use crate::utils::decibels::gain_from_value;
+use crate::utils::time::time_to_samples;
 
 #[derive(Clone, Debug)]
 pub struct Gain {
@@ -402,12 +403,7 @@ impl Delay {
     }
 
     pub fn from_config(name: &str, samplerate: usize, conf: config::DelayParameters) -> Self {
-        let delay_samples = match conf.unit() {
-            config::TimeUnit::Microseconds => conf.delay / 1000000.0 * (samplerate as PrcFmt),
-            config::TimeUnit::Milliseconds => conf.delay / 1000.0 * (samplerate as PrcFmt),
-            config::TimeUnit::Millimetres => conf.delay / 1000.0 * (samplerate as PrcFmt) / 343.0,
-            config::TimeUnit::Samples => conf.delay,
-        };
+        let delay_samples = time_to_samples(conf.delay, conf.unit(), samplerate);
 
         Self::new(name, samplerate, delay_samples, conf.subsample())
     }

--- a/src/filters/basicfilters.rs
+++ b/src/filters/basicfilters.rs
@@ -33,6 +33,7 @@ use crate::ProcessingParameters;
 use crate::Res;
 use crate::nanos_since_epoch;
 use crate::utils::decibels::gain_from_value;
+use crate::utils::time::time_to_samples;
 
 #[derive(Clone, Debug)]
 pub struct Gain {
@@ -411,12 +412,7 @@ impl Delay {
     }
 
     pub fn from_config(name: &str, samplerate: usize, conf: config::DelayParameters) -> Self {
-        let delay_samples = match conf.unit() {
-            config::TimeUnit::Microseconds => conf.delay / 1000000.0 * (samplerate as PrcFmt),
-            config::TimeUnit::Milliseconds => conf.delay / 1000.0 * (samplerate as PrcFmt),
-            config::TimeUnit::Millimetres => conf.delay / 1000.0 * (samplerate as PrcFmt) / 343.0,
-            config::TimeUnit::Samples => conf.delay,
-        };
+        let delay_samples = time_to_samples(conf.delay, conf.unit(), samplerate);
 
         Self::new(name, samplerate, delay_samples, conf.subsample())
     }

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -19,7 +19,7 @@ use crate::Res;
 use crate::config;
 use crate::filters::Filter;
 use crate::utils::decibels::db_to_linear;
-use crate::utils::time::time_to_samples;
+use crate::utils::time::{time_to_samples, time_to_seconds};
 use std::collections::VecDeque;
 
 #[derive(Debug, Clone)]
@@ -27,12 +27,13 @@ pub struct LookaheadLimiter {
     pub name: String,
     pub limit: PrcFmt,
     pub attack: usize,
-    pub release: usize,
     pub samplerate: usize,
     alpha: PrcFmt,
     epsilon: PrcFmt,
     lookahead_buffer: VecDeque<PrcFmt>,
     release_gain: PrcFmt,
+    gain_buffer: Vec<PrcFmt>,
+    output_buffer: Vec<PrcFmt>,
 }
 
 impl LookaheadLimiter {
@@ -40,36 +41,44 @@ impl LookaheadLimiter {
         name: &str,
         config: config::LookaheadLimiterParameters,
         samplerate: usize,
+        chunksize: usize,
     ) -> Self {
         let limit = db_to_linear(config.limit);
         let unit = config.unit();
         let attack = time_to_samples(config.attack, unit, samplerate) as usize;
-        let release = time_to_samples(config.release, unit, samplerate) as usize;
-        let epsilon = 10f64.powf(-80.0 / 20.0); // -80 dB
-        let alpha = epsilon.powf(1.0 / release as PrcFmt);
+        // When release gain reduction is less than -80dB, just pass the signal through
+        let epsilon = 10f64.powf(-80.0 / 20.0);
+        let alpha = epsilon
+            .powf(1.0 / (samplerate as PrcFmt * time_to_seconds(config.release, unit, samplerate)));
 
         if attack > samplerate {
             panic!(
-                "Lookahead limiter attack time exceeds 1 second ({} samples > {} samplerate)",
+                "Lookahead limiter attack time must not exceed 1 second ({} samples > {} samplerate)",
                 attack, samplerate
             );
         }
 
         debug!(
             "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
-            name, config.limit, limit, attack, release, alpha
+            name,
+            config.limit,
+            limit,
+            attack,
+            time_to_samples(config.release, unit, samplerate),
+            alpha
         );
 
         LookaheadLimiter {
             name: name.to_string(),
             limit,
             attack,
-            release,
             samplerate,
             alpha,
             epsilon,
             lookahead_buffer: vec![0.0; samplerate].into(),
             release_gain: 1.0,
+            gain_buffer: vec![1.0 as PrcFmt; attack + chunksize],
+            output_buffer: vec![0.0 as PrcFmt; chunksize],
         }
     }
 
@@ -87,13 +96,13 @@ impl LookaheadLimiter {
             }
         };
 
-        let mut gain_buffer = vec![1.0 as PrcFmt; self.attack + n];
-
         // Compute gain reduction curve like a simple peak limiter
         for i in 0..(self.attack + n) {
             let sample_abs = get_sample(i, &self.lookahead_buffer, input).abs();
             if sample_abs > self.limit {
-                gain_buffer[i] = self.limit / sample_abs;
+                self.gain_buffer[i] = self.limit / sample_abs;
+            } else {
+                self.gain_buffer[i] = 1.0;
             }
         }
 
@@ -108,12 +117,12 @@ impl LookaheadLimiter {
                 gain = 1.0 - (ramp * attack_peak);
                 samples_since_attack_peak += 1;
             }
-            if gain_buffer[i] < gain {
-                gain = gain_buffer[i];
-                attack_peak = gain_buffer[i];
+            if self.gain_buffer[i] < gain {
+                gain = self.gain_buffer[i];
+                attack_peak = self.gain_buffer[i];
                 samples_since_attack_peak = 0;
             }
-            gain_buffer[i] = gain;
+            self.gain_buffer[i] = gain;
         }
 
         // Forward pass turning peaks into exponential decay.
@@ -122,23 +131,23 @@ impl LookaheadLimiter {
             if self.release_gain > 1.0 - self.epsilon {
                 self.release_gain = 1.0
             }
-            if gain_buffer[i] < self.release_gain {
-                self.release_gain = gain_buffer[i];
+            if self.gain_buffer[i] < self.release_gain {
+                self.release_gain = self.gain_buffer[i];
             } else {
-                gain_buffer[i] = self.release_gain;
+                self.gain_buffer[i] = self.release_gain;
             }
         }
 
-        let mut buf: Vec<PrcFmt> = vec![0.0; n];
+        let delayed_samples = &mut self.output_buffer[..n];
         for i in 0..n {
-            buf[i] = get_sample(i, &self.lookahead_buffer, input);
+            delayed_samples[i] = get_sample(i, &self.lookahead_buffer, input);
         }
         self.lookahead_buffer.drain(0..n);
         for sample in &mut *input {
             self.lookahead_buffer.push_back(*sample);
         }
         for i in 0..n {
-            input[i] = buf[i] * gain_buffer[i];
+            input[i] = delayed_samples[i] * self.gain_buffer[i];
         }
     }
 }
@@ -168,12 +177,13 @@ impl Filter for LookaheadLimiter {
             }
             self.limit = db_to_linear(config.limit);
             self.attack = new_attack;
-            self.release = time_to_samples(config.release, config.unit(), self.samplerate) as usize;
-            self.alpha = self.epsilon.powf(1.0 / self.release as PrcFmt);
+            let release = time_to_samples(config.release, config.unit(), self.samplerate) as usize;
+            let epsilon = 10f64.powf(-80.0 / 20.0);
+            self.alpha = epsilon.powf(1.0 / release as PrcFmt);
 
             debug!(
                 "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
-                self.name, config.limit, self.limit, self.attack, self.release, self.alpha
+                self.name, config.limit, self.limit, self.attack, release, self.alpha
             );
         } else {
             panic!("Invalid config change!");
@@ -237,11 +247,11 @@ mod tests {
     fn test_no_limiting_below_threshold() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
-            unit: Some(TimeUnit::Samples),
+            unit: TimeUnit::Samples,
             attack: 4.0,
             release: 4.0,
         };
-        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut input = vec![0.5, 0.5, 0.5];
         let expected = vec![0.5, 0.5, 0.5];
         limiter.apply_lookahead_limiter(&mut input);
@@ -252,11 +262,11 @@ mod tests {
     fn test_limiter_basic() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
-            unit: Some(TimeUnit::Samples),
+            unit: TimeUnit::Samples,
             attack: 4.0,
             release: 4.0,
         };
-        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut input = vec![
             1.0, 1.0, 1.0, 1.0, 1.0, 2.0, -2.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
             1.0, 1.0,
@@ -274,11 +284,11 @@ mod tests {
     fn test_limiter_peak() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
-            unit: Some(TimeUnit::Samples),
+            unit: TimeUnit::Samples,
             attack: 0.0,
             release: 0.0,
         };
-        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut input = vec![
             1.0, 1.0, 1.0, 1.0, 2.0, -2.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
         ];
@@ -293,11 +303,11 @@ mod tests {
     fn test_limiter_zero_release() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
-            unit: Some(TimeUnit::Samples),
+            unit: TimeUnit::Samples,
             attack: 4.0,
             release: 0.0,
         };
-        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut input = vec![2.0, 2.0, 2.0, 2.0, 2.0];
         limiter.apply_lookahead_limiter(&mut input);
         for &val in &input {
@@ -309,11 +319,11 @@ mod tests {
     fn test_limiter_state_persistence() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
-            unit: Some(TimeUnit::Samples),
+            unit: TimeUnit::Samples,
             attack: 4.0,
             release: 4.0,
         };
-        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut buf1 = vec![1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0];
         let expected1 = vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0];
         limiter.apply_lookahead_limiter(&mut buf1);

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -1,138 +1,144 @@
+// CamillaDSP - A flexible tool for processing audio
+// Copyright (C) 2026 Henrik Enquist
+//
+// This file is part of CamillaDSP.
+//
+// CamillaDSP is free software; you can redistribute it and/or modify it
+// under the terms of either:
+//
+// a) the GNU General Public License version 3,
+//    or
+// b) the Mozilla Public License Version 2.0.
+//
+// You should have received copies of the GNU General Public License and the
+// Mozilla Public License along with this program. If not, see
+// <https://www.gnu.org/licenses/> and <https://www.mozilla.org/en-US/MPL/2.0/>.
+
 use crate::PrcFmt;
 use crate::Res;
 use crate::config;
 use crate::filters::Filter;
-use crate::utils::time::time_to_samples_ceil;
+use crate::utils::decibels::db_to_linear;
+use crate::utils::time::time_to_samples;
+use std::collections::VecDeque;
 
-/// A lookahead limiter that applies gain reduction with lookahead attack and exponential release.
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone)]
 pub struct LookaheadLimiter {
     pub name: String,
-    /// Linear gain limit (amplitude)
     pub limit: PrcFmt,
-    /// Attack time in config units (for display)
-    pub attack: PrcFmt,
-    /// Release time in config units (for display)
-    pub release: PrcFmt,
+    pub attack: usize,
+    pub release: usize,
     pub samplerate: usize,
-    /// Lookahead length in samples (N)
-    lookahead_samples: usize,
-    /// Release coefficient alpha_r = exp(-1/(T_r * fs))
-    alpha_r: PrcFmt,
-    /// Peak gain state carried across buffers (step 2)
-    peak_gain: PrcFmt,
-    /// Steps counter for linear attack (step 2)
-    steps: usize,
-    /// Previous gain state for exponential release (step 3)
-    g_prev: PrcFmt,
+    alpha: PrcFmt,
+    epsilon: PrcFmt,
+    lookahead_buffer: VecDeque<PrcFmt>,
+    release_gain: PrcFmt,
 }
 
 impl LookaheadLimiter {
-    /// Creates a LookaheadLimiter from a config struct
     pub fn from_config(
         name: &str,
         config: config::LookaheadLimiterParameters,
         samplerate: usize,
     ) -> Self {
-        let limit = (10.0 as PrcFmt).powf(config.limit / 20.0);
+        let limit = db_to_linear(config.limit);
         let unit = config.unit();
-        let lookahead_samples = time_to_samples_ceil(config.attack, unit, samplerate);
-        let release_samples = time_to_samples_ceil(config.release, unit, samplerate);
+        let attack = time_to_samples(config.attack, unit, samplerate) as usize;
+        let release = time_to_samples(config.release, unit, samplerate) as usize;
+        let epsilon = 10f64.powf(-80.0 / 20.0); // -80 dB
+        let alpha = epsilon.powf(1.0 / release as PrcFmt);
 
-        // Compute release coefficient alpha_r = exp(-1 / (T_r * fs))
-        // where T_r = release time in seconds.
-        let release_time_seconds =
-            time_to_samples(config.release, unit, samplerate) / samplerate as PrcFmt;
-        let alpha_r = if release_time_seconds > 0.0 {
-            (-1.0 / (release_time_seconds * samplerate as PrcFmt)).exp()
-        } else {
-            // If release time is zero, instant release (alpha_r = 0)
-            0.0
-        };
+        if attack > samplerate {
+            panic!(
+                "Lookahead limiter attack time exceeds 1 second ({} samples > {} samplerate)",
+                attack, samplerate
+            );
+        }
 
         debug!(
-            "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} ms ({} samples), release: {} ms ({} samples), alpha_r: {}",
-            name,
-            config.limit,
-            limit,
-            config.attack,
-            lookahead_samples,
-            config.release,
-            release_samples,
-            alpha_r
+            "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
+            name, config.limit, limit, attack, release, alpha
         );
 
         LookaheadLimiter {
             name: name.to_string(),
             limit,
-            attack: config.attack,
-            release: config.release,
+            attack,
+            release,
             samplerate,
-            lookahead_samples,
-            alpha_r,
-            peak_gain: 1.0,
-            steps: lookahead_samples + 1,
-            g_prev: 1.0,
+            alpha,
+            epsilon,
+            lookahead_buffer: vec![0.0; samplerate].into(),
+            release_gain: 1.0,
         }
     }
 
-    /// Process the waveform with lookahead limiting.
-    fn apply_lookahead_limit(&mut self, input: &mut [PrcFmt]) {
+    fn apply_lookahead_limiter(&mut self, input: &mut [PrcFmt]) {
         let n = input.len();
         if n == 0 {
             return;
         }
 
-        let limit = self.limit;
-        let N = self.lookahead_samples;
-        let alpha_r = self.alpha_r;
-
-        // step 1: target gain
-        let mut g0 = vec![1.0 as PrcFmt; n];
-        for i in 0..n {
-            let abs_x = input[i].abs();
-            if abs_x > limit {
-                g0[i] = limit / abs_x;
-            }
-        }
-
-        // step 2: backward linear attack (carry peak state across buffers)
-        let mut g1 = g0.clone();
-        let mut peak_gain = self.peak_gain;
-        let mut steps = self.steps;
-
-        for i in (0..n).rev() {
-            if g0[i] < 1.0 {
-                peak_gain = g0[i];
-                steps = 0;
+        let get_sample = |i: usize, buf: &VecDeque<PrcFmt>, inp: &[PrcFmt]| -> PrcFmt {
+            if i < self.attack {
+                buf[self.samplerate - self.attack + i]
             } else {
-                steps += 1;
+                inp[i - self.attack]
             }
-            if steps <= N {
-                g1[i] = g1[i].min(1.0 - (1.0 - peak_gain) * steps as PrcFmt / N as PrcFmt);
+        };
+
+        let mut gain_buffer = vec![1.0 as PrcFmt; self.attack + n];
+
+        // Compute gain reduction curve like a simple peak limiter
+        for i in 0..(self.attack + n) {
+            let sample_abs = get_sample(i, &self.lookahead_buffer, input).abs();
+            if sample_abs > self.limit {
+                gain_buffer[i] = self.limit / sample_abs;
             }
         }
 
-        // store state for next buffer
-        self.peak_gain = peak_gain;
-        self.steps = steps;
-
-        // step 3: forward exponential release (carry g_prev across buffers)
-        let mut g2 = g1.clone();
-        let mut prev = self.g_prev;
-
-        for i in 0..n {
-            if g1[i] > prev {
-                g2[i] = g1[i].min(1.0 - (1.0 - prev) * alpha_r);
+        // Backward pass turning peaks into linear ramps.
+        let mut attack_peak = 1.0;
+        let mut samples_since_attack_peak = self.attack;
+        for i in (0..(self.attack + n)).rev() {
+            let mut gain = 1.0;
+            if samples_since_attack_peak <= self.attack {
+                let ramp = (self.attack - samples_since_attack_peak) as PrcFmt
+                    / (self.attack + 1) as PrcFmt;
+                gain = 1.0 - (ramp * attack_peak);
+                samples_since_attack_peak += 1;
             }
-            prev = g2[i];
+            if gain_buffer[i] < gain {
+                gain = gain_buffer[i];
+                attack_peak = gain_buffer[i];
+                samples_since_attack_peak = 0;
+            }
+            gain_buffer[i] = gain;
         }
 
-        self.g_prev = prev;
-
-        // apply gain
+        // Forward pass turning peaks into exponential decay.
         for i in 0..n {
-            input[i] *= g2[i];
+            self.release_gain = 1.0 - (1.0 - self.release_gain) * self.alpha;
+            if self.release_gain > 1.0 - self.epsilon {
+                self.release_gain = 1.0
+            }
+            if gain_buffer[i] < self.release_gain {
+                self.release_gain = gain_buffer[i];
+            } else {
+                gain_buffer[i] = self.release_gain;
+            }
+        }
+
+        let mut buf: Vec<PrcFmt> = vec![0.0; n];
+        for i in 0..n {
+            buf[i] = get_sample(i, &self.lookahead_buffer, input);
+        }
+        self.lookahead_buffer.drain(0..n);
+        for sample in &mut *input {
+            self.lookahead_buffer.push_back(*sample);
+        }
+        for i in 0..n {
+            input[i] = buf[i] * gain_buffer[i];
         }
     }
 }
@@ -142,9 +148,8 @@ impl Filter for LookaheadLimiter {
         &self.name
     }
 
-    /// Apply the lookahead limiter to a waveform, modifying it in-place.
     fn process_waveform(&mut self, waveform: &mut [PrcFmt]) -> Res<()> {
-        self.apply_lookahead_limit(waveform);
+        self.apply_lookahead_limiter(waveform);
         Ok(())
     }
 
@@ -153,46 +158,29 @@ impl Filter for LookaheadLimiter {
             parameters: config, ..
         } = config
         {
-            let limit = (10.0 as PrcFmt).powf(config.limit / 20.0);
-            let unit = config.unit();
-            let lookahead_samples = time_to_samples_ceil(config.attack, unit, self.samplerate);
-            let release_samples = time_to_samples_ceil(config.release, unit, self.samplerate);
-
-            // recompute alpha_r
-            let release_time_seconds =
-                time_to_samples(config.release, unit, self.samplerate) / self.samplerate as PrcFmt;
-            let alpha_r = if release_time_seconds > 0.0 {
-                (-1.0 / (release_time_seconds * self.samplerate as PrcFmt)).exp()
-            } else {
-                0.0
-            };
-
-            self.limit = limit;
-            self.attack = config.attack;
-            self.release = config.release;
-            self.lookahead_samples = lookahead_samples;
-            self.alpha_r = alpha_r;
-            // Note: we keep peak_gain, steps, g_prev unchanged across parameter updates.
+            let new_attack =
+                time_to_samples(config.attack, config.unit(), self.samplerate) as usize;
+            if new_attack > self.samplerate {
+                panic!(
+                    "Lookahead limiter attack time exceeds 1 second ({} samples > {} samplerate)",
+                    new_attack, self.samplerate
+                );
+            }
+            self.limit = db_to_linear(config.limit);
+            self.attack = new_attack;
+            self.release = time_to_samples(config.release, config.unit(), self.samplerate) as usize;
+            self.alpha = self.epsilon.powf(1.0 / self.release as PrcFmt);
 
             debug!(
-                "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} units ({} samples), release: {} units ({} samples), alpha_r: {}",
-                self.name,
-                config.limit,
-                limit,
-                config.attack,
-                lookahead_samples,
-                config.release,
-                release_samples,
-                alpha_r
+                "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
+                self.name, config.limit, self.limit, self.attack, self.release, self.alpha
             );
         } else {
-            // This should never happen unless there is a bug somewhere else
             panic!("Invalid config change!");
         }
     }
 }
 
-/// Validate the lookahead limiter config
 pub fn validate_config(config: &config::LookaheadLimiterParameters) -> Res<()> {
     if config.attack <= 0.0 {
         let msg = "Attack time must be positive.";
@@ -202,56 +190,138 @@ pub fn validate_config(config: &config::LookaheadLimiterParameters) -> Res<()> {
         let msg = "Release time must be non-negative.";
         return Err(config::ConfigError::new(msg).into());
     }
+    let unit = config.unit();
+    match unit {
+        config::TimeUnit::Microseconds => {
+            if config.attack > 1_000_000.0 {
+                let msg = "Attack time must not exceed 1 second.";
+                return Err(config::ConfigError::new(msg).into());
+            }
+        }
+        config::TimeUnit::Milliseconds => {
+            if config.attack > 1000.0 {
+                let msg = "Attack time must not exceed 1 second.";
+                return Err(config::ConfigError::new(msg).into());
+            }
+        }
+        config::TimeUnit::Millimetres => {
+            let seconds = config.attack / 1000.0 / 343.0;
+            if seconds > 1.0 {
+                let msg = "Attack time must not exceed 1 second.";
+                return Err(config::ConfigError::new(msg).into());
+            }
+        }
+        config::TimeUnit::Samples => {}
+    }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::TimeUnit;
 
-    // Helper function to create a test limiter
-    fn create_test_limiter(
-        limit_db: PrcFmt,
-        attack_ms: PrcFmt,
-        release_ms: PrcFmt,
-        samplerate: usize,
-    ) -> LookaheadLimiter {
-        let config = config::LookaheadLimiterParameters {
-            limit: limit_db,
-            attack: attack_ms,
-            release: release_ms,
-            unit: None,
-        };
-        LookaheadLimiter::from_config("test", config, samplerate)
+    fn assert_close(left: &[PrcFmt], right: &[PrcFmt], epsilon: PrcFmt) {
+        assert_eq!(left.len(), right.len());
+        for (i, (&l, &r)) in left.iter().zip(right.iter()).enumerate() {
+            if (l - r).abs() > epsilon {
+                panic!(
+                    "Mismatch at index {i}: left={l}, right={r}, diff={}\nleft:   {left:?}\nright: {right:?}",
+                    l - r
+                );
+            }
+        }
     }
 
     #[test]
     fn test_no_limiting_below_threshold() {
-        let mut limiter = create_test_limiter(0.0, 10.0, 100.0, 48000);
+        let config = config::LookaheadLimiterParameters {
+            limit: 0.0,
+            unit: Some(TimeUnit::Samples),
+            attack: 4.0,
+            release: 4.0,
+        };
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
         let mut input = vec![0.5, 0.5, 0.5];
         let expected = vec![0.5, 0.5, 0.5];
-
-        limiter.apply_lookahead_limit(&mut input);
-        assert_eq!(input, expected);
+        limiter.apply_lookahead_limiter(&mut input);
+        assert_close(&input, &expected, 1e-9);
     }
 
     #[test]
-    fn test_hard_clip_above_threshold() {
-        // Input above limit should be limited to limit (1.0)
-        let mut limiter = create_test_limiter(0.0, 10.0, 100.0, 48000);
-        let mut input = vec![2.0, 2.0, 2.0];
-        // Expect gain reduction to 1.0
-        limiter.apply_lookahead_limit(&mut input);
-        assert!(input[0].abs() <= 1.0);
+    fn test_limiter_basic() {
+        let config = config::LookaheadLimiterParameters {
+            limit: 0.0,
+            unit: Some(TimeUnit::Samples),
+            attack: 4.0,
+            release: 4.0,
+        };
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut input = vec![
+            1.0, 1.0, 1.0, 1.0, 1.0, 2.0, -2.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+            1.0, 1.0,
+        ];
+        let expected = vec![
+            0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0, -1.0, 0.7, 0.6, 1.0, 0.95, 0.995,
+            0.9995, 1.0, 1.0,
+        ];
+        limiter.apply_lookahead_limiter(&mut input);
+        assert_close(&input, &expected, 1e-6);
+    }
+
+    /// Zero attack and release should behave like a peak limiter
+    #[test]
+    fn test_limiter_peak() {
+        let config = config::LookaheadLimiterParameters {
+            limit: 0.0,
+            unit: Some(TimeUnit::Samples),
+            attack: 0.0,
+            release: 0.0,
+        };
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut input = vec![
+            1.0, 1.0, 1.0, 1.0, 2.0, -2.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        ];
+        let expected = vec![
+            1.0, 1.0, 1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+        ];
+        limiter.apply_lookahead_limiter(&mut input);
+        assert_close(&input, &expected, 1e-6);
     }
 
     #[test]
-    fn test_limit_conversion_db_to_linear() {
-        // dB to linear conversion still works
-        let limiter = create_test_limiter(-6.0, 10.0, 100.0, 48000);
-        assert!((limiter.limit - 0.5).abs() < 0.01);
+    fn test_limiter_zero_release() {
+        let config = config::LookaheadLimiterParameters {
+            limit: 0.0,
+            unit: Some(TimeUnit::Samples),
+            attack: 4.0,
+            release: 0.0,
+        };
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut input = vec![2.0, 2.0, 2.0, 2.0, 2.0];
+        limiter.apply_lookahead_limiter(&mut input);
+        for &val in &input {
+            assert!(val.abs() <= 1.0 + 1e-6);
+        }
+    }
 
-        let limiter = create_test_limiter(6.0, 10.0, 100.0, 48000);
-        assert!((limiter.limit - 2.0).abs() < 0.01);
+    #[test]
+    fn test_limiter_state_persistence() {
+        let config = config::LookaheadLimiterParameters {
+            limit: 0.0,
+            unit: Some(TimeUnit::Samples),
+            attack: 4.0,
+            release: 4.0,
+        };
+        let mut limiter = LookaheadLimiter::from_config("test", config, 48000);
+        let mut buf1 = vec![1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0];
+        let expected1 = vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0];
+        limiter.apply_lookahead_limiter(&mut buf1);
+        assert_close(&buf1, &expected1, 1e-6);
+
+        let mut buf2 = vec![1.0, 1.0, 1.0, 1.0];
+        let expected2 = vec![0.95, 0.995, 0.9995, 1.0];
+        limiter.apply_lookahead_limiter(&mut buf2);
+        assert_close(&buf2, &expected2, 1e-6);
     }
 }

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -87,11 +87,9 @@ impl LookaheadLimiter {
         }
 
         // Backward pass turning peaks into linear ramps.
-        let mut attack_peak = 1.0;
-        let mut samples_since_attack_peak = self.attack;
+        let mut peak = 1.0;
+        let mut samples_since_peak = self.attack;
         for i in (0..(self.attack + n)).rev() {
-            let mut gain = 1.0;
-
             // Get sample amplitude
             let amplitude = (if i < self.attack {
                 self.lookahead_buffer[self.samplerate - self.attack + i]
@@ -100,25 +98,31 @@ impl LookaheadLimiter {
             })
             .abs();
 
-            // Compute gain envelope like simple limiter
-            if amplitude > self.limit {
-                self.output_buffer[i] = self.limit / amplitude;
+            // Compute reduction gain for current sample
+            let mut gain = if amplitude > self.limit {
+                self.limit / amplitude
             } else {
-                self.output_buffer[i] = 1.0;
-            }
+                1.0
+            };
 
             // Compute ramp
-            if samples_since_attack_peak <= self.attack {
-                let ramp = (self.attack - samples_since_attack_peak) as PrcFmt
-                    / (self.attack + 1) as PrcFmt;
-                gain = 1.0 - (ramp * attack_peak);
-                samples_since_attack_peak += 1;
+            let mut ramp_gain = 1.0;
+            if samples_since_peak <= self.attack {
+                let ramp =
+                    (self.attack - samples_since_peak) as PrcFmt / (self.attack + 1) as PrcFmt;
+                ramp_gain = 1.0 - (ramp * peak);
+                samples_since_peak += 1;
             }
-            if self.output_buffer[i] < gain {
-                gain = self.output_buffer[i];
-                attack_peak = self.output_buffer[i];
-                samples_since_attack_peak = 0;
+
+            // Peak found, start new ramp
+            if gain < ramp_gain {
+                peak = gain;
+                samples_since_peak = 0;
+            } else {
+                gain = ramp_gain;
             }
+
+            // Save gain envelope
             self.output_buffer[i] = gain;
         }
 
@@ -249,22 +253,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_limiting_below_threshold() {
-        let config = config::LookaheadLimiterParameters {
-            limit: 0.0,
-            unit: TimeUnit::Samples,
-            attack: 4.0,
-            release: 4.0,
-        };
-        let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
-        let mut input = vec![0.5, 0.5, 0.5];
-        let expected = vec![0.5, 0.5, 0.5];
-        limiter.apply_lookahead_limiter(&mut input);
-        assert_close(&input, &expected, 1e-9);
-    }
-
-    #[test]
-    fn test_limiter_basic() {
+    fn test_lookahead_limiter_basic() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
             unit: TimeUnit::Samples,
@@ -286,7 +275,7 @@ mod tests {
 
     /// Zero attack and release should behave like a peak limiter
     #[test]
-    fn test_limiter_peak() {
+    fn test_lookahead_limiter_peak() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
             unit: TimeUnit::Samples,
@@ -305,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn test_limiter_zero_release() {
+    fn test_lookahead_limiter_zero_release() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
             unit: TimeUnit::Samples,
@@ -321,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    fn test_limiter_state_persistence() {
+    fn test_lookahead_limiter_state_persistence() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
             unit: TimeUnit::Samples,

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -1,0 +1,160 @@
+use crate::PrcFmt;
+use crate::Res;
+use crate::config;
+use crate::filters::Filter;
+use crate::utils::time::time_to_samples_ceil;
+
+/// A lookahead limiter that does nothing (caveman max).
+#[derive(Clone, Debug)]
+pub struct LookaheadLimiter {
+    pub name: String,
+    pub limit: PrcFmt,
+    pub attack: PrcFmt,
+    pub release: PrcFmt,
+    pub samplerate: usize,
+}
+
+impl LookaheadLimiter {
+    /// Creates a LookaheadLimiter from a config struct
+    pub fn from_config(
+        name: &str,
+        config: config::LookaheadLimiterParameters,
+        samplerate: usize,
+    ) -> Self {
+        let limit = (10.0 as PrcFmt).powf(config.limit / 20.0);
+        let unit = config.unit();
+        let lookahead_samples = time_to_samples_ceil(config.attack, unit, samplerate);
+        let release_samples = time_to_samples_ceil(config.release, unit, samplerate);
+
+        debug!(
+            "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} ms ({} samples), release: {} ms ({} samples)",
+            name,
+            config.limit,
+            limit,
+            config.attack,
+            lookahead_samples,
+            config.release,
+            release_samples
+        );
+
+        LookaheadLimiter {
+            name: name.to_string(),
+            limit,
+            attack: config.attack,
+            release: config.release,
+            samplerate,
+        }
+    }
+
+    /// Process the waveform with lookahead limiting (no‑op).
+    fn apply_lookahead_limit(&mut self, _input: &mut [PrcFmt]) {
+        // do nothing, input stays as is.
+    }
+}
+
+impl Filter for LookaheadLimiter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Apply the lookahead limiter to a waveform, modifying it in-place.
+    fn process_waveform(&mut self, waveform: &mut [PrcFmt]) -> Res<()> {
+        self.apply_lookahead_limit(waveform);
+        Ok(())
+    }
+
+    fn update_parameters(&mut self, config: config::Filter) {
+        if let config::Filter::LookaheadLimiter {
+            parameters: config, ..
+        } = config
+        {
+            let limit = (10.0 as PrcFmt).powf(config.limit / 20.0);
+            let unit = config.unit();
+            let lookahead_samples = time_to_samples_ceil(config.attack, unit, self.samplerate);
+            let release_samples = time_to_samples_ceil(config.release, unit, self.samplerate);
+
+            self.limit = limit;
+            self.attack = config.attack;
+            self.release = config.release;
+
+            debug!(
+                "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} units ({} samples), release: {} units ({} samples)",
+                self.name,
+                config.limit,
+                limit,
+                config.attack,
+                lookahead_samples,
+                config.release,
+                release_samples
+            );
+        } else {
+            // This should never happen unless there is a bug somewhere else
+            panic!("Invalid config change!");
+        }
+    }
+}
+
+/// Validate the lookahead limiter config
+pub fn validate_config(config: &config::LookaheadLimiterParameters) -> Res<()> {
+    if config.attack <= 0.0 {
+        let msg = "Attack time must be positive.";
+        return Err(config::ConfigError::new(msg).into());
+    }
+    if config.release < 0.0 {
+        let msg = "Release time must be non-negative.";
+        return Err(config::ConfigError::new(msg).into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper function to create a test limiter
+    fn create_test_limiter(
+        limit_db: PrcFmt,
+        attack_ms: PrcFmt,
+        release_ms: PrcFmt,
+        samplerate: usize,
+    ) -> LookaheadLimiter {
+        let config = config::LookaheadLimiterParameters {
+            limit: limit_db,
+            attack: attack_ms,
+            release: release_ms,
+            unit: None,
+        };
+        LookaheadLimiter::from_config("test", config, samplerate)
+    }
+
+    #[test]
+    fn test_no_limiting_below_threshold() {
+        let mut limiter = create_test_limiter(0.0, 10.0, 100.0, 48000);
+        let mut input = vec![0.5, 0.5, 0.5];
+        let expected = vec![0.5, 0.5, 0.5];
+
+        limiter.apply_lookahead_limit(&mut input);
+        assert_eq!(input, expected);
+    }
+
+    #[test]
+    fn test_hard_clip_above_threshold() {
+        // Input unchanged even above limit
+        let mut limiter = create_test_limiter(0.0, 10.0, 100.0, 48000);
+        let mut input = vec![2.0, 2.0, 2.0];
+        let expected = vec![2.0, 2.0, 2.0];
+
+        limiter.apply_lookahead_limit(&mut input);
+        assert_eq!(input, expected);
+    }
+
+    #[test]
+    fn test_limit_conversion_db_to_linear() {
+        // dB to linear conversion still works
+        let limiter = create_test_limiter(-6.0, 10.0, 100.0, 48000);
+        assert!((limiter.limit - 0.5).abs() < 0.01);
+
+        let limiter = create_test_limiter(6.0, 10.0, 100.0, 48000);
+        assert!((limiter.limit - 2.0).abs() < 0.01);
+    }
+}

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -4,14 +4,27 @@ use crate::config;
 use crate::filters::Filter;
 use crate::utils::time::time_to_samples_ceil;
 
-/// A lookahead limiter that does nothing (caveman max).
+/// A lookahead limiter that applies gain reduction with lookahead attack and exponential release.
 #[derive(Clone, Debug)]
 pub struct LookaheadLimiter {
     pub name: String,
+    /// Linear gain limit (amplitude)
     pub limit: PrcFmt,
+    /// Attack time in config units (for display)
     pub attack: PrcFmt,
+    /// Release time in config units (for display)
     pub release: PrcFmt,
     pub samplerate: usize,
+    /// Lookahead length in samples (N)
+    lookahead_samples: usize,
+    /// Release coefficient alpha_r = exp(-1/(T_r * fs))
+    alpha_r: PrcFmt,
+    /// Peak gain state carried across buffers (step 2)
+    peak_gain: PrcFmt,
+    /// Steps counter for linear attack (step 2)
+    steps: usize,
+    /// Previous gain state for exponential release (step 3)
+    g_prev: PrcFmt,
 }
 
 impl LookaheadLimiter {
@@ -26,15 +39,27 @@ impl LookaheadLimiter {
         let lookahead_samples = time_to_samples_ceil(config.attack, unit, samplerate);
         let release_samples = time_to_samples_ceil(config.release, unit, samplerate);
 
+        // Compute release coefficient alpha_r = exp(-1 / (T_r * fs))
+        // where T_r = release time in seconds.
+        let release_time_seconds =
+            time_to_samples(config.release, unit, samplerate) / samplerate as PrcFmt;
+        let alpha_r = if release_time_seconds > 0.0 {
+            (-1.0 / (release_time_seconds * samplerate as PrcFmt)).exp()
+        } else {
+            // If release time is zero, instant release (alpha_r = 0)
+            0.0
+        };
+
         debug!(
-            "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} ms ({} samples), release: {} ms ({} samples)",
+            "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} ms ({} samples), release: {} ms ({} samples), alpha_r: {}",
             name,
             config.limit,
             limit,
             config.attack,
             lookahead_samples,
             config.release,
-            release_samples
+            release_samples,
+            alpha_r
         );
 
         LookaheadLimiter {
@@ -43,12 +68,72 @@ impl LookaheadLimiter {
             attack: config.attack,
             release: config.release,
             samplerate,
+            lookahead_samples,
+            alpha_r,
+            peak_gain: 1.0,
+            steps: lookahead_samples + 1,
+            g_prev: 1.0,
         }
     }
 
-    /// Process the waveform with lookahead limiting (no‑op).
-    fn apply_lookahead_limit(&mut self, _input: &mut [PrcFmt]) {
-        // do nothing, input stays as is.
+    /// Process the waveform with lookahead limiting.
+    fn apply_lookahead_limit(&mut self, input: &mut [PrcFmt]) {
+        let n = input.len();
+        if n == 0 {
+            return;
+        }
+
+        let limit = self.limit;
+        let N = self.lookahead_samples;
+        let alpha_r = self.alpha_r;
+
+        // step 1: target gain
+        let mut g0 = vec![1.0 as PrcFmt; n];
+        for i in 0..n {
+            let abs_x = input[i].abs();
+            if abs_x > limit {
+                g0[i] = limit / abs_x;
+            }
+        }
+
+        // step 2: backward linear attack (carry peak state across buffers)
+        let mut g1 = g0.clone();
+        let mut peak_gain = self.peak_gain;
+        let mut steps = self.steps;
+
+        for i in (0..n).rev() {
+            if g0[i] < 1.0 {
+                peak_gain = g0[i];
+                steps = 0;
+            } else {
+                steps += 1;
+            }
+            if steps <= N {
+                g1[i] = g1[i].min(1.0 - (1.0 - peak_gain) * steps as PrcFmt / N as PrcFmt);
+            }
+        }
+
+        // store state for next buffer
+        self.peak_gain = peak_gain;
+        self.steps = steps;
+
+        // step 3: forward exponential release (carry g_prev across buffers)
+        let mut g2 = g1.clone();
+        let mut prev = self.g_prev;
+
+        for i in 0..n {
+            if g1[i] > prev {
+                g2[i] = g1[i].min(1.0 - (1.0 - prev) * alpha_r);
+            }
+            prev = g2[i];
+        }
+
+        self.g_prev = prev;
+
+        // apply gain
+        for i in 0..n {
+            input[i] *= g2[i];
+        }
     }
 }
 
@@ -73,19 +158,32 @@ impl Filter for LookaheadLimiter {
             let lookahead_samples = time_to_samples_ceil(config.attack, unit, self.samplerate);
             let release_samples = time_to_samples_ceil(config.release, unit, self.samplerate);
 
+            // recompute alpha_r
+            let release_time_seconds =
+                time_to_samples(config.release, unit, self.samplerate) / self.samplerate as PrcFmt;
+            let alpha_r = if release_time_seconds > 0.0 {
+                (-1.0 / (release_time_seconds * self.samplerate as PrcFmt)).exp()
+            } else {
+                0.0
+            };
+
             self.limit = limit;
             self.attack = config.attack;
             self.release = config.release;
+            self.lookahead_samples = lookahead_samples;
+            self.alpha_r = alpha_r;
+            // Note: we keep peak_gain, steps, g_prev unchanged across parameter updates.
 
             debug!(
-                "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} units ({} samples), release: {} units ({} samples)",
+                "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} units ({} samples), release: {} units ({} samples), alpha_r: {}",
                 self.name,
                 config.limit,
                 limit,
                 config.attack,
                 lookahead_samples,
                 config.release,
-                release_samples
+                release_samples,
+                alpha_r
             );
         } else {
             // This should never happen unless there is a bug somewhere else
@@ -139,13 +237,12 @@ mod tests {
 
     #[test]
     fn test_hard_clip_above_threshold() {
-        // Input unchanged even above limit
+        // Input above limit should be limited to limit (1.0)
         let mut limiter = create_test_limiter(0.0, 10.0, 100.0, 48000);
         let mut input = vec![2.0, 2.0, 2.0];
-        let expected = vec![2.0, 2.0, 2.0];
-
+        // Expect gain reduction to 1.0
         limiter.apply_lookahead_limit(&mut input);
-        assert_eq!(input, expected);
+        assert!(input[0].abs() <= 1.0);
     }
 
     #[test]

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -32,7 +32,6 @@ pub struct LookaheadLimiter {
     epsilon: PrcFmt,
     lookahead_buffer: VecDeque<PrcFmt>,
     release_gain: PrcFmt,
-    gain_buffer: Vec<PrcFmt>,
     output_buffer: Vec<PrcFmt>,
 }
 
@@ -77,7 +76,6 @@ impl LookaheadLimiter {
             epsilon,
             lookahead_buffer: vec![0.0; samplerate].into(),
             release_gain: 1.0,
-            gain_buffer: vec![1.0 as PrcFmt; attack + chunksize],
             output_buffer: vec![0.0 as PrcFmt; chunksize],
         }
     }
@@ -88,41 +86,40 @@ impl LookaheadLimiter {
             return;
         }
 
-        let get_sample = |i: usize, buf: &VecDeque<PrcFmt>, inp: &[PrcFmt]| -> PrcFmt {
-            if i < self.attack {
-                buf[self.samplerate - self.attack + i]
-            } else {
-                inp[i - self.attack]
-            }
-        };
-
-        // Compute gain reduction curve like a simple peak limiter
-        for i in 0..(self.attack + n) {
-            let sample_abs = get_sample(i, &self.lookahead_buffer, input).abs();
-            if sample_abs > self.limit {
-                self.gain_buffer[i] = self.limit / sample_abs;
-            } else {
-                self.gain_buffer[i] = 1.0;
-            }
-        }
-
         // Backward pass turning peaks into linear ramps.
         let mut attack_peak = 1.0;
         let mut samples_since_attack_peak = self.attack;
         for i in (0..(self.attack + n)).rev() {
             let mut gain = 1.0;
+
+            // Get sample amplitude
+            let amplitude = (if i < self.attack {
+                self.lookahead_buffer[self.samplerate - self.attack + i]
+            } else {
+                input[i - self.attack]
+            })
+            .abs();
+
+            // Compute gain envelope like simple limiter
+            if amplitude > self.limit {
+                self.output_buffer[i] = self.limit / amplitude;
+            } else {
+                self.output_buffer[i] = 1.0;
+            }
+
+            // Compute ramp
             if samples_since_attack_peak <= self.attack {
                 let ramp = (self.attack - samples_since_attack_peak) as PrcFmt
                     / (self.attack + 1) as PrcFmt;
                 gain = 1.0 - (ramp * attack_peak);
                 samples_since_attack_peak += 1;
             }
-            if self.gain_buffer[i] < gain {
-                gain = self.gain_buffer[i];
-                attack_peak = self.gain_buffer[i];
+            if self.output_buffer[i] < gain {
+                gain = self.output_buffer[i];
+                attack_peak = self.output_buffer[i];
                 samples_since_attack_peak = 0;
             }
-            self.gain_buffer[i] = gain;
+            self.output_buffer[i] = gain;
         }
 
         // Forward pass turning peaks into exponential decay.
@@ -131,23 +128,31 @@ impl LookaheadLimiter {
             if self.release_gain > 1.0 - self.epsilon {
                 self.release_gain = 1.0
             }
-            if self.gain_buffer[i] < self.release_gain {
-                self.release_gain = self.gain_buffer[i];
+            if self.output_buffer[i] < self.release_gain {
+                self.release_gain = self.output_buffer[i];
             } else {
-                self.gain_buffer[i] = self.release_gain;
+                self.output_buffer[i] = self.release_gain;
             }
         }
 
-        let delayed_samples = &mut self.output_buffer[..n];
+        // Apply gain reduction to delayed samples
         for i in 0..n {
-            delayed_samples[i] = get_sample(i, &self.lookahead_buffer, input);
+            self.output_buffer[i] *= if i < self.attack {
+                self.lookahead_buffer[self.samplerate - self.attack + i]
+            } else {
+                input[i - self.attack]
+            }
         }
+
+        // Copy input to end of lookahead buffer
         self.lookahead_buffer.drain(0..n);
         for sample in &mut *input {
             self.lookahead_buffer.push_back(*sample);
         }
+
+        // Ouput
         for i in 0..n {
-            input[i] = delayed_samples[i] * self.gain_buffer[i];
+            input[i] = self.output_buffer[i];
         }
     }
 }

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -239,14 +239,14 @@ mod tests {
             limit: 0.0,
             unit: TimeUnit::Samples,
             attack: 4.0,
-            release: 1.0 / std::f64::consts::LN_2,
+            release: 1.0 / std::f64::consts::LN_2 as PrcFmt,
         };
         let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut input = vec![
             1.0, 1.0, 1.0, 1.0, 1.0, 2.0, -2.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
             1.0, 1.0,
         ];
-        let expected = vec![
+        let expected: Vec<PrcFmt> = vec![
             0.0,
             0.0,
             0.0,
@@ -258,14 +258,14 @@ mod tests {
             0.625,
             1.0,
             -1.0,
-            0.5_f64.powf(1.0 / 2.0),
+            0.5_f64.powf(1.0 / 2.0) as PrcFmt,
             0.625,
             1.0,
-            0.5_f64.powf(1.0 / 2.0),
-            0.5_f64.powf(1.0 / 4.0),
-            0.5_f64.powf(1.0 / 8.0),
-            0.5_f64.powf(1.0 / 16.0),
-            0.5_f64.powf(1.0 / 32.0),
+            0.5_f64.powf(1.0 / 2.0) as PrcFmt,
+            0.5_f64.powf(1.0 / 4.0) as PrcFmt,
+            0.5_f64.powf(1.0 / 8.0) as PrcFmt,
+            0.5_f64.powf(1.0 / 16.0) as PrcFmt,
+            0.5_f64.powf(1.0 / 32.0) as PrcFmt,
         ];
         limiter.apply_lookahead_limiter(&mut input);
         assert_close(&input, &expected, 1e-6);
@@ -366,20 +366,20 @@ mod tests {
             limit: 0.0,
             unit: TimeUnit::Samples,
             attack: 5.0,
-            release: 1.0 / std::f64::consts::LN_2,
+            release: 1.0 / std::f64::consts::LN_2 as PrcFmt,
         };
         let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut buf1 = vec![1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0];
-        let expected1 = vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0];
+        let expected1: Vec<PrcFmt> = vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0];
         limiter.apply_lookahead_limiter(&mut buf1);
         assert_close(&buf1, &expected1, 1e-6);
 
         let mut buf2 = vec![1.0, 1.0, 1.0, 1.0];
-        let expected2 = vec![
-            0.5_f64.powf(1.0 / 2.0),
-            0.5_f64.powf(1.0 / 4.0),
-            0.5_f64.powf(1.0 / 8.0),
-            0.5_f64.powf(1.0 / 16.0),
+        let expected2: Vec<PrcFmt> = vec![
+            0.5_f64.powf(1.0 / 2.0) as PrcFmt,
+            0.5_f64.powf(1.0 / 4.0) as PrcFmt,
+            0.5_f64.powf(1.0 / 8.0) as PrcFmt,
+            0.5_f64.powf(1.0 / 16.0) as PrcFmt,
         ];
         limiter.apply_lookahead_limiter(&mut buf2);
         assert_close(&buf2, &expected2, 1e-6);

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -183,6 +183,10 @@ impl Filter for LookaheadLimiter {
             (self.limit, self.attack_samples, self.release_coeff) =
                 LookaheadLimiter::configure(&config, self.samplerate);
 
+            for _ in 0..self.attack_samples {
+                self.lookahead_buffer.push_overwrite(0.0);
+            }
+
             debug!(
                 "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release coefficient: {}",
                 self.name, config.limit, self.limit, self.attack_samples, self.release_coeff

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -92,15 +92,15 @@ impl LookaheadLimiter {
     }
 
     fn apply_lookahead_limiter(&mut self, input: &mut [PrcFmt]) {
-        let n = input.len();
-        if n == 0 {
+        let len = input.len();
+        if len == 0 {
             return;
         }
 
         // Backward pass turning peaks into linear ramps.
         let mut peak = 1.0;
-        let mut samples_since_peak = self.attack;
-        for i in (0..(self.attack + n)).rev() {
+        let mut samples_since_peak = self.attack + 1;
+        for i in (0..(self.attack + len)).rev() {
             // Get sample amplitude
             let amplitude = (if i < self.attack {
                 self.lookahead_buffer[self.samplerate - self.attack + i]
@@ -120,15 +120,15 @@ impl LookaheadLimiter {
             let mut ramp_gain = 1.0;
             if samples_since_peak <= self.attack {
                 let ramp =
-                    (self.attack - samples_since_peak) as PrcFmt / (self.attack + 1) as PrcFmt;
-                ramp_gain = 1.0 - (ramp * peak);
+                    (self.attack - samples_since_peak) as PrcFmt / self.attack.max(1) as PrcFmt;
+                ramp_gain = 1.0 - (ramp * (1.0 - peak));
                 samples_since_peak += 1;
             }
 
             // Peak found, start new ramp
             if gain < ramp_gain {
                 peak = gain;
-                samples_since_peak = 0;
+                samples_since_peak = 1;
             } else {
                 gain = ramp_gain;
             }
@@ -140,7 +140,7 @@ impl LookaheadLimiter {
         }
 
         // Forward pass turning peaks into exponential decay.
-        for i in 0..n {
+        for i in 0..len {
             self.release_gain = 1.0 - (1.0 - self.release_gain) * self.alpha;
             if self.release_gain > 1.0 - self.epsilon {
                 self.release_gain = 1.0
@@ -153,7 +153,7 @@ impl LookaheadLimiter {
         }
 
         // Apply gain reduction to delayed samples
-        for i in 0..n {
+        for i in 0..len {
             self.output_buffer[i] *= if i < self.attack {
                 self.lookahead_buffer[self.samplerate - self.attack + i]
             } else {
@@ -162,11 +162,11 @@ impl LookaheadLimiter {
         }
 
         // Drop old samples from beginning of lookahead buffer and copy input samples to its end
-        self.lookahead_buffer.drain(..n);
+        self.lookahead_buffer.drain(..len);
         self.lookahead_buffer.extend(input.iter().copied());
 
         // Ouput
-        input[..n].copy_from_slice(&self.output_buffer[..n]);
+        input[..len].copy_from_slice(&self.output_buffer[..len]);
     }
 }
 
@@ -242,8 +242,8 @@ mod tests {
             1.0, 1.0,
         ];
         let expected = vec![
-            0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0, -1.0, 0.7, 0.6, 1.0, 0.95, 0.995,
-            0.9995, 1.0, 1.0,
+            0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.875, 0.75, 0.625, 1.0, -1.0, 0.75, 0.625, 1.0, 0.95,
+            0.995, 0.9995, 1.0, 1.0,
         ];
         limiter.apply_lookahead_limiter(&mut input);
         assert_close(&input, &expected, 1e-6);
@@ -290,12 +290,12 @@ mod tests {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
             unit: TimeUnit::Samples,
-            attack: 4.0,
+            attack: 5.0,
             release: 4.0,
         };
         let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
-        let mut buf1 = vec![1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0];
-        let expected1 = vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0];
+        let mut buf1 = vec![1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0];
+        let expected1 = vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0];
         limiter.apply_lookahead_limiter(&mut buf1);
         assert_close(&buf1, &expected1, 1e-6);
 

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -27,9 +27,8 @@ pub struct LookaheadLimiter {
     pub name: String,
     pub limit: PrcFmt,
     pub attack_samples: usize,
+    pub release_coeff: PrcFmt,
     pub samplerate: usize,
-    epsilon: PrcFmt,
-    alpha: PrcFmt,
     lookahead_buffer: VecDeque<PrcFmt>,
     release_gain: PrcFmt,
     output_buffer: Vec<PrcFmt>,
@@ -42,21 +41,20 @@ impl LookaheadLimiter {
         samplerate: usize,
         chunksize: usize,
     ) -> Self {
-        let (limit, attack_samples, release, epsilon, alpha) =
+        let (limit, attack_samples, release_coeff) =
             LookaheadLimiter::configure(&config, samplerate);
 
         debug!(
-            "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
-            name, config.limit, limit, attack_samples, release, alpha
+            "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release coefficient: {}",
+            name, config.limit, limit, attack_samples, release_coeff
         );
 
         LookaheadLimiter {
             name: name.to_string(),
             limit,
             attack_samples,
+            release_coeff,
             samplerate,
-            epsilon,
-            alpha,
             lookahead_buffer: vec![0.0; samplerate].into(),
             release_gain: 1.0,
             output_buffer: vec![0.0 as PrcFmt; chunksize],
@@ -66,20 +64,17 @@ impl LookaheadLimiter {
     fn configure(
         config: &config::LookaheadLimiterParameters,
         samplerate: usize,
-    ) -> (f64, usize, usize, f64, f64) {
+    ) -> (PrcFmt, usize, PrcFmt) {
         let limit = db_to_linear(config.limit);
 
         let unit = config.unit();
 
         let attack_samples = time_to_samples(config.attack, unit, samplerate).round() as usize;
 
-        let release = time_to_samples(config.release, unit, samplerate) as usize;
-        // When release gain reduction is less than -80dB, just pass the signal through
-        let epsilon = 10f64.powf(-80.0 / 20.0);
-        // Release exponential factor
-        let alpha = epsilon.powf(1.0 / time_to_samples(config.release, unit, samplerate));
+        let release_samples = time_to_samples(config.release, unit, samplerate);
+        let release_coeff = (-1.0 / release_samples).exp();
 
-        (limit, attack_samples, release, epsilon, alpha)
+        (limit, attack_samples, release_coeff)
     }
 
     fn apply_lookahead_limiter(&mut self, input: &mut [PrcFmt]) {
@@ -131,11 +126,10 @@ impl LookaheadLimiter {
         }
 
         // Forward pass turning peaks into exponential decay.
+        // Release uses the same 1/e time constant coefficient as Compressor.
+        // They are not exactly equal because Compressor works in the dB domain and has 1e-6 bias.
         for i in 0..len {
-            self.release_gain = 1.0 - (1.0 - self.release_gain) * self.alpha;
-            if self.release_gain > 1.0 - self.epsilon {
-                self.release_gain = 1.0
-            }
+            self.release_gain = self.release_gain.powf(self.release_coeff);
             if self.output_buffer[i] < self.release_gain {
                 self.release_gain = self.output_buffer[i];
             } else {
@@ -176,13 +170,12 @@ impl Filter for LookaheadLimiter {
             parameters: config, ..
         } = config
         {
-            let release;
-            (self.limit, self.attack_samples, release, self.epsilon, self.alpha) =
+            (self.limit, self.attack_samples, self.release_coeff) =
                 LookaheadLimiter::configure(&config, self.samplerate);
 
             debug!(
-                "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
-                self.name, config.limit, self.limit, self.attack_samples, release, self.alpha
+                "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release coefficient: {}",
+                self.name, config.limit, self.limit, self.attack_samples, self.release_coeff
             );
         } else {
             panic!("Invalid config change!");
@@ -201,7 +194,7 @@ pub fn validate_config(config: &config::LookaheadLimiterParameters, samplerate: 
         return Err(config::ConfigError::new(msg).into());
     }
     if config.release < 0.0 {
-        let msg = "Release time must be non-negative.";
+        let msg = "Release time must be greater than or equal to 0.";
         return Err(config::ConfigError::new(msg).into());
     }
     Ok(())
@@ -210,7 +203,9 @@ pub fn validate_config(config: &config::LookaheadLimiterParameters, samplerate: 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audiochunk::AudioChunk;
     use crate::config::TimeUnit;
+    use crate::processors::Processor;
 
     fn assert_close(left: &[PrcFmt], right: &[PrcFmt], epsilon: PrcFmt) {
         assert_eq!(left.len(), right.len());
@@ -230,7 +225,7 @@ mod tests {
             limit: 0.0,
             unit: TimeUnit::Samples,
             attack: 4.0,
-            release: 4.0,
+            release: 1.0 / std::f64::consts::LN_2,
         };
         let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut input = vec![
@@ -238,8 +233,25 @@ mod tests {
             1.0, 1.0,
         ];
         let expected = vec![
-            0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.875, 0.75, 0.625, 1.0, -1.0, 0.75, 0.625, 1.0, 0.95,
-            0.995, 0.9995, 1.0, 1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            1.0,
+            0.875,
+            0.75,
+            0.625,
+            1.0,
+            -1.0,
+            0.5_f64.powf(1.0 / 2.0),
+            0.625,
+            1.0,
+            0.5_f64.powf(1.0 / 2.0),
+            0.5_f64.powf(1.0 / 4.0),
+            0.5_f64.powf(1.0 / 8.0),
+            0.5_f64.powf(1.0 / 16.0),
+            0.5_f64.powf(1.0 / 32.0),
         ];
         limiter.apply_lookahead_limiter(&mut input);
         assert_close(&input, &expected, 1e-6);
@@ -273,6 +285,52 @@ mod tests {
     }
 
     #[test]
+    fn test_lookahead_limiter_zero_attack_matches_compressor() {
+        let release_samples: PrcFmt = 4.0;
+        let samplerate = 48000;
+        let mut limiter_input = vec![2.0, 1.0, 1.0, 1.0, 1.0];
+        let chunksize = limiter_input.len();
+        let config = config::LookaheadLimiterParameters {
+            limit: 0.0,
+            unit: TimeUnit::Samples,
+            attack: 0.0,
+            release: release_samples,
+        };
+        let mut limiter = LookaheadLimiter::from_config("test", config, samplerate, chunksize);
+        let mut compressor = crate::processors::compressor::Compressor::from_config(
+            "test",
+            config::CompressorParameters {
+                channels: 1,
+                monitor_channels: None,
+                process_channels: None,
+                attack: 0.0,
+                release: release_samples / samplerate as PrcFmt,
+                threshold: 0.0,
+                factor: 1.0e20,
+                makeup_gain: None,
+                soft_clip: None,
+                clip_limit: None,
+            },
+            samplerate,
+            chunksize,
+        );
+
+        let mut compressor_chunk = AudioChunk::new(
+            vec![limiter_input.clone()],
+            1.0,
+            -1.0,
+            limiter_input.len(),
+            limiter_input.len(),
+        );
+
+        limiter.apply_lookahead_limiter(&mut limiter_input);
+        compressor.process_chunk(&mut compressor_chunk).unwrap();
+
+        // The values are not exactly equal because compressor works in the dB domain and has 1e-6 bias.
+        assert_close(&limiter_input, &compressor_chunk.waveforms[0], 1e-6);
+    }
+
+    #[test]
     fn test_lookahead_limiter_zero_release() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
@@ -294,7 +352,7 @@ mod tests {
             limit: 0.0,
             unit: TimeUnit::Samples,
             attack: 5.0,
-            release: 4.0,
+            release: 1.0 / std::f64::consts::LN_2,
         };
         let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut buf1 = vec![1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0];
@@ -303,7 +361,12 @@ mod tests {
         assert_close(&buf1, &expected1, 1e-6);
 
         let mut buf2 = vec![1.0, 1.0, 1.0, 1.0];
-        let expected2 = vec![0.95, 0.995, 0.9995, 1.0];
+        let expected2 = vec![
+            0.5_f64.powf(1.0 / 2.0),
+            0.5_f64.powf(1.0 / 4.0),
+            0.5_f64.powf(1.0 / 8.0),
+            0.5_f64.powf(1.0 / 16.0),
+        ];
         limiter.apply_lookahead_limiter(&mut buf2);
         assert_close(&buf2, &expected2, 1e-6);
     }

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -19,7 +19,7 @@ use crate::Res;
 use crate::config;
 use crate::filters::Filter;
 use crate::utils::decibels::db_to_linear;
-use crate::utils::time::{time_to_samples, time_to_seconds};
+use crate::utils::time::time_to_samples;
 use std::collections::VecDeque;
 
 #[derive(Debug, Clone)]
@@ -86,8 +86,7 @@ impl LookaheadLimiter {
         // When release gain reduction is less than -80dB, just pass the signal through
         let epsilon = 10f64.powf(-80.0 / 20.0);
         // Release exponential factor
-        let alpha = epsilon
-            .powf(1.0 / (samplerate as PrcFmt * time_to_seconds(config.release, unit, samplerate)));
+        let alpha = epsilon.powf(1.0 / time_to_samples(config.release, unit, samplerate));
 
         (limit, attack, release, epsilon, alpha)
     }

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -28,8 +28,8 @@ pub struct LookaheadLimiter {
     pub limit: PrcFmt,
     pub attack: usize,
     pub samplerate: usize,
-    alpha: PrcFmt,
     epsilon: PrcFmt,
+    alpha: PrcFmt,
     lookahead_buffer: VecDeque<PrcFmt>,
     release_gain: PrcFmt,
     output_buffer: Vec<PrcFmt>,
@@ -42,29 +42,12 @@ impl LookaheadLimiter {
         samplerate: usize,
         chunksize: usize,
     ) -> Self {
-        let limit = db_to_linear(config.limit);
-        let unit = config.unit();
-        let attack = time_to_samples(config.attack, unit, samplerate) as usize;
-        // When release gain reduction is less than -80dB, just pass the signal through
-        let epsilon = 10f64.powf(-80.0 / 20.0);
-        let alpha = epsilon
-            .powf(1.0 / (samplerate as PrcFmt * time_to_seconds(config.release, unit, samplerate)));
-
-        if attack > samplerate {
-            panic!(
-                "Lookahead limiter attack time must not exceed 1 second ({} samples > {} samplerate)",
-                attack, samplerate
-            );
-        }
+        let (limit, attack, release, epsilon, alpha) =
+            LookaheadLimiter::configure(&config, samplerate);
 
         debug!(
             "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
-            name,
-            config.limit,
-            limit,
-            attack,
-            time_to_samples(config.release, unit, samplerate),
-            alpha
+            name, config.limit, limit, attack, release, alpha
         );
 
         LookaheadLimiter {
@@ -72,12 +55,41 @@ impl LookaheadLimiter {
             limit,
             attack,
             samplerate,
-            alpha,
             epsilon,
+            alpha,
             lookahead_buffer: vec![0.0; samplerate].into(),
             release_gain: 1.0,
             output_buffer: vec![0.0 as PrcFmt; chunksize],
         }
+    }
+
+    fn configure(
+        config: &config::LookaheadLimiterParameters,
+        samplerate: usize,
+    ) -> (f64, usize, usize, f64, f64) {
+        let limit = db_to_linear(config.limit);
+
+        let unit = config.unit();
+
+        let attack_raw = time_to_samples(config.attack, unit, samplerate) as usize;
+        let attack = if attack_raw <= samplerate {
+            attack_raw
+        } else {
+            warn!(
+                "Lookahead limiter attack time exceeds 1 second ({} samples > {} samplerate), limiting to 1 second.",
+                attack_raw, samplerate
+            );
+            samplerate
+        };
+
+        let release = time_to_samples(config.release, unit, samplerate) as usize;
+        // When release gain reduction is less than -80dB, just pass the signal through
+        let epsilon = 10f64.powf(-80.0 / 20.0);
+        // Release exponential factor
+        let alpha = epsilon
+            .powf(1.0 / (samplerate as PrcFmt * time_to_seconds(config.release, unit, samplerate)));
+
+        (limit, attack, release, epsilon, alpha)
     }
 
     fn apply_lookahead_limiter(&mut self, input: &mut [PrcFmt]) {
@@ -123,7 +135,9 @@ impl LookaheadLimiter {
             }
 
             // Save gain envelope
-            self.output_buffer[i] = gain;
+            if i < self.output_buffer.len() {
+                self.output_buffer[i] = gain;
+            }
         }
 
         // Forward pass turning peaks into exponential decay.
@@ -148,16 +162,12 @@ impl LookaheadLimiter {
             }
         }
 
-        // Copy input to end of lookahead buffer
-        self.lookahead_buffer.drain(0..n);
-        for sample in &mut *input {
-            self.lookahead_buffer.push_back(*sample);
-        }
+        // Drop old samples from beginning of lookahead buffer and copy input samples to its end
+        self.lookahead_buffer.drain(..n);
+        self.lookahead_buffer.extend(input.iter().copied());
 
         // Ouput
-        for i in 0..n {
-            input[i] = self.output_buffer[i];
-        }
+        input[..n].copy_from_slice(&self.output_buffer[..n]);
     }
 }
 
@@ -176,19 +186,9 @@ impl Filter for LookaheadLimiter {
             parameters: config, ..
         } = config
         {
-            let new_attack =
-                time_to_samples(config.attack, config.unit(), self.samplerate) as usize;
-            if new_attack > self.samplerate {
-                panic!(
-                    "Lookahead limiter attack time exceeds 1 second ({} samples > {} samplerate)",
-                    new_attack, self.samplerate
-                );
-            }
-            self.limit = db_to_linear(config.limit);
-            self.attack = new_attack;
-            let release = time_to_samples(config.release, config.unit(), self.samplerate) as usize;
-            let epsilon = 10f64.powf(-80.0 / 20.0);
-            self.alpha = epsilon.powf(1.0 / release as PrcFmt);
+            let release;
+            (self.limit, self.attack, release, self.epsilon, self.alpha) =
+                LookaheadLimiter::configure(&config, self.samplerate);
 
             debug!(
                 "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
@@ -208,29 +208,6 @@ pub fn validate_config(config: &config::LookaheadLimiterParameters) -> Res<()> {
     if config.release < 0.0 {
         let msg = "Release time must be non-negative.";
         return Err(config::ConfigError::new(msg).into());
-    }
-    let unit = config.unit();
-    match unit {
-        config::TimeUnit::Microseconds => {
-            if config.attack > 1_000_000.0 {
-                let msg = "Attack time must not exceed 1 second.";
-                return Err(config::ConfigError::new(msg).into());
-            }
-        }
-        config::TimeUnit::Milliseconds => {
-            if config.attack > 1000.0 {
-                let msg = "Attack time must not exceed 1 second.";
-                return Err(config::ConfigError::new(msg).into());
-            }
-        }
-        config::TimeUnit::Millimetres => {
-            let seconds = config.attack / 1000.0 / 343.0;
-            if seconds > 1.0 {
-                let msg = "Attack time must not exceed 1 second.";
-                return Err(config::ConfigError::new(msg).into());
-            }
-        }
-        config::TimeUnit::Samples => {}
     }
     Ok(())
 }
@@ -327,5 +304,17 @@ mod tests {
         let expected2 = vec![0.95, 0.995, 0.9995, 1.0];
         limiter.apply_lookahead_limiter(&mut buf2);
         assert_close(&buf2, &expected2, 1e-6);
+    }
+
+    #[test]
+    fn test_lookahead_limiter_attack_clamped_to_one_second() {
+        let config = config::LookaheadLimiterParameters {
+            limit: 0.0,
+            unit: TimeUnit::Samples,
+            attack: 48001.0,
+            release: 4.0,
+        };
+        let limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
+        assert_eq!(limiter.attack, 48000);
     }
 }

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -20,16 +20,17 @@ use crate::config;
 use crate::filters::Filter;
 use crate::utils::decibels::db_to_linear;
 use crate::utils::time::time_to_samples;
-use std::collections::VecDeque;
+use ringbuf::LocalRb;
+use ringbuf::storage::Heap;
+use ringbuf::traits::*;
 
-#[derive(Debug, Clone)]
 pub struct LookaheadLimiter {
     pub name: String,
     pub limit: PrcFmt,
     pub attack_samples: usize,
     pub release_coeff: PrcFmt,
     pub samplerate: usize,
-    lookahead_buffer: VecDeque<PrcFmt>,
+    lookahead_buffer: LocalRb<Heap<PrcFmt>>,
     release_gain: PrcFmt,
     output_buffer: Vec<PrcFmt>,
 }
@@ -49,13 +50,16 @@ impl LookaheadLimiter {
             name, config.limit, limit, attack_samples, release_coeff
         );
 
+        let lookahead_buffer_len = samplerate.max(chunksize);
+        let lookahead_buffer = LocalRb::from(vec![0.0 as PrcFmt; lookahead_buffer_len]);
+
         LookaheadLimiter {
             name: name.to_string(),
             limit,
             attack_samples,
             release_coeff,
             samplerate,
-            lookahead_buffer: vec![0.0; samplerate.max(chunksize)].into(),
+            lookahead_buffer,
             release_gain: 1.0,
             output_buffer: vec![0.0 as PrcFmt; chunksize],
         }
@@ -83,19 +87,28 @@ impl LookaheadLimiter {
             return;
         }
 
+        let lookahead_start = self.lookahead_buffer.occupied_len() - self.attack_samples;
+        let (first, second) = self.lookahead_buffer.as_slices();
+        let get_input_sample = |i: usize| -> PrcFmt {
+            if i < self.attack_samples {
+                let idx = lookahead_start + i;
+                if idx < first.len() {
+                    first[idx]
+                } else {
+                    second[idx - first.len()]
+                }
+            } else {
+                input[i - self.attack_samples]
+            }
+        };
+
         // Backward pass turning peaks into linear ramps.
         let mut peak = 1.0;
         let mut samples_since_peak = self.attack_samples + 1;
-        let lookahead_start = self.lookahead_buffer.len() - self.attack_samples;
 
         for i in (0..(self.attack_samples + len)).rev() {
             // Get sample amplitude
-            let amplitude = (if i < self.attack_samples {
-                self.lookahead_buffer[lookahead_start + i]
-            } else {
-                input[i - self.attack_samples]
-            })
-            .abs();
+            let amplitude = get_input_sample(i).abs();
 
             // Compute reduction gain for current sample
             let mut gain = if amplitude > self.limit {
@@ -141,16 +154,11 @@ impl LookaheadLimiter {
 
         // Apply gain reduction to delayed samples
         for i in 0..len {
-            self.output_buffer[i] *= if i < self.attack_samples {
-                self.lookahead_buffer[lookahead_start + i]
-            } else {
-                input[i - self.attack_samples]
-            }
+            self.output_buffer[i] *= get_input_sample(i);
         }
 
         // Drop old samples from beginning of lookahead buffer and copy input samples to its end
-        self.lookahead_buffer.drain(..len);
-        self.lookahead_buffer.extend(input.iter().copied());
+        self.lookahead_buffer.push_slice_overwrite(input);
 
         // Ouput
         input[..len].copy_from_slice(&self.output_buffer[..len]);

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -55,7 +55,7 @@ impl LookaheadLimiter {
             attack_samples,
             release_coeff,
             samplerate,
-            lookahead_buffer: vec![0.0; samplerate].into(),
+            lookahead_buffer: vec![0.0; samplerate.max(chunksize)].into(),
             release_gain: 1.0,
             output_buffer: vec![0.0 as PrcFmt; chunksize],
         }
@@ -86,10 +86,12 @@ impl LookaheadLimiter {
         // Backward pass turning peaks into linear ramps.
         let mut peak = 1.0;
         let mut samples_since_peak = self.attack_samples + 1;
+        let lookahead_start = self.lookahead_buffer.len() - self.attack_samples;
+
         for i in (0..(self.attack_samples + len)).rev() {
             // Get sample amplitude
             let amplitude = (if i < self.attack_samples {
-                self.lookahead_buffer[self.samplerate - self.attack_samples + i]
+                self.lookahead_buffer[lookahead_start + i]
             } else {
                 input[i - self.attack_samples]
             })
@@ -140,7 +142,7 @@ impl LookaheadLimiter {
         // Apply gain reduction to delayed samples
         for i in 0..len {
             self.output_buffer[i] *= if i < self.attack_samples {
-                self.lookahead_buffer[self.samplerate - self.attack_samples + i]
+                self.lookahead_buffer[lookahead_start + i]
             } else {
                 input[i - self.attack_samples]
             }
@@ -380,5 +382,23 @@ mod tests {
             release: 4.0,
         };
         assert!(validate_config(&config, 48000).is_err());
+    }
+
+    #[test]
+    fn test_lookahead_limiter_chunksize_larger_than_samplerate() {
+        let samplerate = 4;
+        let chunksize = 8;
+        let config = config::LookaheadLimiterParameters {
+            limit: 0.0,
+            unit: TimeUnit::Samples,
+            attack: 4.0,
+            release: 1.0,
+        };
+        let mut limiter = LookaheadLimiter::from_config("test", config, samplerate, chunksize);
+        let mut input = vec![1.0, 1.0, 2.0, 1.0, 1.0, -2.0, 1.0, 1.0];
+
+        limiter.apply_lookahead_limiter(&mut input);
+
+        assert_eq!(input.len(), chunksize);
     }
 }

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -26,7 +26,7 @@ use std::collections::VecDeque;
 pub struct LookaheadLimiter {
     pub name: String,
     pub limit: PrcFmt,
-    pub attack: usize,
+    pub attack_samples: usize,
     pub samplerate: usize,
     epsilon: PrcFmt,
     alpha: PrcFmt,
@@ -42,18 +42,18 @@ impl LookaheadLimiter {
         samplerate: usize,
         chunksize: usize,
     ) -> Self {
-        let (limit, attack, release, epsilon, alpha) =
+        let (limit, attack_samples, release, epsilon, alpha) =
             LookaheadLimiter::configure(&config, samplerate);
 
         debug!(
             "Creating lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
-            name, config.limit, limit, attack, release, alpha
+            name, config.limit, limit, attack_samples, release, alpha
         );
 
         LookaheadLimiter {
             name: name.to_string(),
             limit,
-            attack,
+            attack_samples,
             samplerate,
             epsilon,
             alpha,
@@ -71,16 +71,7 @@ impl LookaheadLimiter {
 
         let unit = config.unit();
 
-        let attack_raw = time_to_samples(config.attack, unit, samplerate) as usize;
-        let attack = if attack_raw <= samplerate {
-            attack_raw
-        } else {
-            warn!(
-                "Lookahead limiter attack time exceeds 1 second ({} samples > {} samplerate), limiting to 1 second.",
-                attack_raw, samplerate
-            );
-            samplerate
-        };
+        let attack_samples = time_to_samples(config.attack, unit, samplerate).round() as usize;
 
         let release = time_to_samples(config.release, unit, samplerate) as usize;
         // When release gain reduction is less than -80dB, just pass the signal through
@@ -88,7 +79,7 @@ impl LookaheadLimiter {
         // Release exponential factor
         let alpha = epsilon.powf(1.0 / time_to_samples(config.release, unit, samplerate));
 
-        (limit, attack, release, epsilon, alpha)
+        (limit, attack_samples, release, epsilon, alpha)
     }
 
     fn apply_lookahead_limiter(&mut self, input: &mut [PrcFmt]) {
@@ -99,13 +90,13 @@ impl LookaheadLimiter {
 
         // Backward pass turning peaks into linear ramps.
         let mut peak = 1.0;
-        let mut samples_since_peak = self.attack + 1;
-        for i in (0..(self.attack + len)).rev() {
+        let mut samples_since_peak = self.attack_samples + 1;
+        for i in (0..(self.attack_samples + len)).rev() {
             // Get sample amplitude
-            let amplitude = (if i < self.attack {
-                self.lookahead_buffer[self.samplerate - self.attack + i]
+            let amplitude = (if i < self.attack_samples {
+                self.lookahead_buffer[self.samplerate - self.attack_samples + i]
             } else {
-                input[i - self.attack]
+                input[i - self.attack_samples]
             })
             .abs();
 
@@ -118,9 +109,9 @@ impl LookaheadLimiter {
 
             // Compute ramp
             let mut ramp_gain = 1.0;
-            if samples_since_peak <= self.attack {
-                let ramp =
-                    (self.attack - samples_since_peak) as PrcFmt / self.attack.max(1) as PrcFmt;
+            if samples_since_peak <= self.attack_samples {
+                let ramp = (self.attack_samples - samples_since_peak) as PrcFmt
+                    / self.attack_samples.max(1) as PrcFmt;
                 ramp_gain = 1.0 - (ramp * (1.0 - peak));
                 samples_since_peak += 1;
             }
@@ -154,10 +145,10 @@ impl LookaheadLimiter {
 
         // Apply gain reduction to delayed samples
         for i in 0..len {
-            self.output_buffer[i] *= if i < self.attack {
-                self.lookahead_buffer[self.samplerate - self.attack + i]
+            self.output_buffer[i] *= if i < self.attack_samples {
+                self.lookahead_buffer[self.samplerate - self.attack_samples + i]
             } else {
-                input[i - self.attack]
+                input[i - self.attack_samples]
             }
         }
 
@@ -186,12 +177,12 @@ impl Filter for LookaheadLimiter {
         } = config
         {
             let release;
-            (self.limit, self.attack, release, self.epsilon, self.alpha) =
+            (self.limit, self.attack_samples, release, self.epsilon, self.alpha) =
                 LookaheadLimiter::configure(&config, self.samplerate);
 
             debug!(
                 "Updated lookahead limiter '{}', limit dB: {}, linear: {}, attack/lookahead: {} samples, release: {} samples, alpha: {}",
-                self.name, config.limit, self.limit, self.attack, release, self.alpha
+                self.name, config.limit, self.limit, self.attack_samples, release, self.alpha
             );
         } else {
             panic!("Invalid config change!");
@@ -199,9 +190,14 @@ impl Filter for LookaheadLimiter {
     }
 }
 
-pub fn validate_config(config: &config::LookaheadLimiterParameters) -> Res<()> {
-    if config.attack <= 0.0 {
-        let msg = "Attack time must be positive.";
+pub fn validate_config(config: &config::LookaheadLimiterParameters, samplerate: usize) -> Res<()> {
+    if config.attack < 0.0 {
+        let msg = "Attack time must be greater than or equal to 0.";
+        return Err(config::ConfigError::new(msg).into());
+    }
+    let attack_samples = time_to_samples(config.attack, config.unit(), samplerate).round() as usize;
+    if attack_samples > samplerate {
+        let msg = "Lookahead limiter attack time must be less than or equal to 1 second.";
         return Err(config::ConfigError::new(msg).into());
     }
     if config.release < 0.0 {
@@ -251,22 +247,29 @@ mod tests {
 
     /// Zero attack and release should behave like a peak limiter
     #[test]
-    fn test_lookahead_limiter_peak() {
+    fn test_lookahead_limiter_same_as_limiter() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
             unit: TimeUnit::Samples,
             attack: 0.0,
             release: 0.0,
         };
-        let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
-        let mut input = vec![
-            1.0, 1.0, 1.0, 1.0, 2.0, -2.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-        ];
-        let expected = vec![
-            1.0, 1.0, 1.0, 1.0, 1.0, -1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
-        ];
-        limiter.apply_lookahead_limiter(&mut input);
-        assert_close(&input, &expected, 1e-6);
+        let mut lookahead_limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
+        let limiter = crate::filters::limiter::Limiter::from_config(
+            "test",
+            config::LimiterParameters {
+                soft_clip: None,
+                clip_limit: 0.0,
+            },
+        );
+
+        let mut lookahead_input = vec![0.5, 1.0, 2.0, -2.0, -1.0, -0.5, 1.5, -1.5, 0.0];
+        let mut limiter_input = lookahead_input.clone();
+
+        lookahead_limiter.apply_lookahead_limiter(&mut lookahead_input);
+        limiter.apply_clip(&mut limiter_input);
+
+        assert_eq!(lookahead_input, limiter_input);
     }
 
     #[test]
@@ -274,14 +277,14 @@ mod tests {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
             unit: TimeUnit::Samples,
-            attack: 4.0,
+            attack: 2.0,
             release: 0.0,
         };
         let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
-        let mut input = vec![2.0, 2.0, 2.0, 2.0, 2.0];
+        let mut input = vec![1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0];
         limiter.apply_lookahead_limiter(&mut input);
         for &val in &input {
-            assert!(val.abs() <= 1.0 + 1e-6);
+            assert!(val.abs() <= 1.0);
         }
     }
 
@@ -306,14 +309,13 @@ mod tests {
     }
 
     #[test]
-    fn test_lookahead_limiter_attack_clamped_to_one_second() {
+    fn test_lookahead_limiter_attack_over_one_second_rejected() {
         let config = config::LookaheadLimiterParameters {
             limit: 0.0,
             unit: TimeUnit::Samples,
             attack: 48001.0,
             release: 4.0,
         };
-        let limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
-        assert_eq!(limiter.attack, 48000);
+        assert!(validate_config(&config, 48000).is_err());
     }
 }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -21,6 +21,7 @@ pub mod diffeq;
 pub mod dither;
 pub mod fftconv;
 pub mod limiter;
+pub mod lookahead_limiter;
 pub mod loudness;
 
 use crate::config;
@@ -230,6 +231,9 @@ pub fn validate_filter(fs: usize, filter_config: &config::Filter) -> Res<()> {
             biquadcombo::validate_config(fs, parameters)
         }
         config::Filter::Limiter { parameters, .. } => limiter::validate_config(parameters),
+        config::Filter::LookaheadLimiter { parameters, .. } => {
+            lookahead_limiter::validate_config(parameters)
+        }
     }
 }
 

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -28,6 +28,8 @@ pub mod dither;
 pub mod fftconv;
 /// Hard-clipping limiter filter.
 pub mod limiter;
+/// Lookahead limiter.
+pub mod lookahead_limiter;
 /// Loudness compensation filter.
 pub mod loudness;
 
@@ -247,6 +249,9 @@ pub fn validate_filter(fs: usize, filter_config: &config::Filter) -> Res<()> {
             biquadcombo::validate_config(fs, parameters)
         }
         config::Filter::Limiter { parameters, .. } => limiter::validate_config(parameters),
+        config::Filter::LookaheadLimiter { parameters, .. } => {
+            lookahead_limiter::validate_config(parameters)
+        }
     }
 }
 

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -250,7 +250,7 @@ pub fn validate_filter(fs: usize, filter_config: &config::Filter) -> Res<()> {
         }
         config::Filter::Limiter { parameters, .. } => limiter::validate_config(parameters),
         config::Filter::LookaheadLimiter { parameters, .. } => {
-            lookahead_limiter::validate_config(parameters)
+            lookahead_limiter::validate_config(parameters, fs)
         }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -96,6 +96,13 @@ impl FilterGroup {
                 config::Filter::Limiter { parameters, .. } => {
                     Box::new(filters::limiter::Limiter::from_config(name, parameters))
                 }
+                config::Filter::LookaheadLimiter { parameters, .. } => {
+                    Box::new(filters::lookahead_limiter::LookaheadLimiter::from_config(
+                        name,
+                        parameters,
+                        sample_freq,
+                    ))
+                }
             };
             filters.push(filter);
         }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -14,8 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use crate::ProcessingParameters;
-use crate::Res;
 use crate::audiochunk::AudioChunk;
 use crate::config;
 use crate::filters;
@@ -23,6 +21,8 @@ use crate::filters::Filter;
 use crate::mixer;
 use crate::processors;
 use crate::processors::Processor;
+use crate::ProcessingParameters;
+use crate::Res;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -101,6 +101,7 @@ impl FilterGroup {
                         name,
                         parameters,
                         sample_freq,
+                        waveform_length,
                     ))
                 }
             };

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -14,8 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use crate::ProcessingParameters;
-use crate::Res;
 use crate::audiochunk::AudioChunk;
 use crate::config;
 use crate::filters;
@@ -23,6 +21,8 @@ use crate::filters::Filter;
 use crate::mixer;
 use crate::processors;
 use crate::processors::Processor;
+use crate::ProcessingParameters;
+use crate::Res;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -102,6 +102,7 @@ impl FilterGroup {
                         name,
                         parameters,
                         sample_freq,
+                        waveform_length,
                     ))
                 }
             };

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -97,6 +97,13 @@ impl FilterGroup {
                 config::Filter::Limiter { parameters, .. } => {
                     Box::new(filters::limiter::Limiter::from_config(name, parameters))
                 }
+                config::Filter::LookaheadLimiter { parameters, .. } => {
+                    Box::new(filters::lookahead_limiter::LookaheadLimiter::from_config(
+                        name,
+                        parameters,
+                        sample_freq,
+                    ))
+                }
             };
             filters.push(filter);
         }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -14,6 +14,8 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
+use crate::ProcessingParameters;
+use crate::Res;
 use crate::audiochunk::AudioChunk;
 use crate::config;
 use crate::filters;
@@ -21,8 +23,6 @@ use crate::filters::Filter;
 use crate::mixer;
 use crate::processors;
 use crate::processors::Processor;
-use crate::ProcessingParameters;
-use crate::Res;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -21,4 +21,5 @@ pub mod rate_controller;
 pub mod resampling;
 pub mod ringbuffer;
 pub mod stash;
+pub mod time;
 pub mod wavtools;

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -1,0 +1,34 @@
+// CamillaDSP - A flexible tool for processing audio
+// Copyright (C) 2026 Henrik Enquist
+//
+// This file is part of CamillaDSP.
+//
+// CamillaDSP is free software; you can redistribute it and/or modify it
+// under the terms of either:
+//
+// a) the GNU General Public License version 3,
+//    or
+// b) the Mozilla Public License Version 2.0.
+//
+// You should have received copies of the GNU General Public License and the
+// Mozilla Public License along with this program. If not, see
+// <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
+
+use crate::PrcFmt;
+use crate::config::TimeUnit;
+
+/// Convert a time value with a given unit to a number of samples (floating point).
+/// The result is exact, not rounded.
+pub fn time_to_samples(value: PrcFmt, unit: TimeUnit, samplerate: usize) -> PrcFmt {
+    match unit {
+        TimeUnit::Microseconds => value / 1_000_000.0 * samplerate as PrcFmt,
+        TimeUnit::Milliseconds => value / 1000.0 * samplerate as PrcFmt,
+        TimeUnit::Millimetres => value / 1000.0 * samplerate as PrcFmt / 343.0,
+        TimeUnit::Samples => value,
+    }
+}
+
+/// Convert a time value with a given unit to a number of samples, rounded up to the nearest integer.
+pub fn time_to_samples_ceil(value: PrcFmt, unit: TimeUnit, samplerate: usize) -> usize {
+    time_to_samples(value, unit, samplerate).ceil() as usize
+}

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -27,8 +27,3 @@ pub fn time_to_samples(value: PrcFmt, unit: TimeUnit, samplerate: usize) -> PrcF
         TimeUnit::Samples => value,
     }
 }
-
-/// Convert a time value with a given unit to a number of samples, rounded up to the nearest integer.
-pub fn time_to_samples_ceil(value: PrcFmt, unit: TimeUnit, samplerate: usize) -> usize {
-    time_to_samples(value, unit, samplerate).ceil() as usize
-}

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -14,8 +14,8 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use crate::PrcFmt;
 use crate::config::TimeUnit;
+use crate::PrcFmt;
 
 /// Convert a time value with a given unit to a number of samples (floating point).
 /// The result is exact, not rounded.
@@ -25,5 +25,15 @@ pub fn time_to_samples(value: PrcFmt, unit: TimeUnit, samplerate: usize) -> PrcF
         TimeUnit::Milliseconds => value / 1000.0 * samplerate as PrcFmt,
         TimeUnit::Millimetres => value / 1000.0 * samplerate as PrcFmt / 343.0,
         TimeUnit::Samples => value,
+    }
+}
+
+/// Convert a time value with a given unit to seconds.
+pub fn time_to_seconds(value: PrcFmt, unit: TimeUnit, samplerate: usize) -> PrcFmt {
+    match unit {
+        TimeUnit::Microseconds => value / 1_000_000.0,
+        TimeUnit::Milliseconds => value / 1000.0,
+        TimeUnit::Millimetres => value / 1000.0 / 343.0,
+        TimeUnit::Samples => value / samplerate as PrcFmt,
     }
 }

--- a/src/utils/time.rs
+++ b/src/utils/time.rs
@@ -14,8 +14,8 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use crate::config::TimeUnit;
 use crate::PrcFmt;
+use crate::config::TimeUnit;
 
 /// Convert a time value with a given unit to a number of samples (floating point).
 /// The result is exact, not rounded.
@@ -25,15 +25,5 @@ pub fn time_to_samples(value: PrcFmt, unit: TimeUnit, samplerate: usize) -> PrcF
         TimeUnit::Milliseconds => value / 1000.0 * samplerate as PrcFmt,
         TimeUnit::Millimetres => value / 1000.0 * samplerate as PrcFmt / 343.0,
         TimeUnit::Samples => value,
-    }
-}
-
-/// Convert a time value with a given unit to seconds.
-pub fn time_to_seconds(value: PrcFmt, unit: TimeUnit, samplerate: usize) -> PrcFmt {
-    match unit {
-        TimeUnit::Microseconds => value / 1_000_000.0,
-        TimeUnit::Milliseconds => value / 1000.0,
-        TimeUnit::Millimetres => value / 1000.0 / 343.0,
-        TimeUnit::Samples => value / samplerate as PrcFmt,
     }
 }


### PR DESCRIPTION
This PR adds a new filter type: Lookahead Limiter.

It delays the signal by the attack time, detects peaks in advance, uses linear gain reduction ramp 
to reach the required level exactly when the peak arrives. After the peak passes, the gain
is restored using an exponential release curve.

At least one second long buffer is always reserved to avoid runtime buffer growth, attack time is limited to this maximum.