### PR TITLE
Added ReadConfigJson and ValidateConfigJson ws commands

### DIFF
--- a/src/socketserver.rs
+++ b/src/socketserver.rs
@@ -98,8 +98,10 @@ enum WsCommand {
     GetConfigDescription,
     GetPreviousConfig,
     ReadConfig(String),
+    ReadConfigJson(String),
     ReadConfigFile(String),
     ValidateConfig(String),
+    ValidateConfigJson(String),
     GetConfigJson,
     GetConfigFilePath,
     GetStateFilePath,
@@ -218,6 +220,10 @@ enum WsReply {
         result: WsResult,
         value: String,
     },
+    GetConfigJson {
+        result: WsResult,
+        value: String,
+    },
     GetConfigValue {
         result: WsResult,
         value: serde_json::Value,
@@ -238,6 +244,10 @@ enum WsReply {
         result: WsResult,
         value: String,
     },
+    ReadConfigJson {
+        result: WsResult,
+        value: String,
+    },
     ReadConfigFile {
         result: WsResult,
         value: String,
@@ -246,7 +256,7 @@ enum WsReply {
         result: WsResult,
         value: String,
     },
-    GetConfigJson {
+    ValidateConfigJson {
         result: WsResult,
         value: String,
     },
@@ -1467,6 +1477,21 @@ fn handle_command(
                 }
             }
         }
+        WsCommand::ReadConfigJson(config_json) => {
+            match serde_json::from_str::<config::Configuration>(&config_json) {
+                Ok(conf) => Some(WsReply::ReadConfigJson {
+                    result: WsResult::Ok,
+                    value: serde_json::to_string(&conf).unwrap(),
+                }),
+                Err(error) => {
+                    error!("Error reading config: {}", error);
+                    Some(WsReply::ReadConfigJson {
+                        result: WsResult::ConfigReadError(error.to_string()),
+                        value: error.to_string(),
+                    })
+                }
+            }
+        }
         WsCommand::ReadConfigFile(path) => match config::load_config(&path) {
             Ok(conf) => Some(WsReply::ReadConfigFile {
                 result: WsResult::Ok,
@@ -1498,6 +1523,30 @@ fn handle_command(
                 Err(error) => {
                     debug!("Config error: {error}");
                     Some(WsReply::ValidateConfig {
+                        result: WsResult::ConfigReadError(error.to_string()),
+                        value: error.to_string(),
+                    })
+                }
+            }
+        }
+        WsCommand::ValidateConfigJson(config_json) => {
+            match serde_json::from_str::<config::Configuration>(&config_json) {
+                Ok(mut conf) => match config::validate_config(&mut conf, None) {
+                    Ok(()) => Some(WsReply::ValidateConfigJson {
+                        result: WsResult::Ok,
+                        value: serde_json::to_string(&conf).unwrap(),
+                    }),
+                    Err(error) => {
+                        debug!("Config error: {error}");
+                        Some(WsReply::ValidateConfigJson {
+                            result: WsResult::ConfigValidationError(error.to_string()),
+                            value: error.to_string(),
+                        })
+                    }
+                },
+                Err(error) => {
+                    debug!("Config error: {error}");
+                    Some(WsReply::ValidateConfigJson {
                         result: WsResult::ConfigReadError(error.to_string()),
                         value: error.to_string(),
                     })

--- a/websocket.md
+++ b/websocket.md
@@ -269,8 +269,10 @@ These commands are used to check the syntax and contents of configurations. They
 - `ReadConfig` : read the provided config (as a yaml string) and check it for yaml syntax errors.
   * If the config is ok, it returns the config with all optional fields filled with their default values.
     If there are problems, the status will be Error and the return value an error message.
+- `ReadConfigJson` : same as ReadConfig but reads the provided config as a json string.
 - `ReadConfigFile` : same as ReadConfig but reads the config from the file at the given path.
 - `ValidateConfig`: same as ReadConfig but performs more extensive checks to ensure the configuration can be applied.
+- `ValidateConfigJson`: same as ReadConfigJson but performs more extensive checks to ensure the configuration can be applied.
 
 ### Audio device listing
 


### PR DESCRIPTION
Hi there !
Thanks you so much for this wonderful piece of software
This pull request is about making the the WebSocket scheme more coherent, Jsonizing what wasn't already.

I have a use case in a current open-source [project](https://codeberg.org/jean-paul-sartres/camille) where in only get/set the config through the websocket API, being able to validate it using the same scheme seemed like a nice to have.
I used it to test this patch.

Please let me know if you need any change,
Have a nice day