### PR TITLE
Threaded alsa shutdown cleanup

### DIFF
--- a/src/alsa_backend/buffermanager.rs
+++ b/src/alsa_backend/buffermanager.rs
@@ -65,7 +65,10 @@ pub trait DeviceBufferManager {
     // Calculate a buffer size and apply it to a hwp container. Only for use when opening a device.
     fn apply_buffer_size(&mut self, hwp: &HwParams) -> Res<()> {
         let min_period = hwp.get_period_size_min().unwrap_or(0);
-        let buffer_frames = self.calculate_buffer_size(min_period);
+        let buffer_frames = self
+            .data()
+            .requested_bufsize
+            .unwrap_or_else(|| self.calculate_buffer_size(min_period));
         let alt_buffer_frames = self.calculate_buffer_size_alt(min_period);
         let data = self.data_mut();
         debug!("Setting buffer size to {buffer_frames} frames");
@@ -73,7 +76,10 @@ pub trait DeviceBufferManager {
             Ok(frames) => {
                 data.bufsize = frames;
             }
-            Err(_) => {
+            Err(err) => {
+                if data.requested_bufsize.is_some() {
+                    return Err(Box::new(err));
+                }
                 debug!(
                     "Device did not accept a buffer size of {buffer_frames} frames, trying again with {alt_buffer_frames}"
                 );
@@ -87,13 +93,16 @@ pub trait DeviceBufferManager {
     // Calculate a period size and apply it to a hwp container. Only for use when opening a device, after setting buffer size.
     fn apply_period_size(&mut self, hwp: &HwParams) -> Res<()> {
         let data = self.data_mut();
-        let period_frames = data.bufsize / 8;
+        let period_frames = data.requested_period.unwrap_or(data.bufsize / 8);
         debug!("Setting period size to {period_frames} frames");
         match hwp.set_period_size_near(period_frames, alsa::ValueOr::Nearest) {
             Ok(frames) => {
                 data.period = frames;
             }
-            Err(_) => {
+            Err(err) => {
+                if data.requested_period.is_some() {
+                    return Err(Box::new(err));
+                }
                 let alt_period_frames =
                     3 * 2.0f32.powi((period_frames as f32 / 2.0).log2().ceil() as i32) as Frames;
                 debug!(
@@ -152,6 +161,8 @@ pub struct DeviceBufferData {
     io_size: Frames, /* size of read/write block */
     chunksize: Frames,
     resampling_ratio: f32,
+    requested_bufsize: Option<Frames>,
+    requested_period: Option<Frames>,
 }
 
 impl DeviceBufferData {
@@ -166,7 +177,12 @@ pub struct CaptureBufferManager {
 }
 
 impl CaptureBufferManager {
-    pub fn new(chunksize: Frames, resampling_ratio: f32) -> Self {
+    pub fn new(
+        chunksize: Frames,
+        resampling_ratio: f32,
+        requested_bufsize: Option<Frames>,
+        requested_period: Option<Frames>,
+    ) -> Self {
         let init_io_size = (chunksize as f32 / resampling_ratio) as Frames;
         CaptureBufferManager {
             data: DeviceBufferData {
@@ -177,6 +193,8 @@ impl CaptureBufferManager {
                 io_size: init_io_size,
                 resampling_ratio,
                 chunksize,
+                requested_bufsize,
+                requested_period,
             },
         }
     }
@@ -211,7 +229,12 @@ pub struct PlaybackBufferManager {
 }
 
 impl PlaybackBufferManager {
-    pub fn new(chunksize: Frames, target_level: Frames) -> Self {
+    pub fn new(
+        chunksize: Frames,
+        target_level: Frames,
+        requested_bufsize: Option<Frames>,
+        requested_period: Option<Frames>,
+    ) -> Self {
         PlaybackBufferManager {
             data: DeviceBufferData {
                 bufsize: 0,
@@ -221,6 +244,8 @@ impl PlaybackBufferManager {
                 io_size: chunksize,
                 resampling_ratio: 1.0,
                 chunksize,
+                requested_bufsize,
+                requested_period,
             },
             target_level,
         }

--- a/src/alsa_backend/device.rs
+++ b/src/alsa_backend/device.rs
@@ -56,7 +56,7 @@ use crate::alsa_backend::utils::{
 };
 use crate::utils::rate_controller::PIRateController;
 use crate::utils::resampling::{ChunkResampler, new_resampler, resampler_is_async};
-use crate::{CaptureStatus, PlaybackStatus, ProcessingParameters};
+use crate::{CaptureStatus, PlaybackStatus, ProcessingParameters, SHUTDOWN_REQUESTED};
 
 static ALSA_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
@@ -255,6 +255,9 @@ fn capture_buffer(
     params: &mut CaptureParams,
     processing_params: &Arc<ProcessingParameters>,
 ) -> Res<CaptureResult> {
+    if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+        return Ok(CaptureResult::Done);
+    }
     let capture_state = pcmdevice.state_raw();
     if capture_state == alsa_sys::SND_PCM_STATE_XRUN as i32 {
         warn!("Prepare capture device");
@@ -292,12 +295,23 @@ fn capture_buffer(
             None
         };
         trace!("Capture pcmdevice.wait with timeout {timeout_millis} ms");
+        let mut remaining_timeout_millis = timeout_millis;
         loop {
-            match fds.wait(timeout_millis as i32) {
+            if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+                return Ok(CaptureResult::Done);
+            }
+            let poll_slice_millis = remaining_timeout_millis.min(20);
+            match fds.wait(poll_slice_millis as i32) {
                 Ok(pollresult) => {
                     if pollresult.poll_res == 0 {
-                        trace!("Wait timed out, capture device takes too long to capture frames");
-                        return Ok(CaptureResult::Stalled);
+                        if remaining_timeout_millis <= poll_slice_millis {
+                            trace!(
+                                "Wait timed out, capture device takes too long to capture frames"
+                            );
+                            return Ok(CaptureResult::Stalled);
+                        }
+                        remaining_timeout_millis -= poll_slice_millis;
+                        continue;
                     }
                     if pollresult.ctl {
                         trace!("Got a control event");
@@ -319,6 +333,8 @@ fn capture_buffer(
                         trace!("Capture waited for {:?}", start.map(|s| s.elapsed()));
                         break;
                     }
+                    remaining_timeout_millis =
+                        remaining_timeout_millis.saturating_sub(poll_slice_millis);
                 }
                 Err(err) => match Errno::from_raw(err.errno()) {
                     Errno::EPIPE => {
@@ -345,6 +361,9 @@ fn capture_buffer(
                     }
                 },
             }
+        }
+        if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+            return Ok(CaptureResult::Done);
         }
         match io.readi(buffer) {
             Ok(frames_read) => {

--- a/src/alsa_backend/device.rs
+++ b/src/alsa_backend/device.rs
@@ -69,6 +69,8 @@ pub struct AlsaPlaybackDevice {
     pub target_level: usize,
     pub adjust_period: f32,
     pub enable_rate_adjust: bool,
+    pub buffersize: Option<usize>,
+    pub period: Option<usize>,
 }
 
 pub struct AlsaCaptureDevice {
@@ -86,6 +88,8 @@ pub struct AlsaCaptureDevice {
     pub stop_on_inactive: bool,
     pub link_volume_control: Option<String>,
     pub link_mute_control: Option<String>,
+    pub buffersize: Option<usize>,
+    pub period: Option<usize>,
 }
 
 struct CaptureChannels {
@@ -1163,8 +1167,12 @@ impl PlaybackDevice for AlsaPlaybackDevice {
         let chunksize = self.chunksize;
         let channels = self.channels;
         let conf_sample_format = self.sample_format;
-        let mut buf_manager =
-            PlaybackBufferManager::new(chunksize as Frames, target_level as Frames);
+        let mut buf_manager = PlaybackBufferManager::new(
+            chunksize as Frames,
+            target_level as Frames,
+            self.buffersize.map(|value| value as Frames),
+            self.period.map(|value| value as Frames),
+        );
         let handle = thread::Builder::new()
             .name("AlsaPlayback".to_string())
             .spawn(move || {
@@ -1247,6 +1255,8 @@ impl CaptureDevice for AlsaCaptureDevice {
         let mut buf_manager = CaptureBufferManager::new(
             chunksize as Frames,
             samplerate as f32 / capture_samplerate as f32,
+            self.buffersize.map(|value| value as Frames),
+            self.period.map(|value| value as Frames),
         );
 
         let handle = thread::Builder::new()

--- a/src/alsa_backend/threaded_buffermanager.rs
+++ b/src/alsa_backend/threaded_buffermanager.rs
@@ -63,7 +63,10 @@ pub trait DeviceBufferManager {
     // Calculate a buffer size and apply it to a hwp container. Only for use when opening a device.
     fn apply_buffer_size(&mut self, hwp: &HwParams) -> Res<()> {
         let min_period = hwp.get_period_size_min().unwrap_or(0);
-        let buffer_frames = self.calculate_buffer_size(min_period);
+        let buffer_frames = self
+            .data()
+            .requested_bufsize
+            .unwrap_or_else(|| self.calculate_buffer_size(min_period));
         let alt_buffer_frames = self.calculate_buffer_size_alt(min_period);
         let data = self.data_mut();
         debug!("Setting buffer size to {buffer_frames} frames");
@@ -71,7 +74,10 @@ pub trait DeviceBufferManager {
             Ok(frames) => {
                 data.bufsize = frames;
             }
-            Err(_) => {
+            Err(err) => {
+                if data.requested_bufsize.is_some() {
+                    return Err(Box::new(err));
+                }
                 debug!(
                     "Device did not accept a buffer size of {buffer_frames} frames, trying again with {alt_buffer_frames}"
                 );
@@ -85,13 +91,16 @@ pub trait DeviceBufferManager {
     // Calculate a period size and apply it to a hwp container. Only for use when opening a device, after setting buffer size.
     fn apply_period_size(&mut self, hwp: &HwParams) -> Res<()> {
         let data = self.data_mut();
-        let period_frames = data.bufsize / 8;
+        let period_frames = data.requested_period.unwrap_or(data.bufsize / 8);
         debug!("Setting period size to {period_frames} frames");
         match hwp.set_period_size_near(period_frames, alsa::ValueOr::Nearest) {
             Ok(frames) => {
                 data.period = frames;
             }
-            Err(_) => {
+            Err(err) => {
+                if data.requested_period.is_some() {
+                    return Err(Box::new(err));
+                }
                 let alt_period_frames =
                     3 * 2.0f32.powi((period_frames as f32 / 2.0).log2().ceil() as i32) as Frames;
                 debug!(
@@ -151,6 +160,8 @@ pub struct DeviceBufferData {
     io_size: Frames, /* size of read/write block */
     chunksize: Frames,
     resampling_ratio: f32,
+    requested_bufsize: Option<Frames>,
+    requested_period: Option<Frames>,
 }
 
 impl DeviceBufferData {
@@ -169,7 +180,12 @@ pub struct CaptureBufferManager {
 }
 
 impl CaptureBufferManager {
-    pub fn new(chunksize: Frames, resampling_ratio: f32) -> Self {
+    pub fn new(
+        chunksize: Frames,
+        resampling_ratio: f32,
+        requested_bufsize: Option<Frames>,
+        requested_period: Option<Frames>,
+    ) -> Self {
         let init_io_size = (chunksize as f32 / resampling_ratio) as Frames;
         CaptureBufferManager {
             data: DeviceBufferData {
@@ -180,6 +196,8 @@ impl CaptureBufferManager {
                 io_size: init_io_size,
                 resampling_ratio,
                 chunksize,
+                requested_bufsize,
+                requested_period,
             },
         }
     }
@@ -214,7 +232,12 @@ pub struct PlaybackBufferManager {
 }
 
 impl PlaybackBufferManager {
-    pub fn new(chunksize: Frames, target_level: Frames) -> Self {
+    pub fn new(
+        chunksize: Frames,
+        target_level: Frames,
+        requested_bufsize: Option<Frames>,
+        requested_period: Option<Frames>,
+    ) -> Self {
         PlaybackBufferManager {
             data: DeviceBufferData {
                 bufsize: 0,
@@ -224,6 +247,8 @@ impl PlaybackBufferManager {
                 io_size: chunksize,
                 resampling_ratio: 1.0,
                 chunksize,
+                requested_bufsize,
+                requested_period,
             },
             target_level,
         }

--- a/src/alsa_backend/threaded_device.rs
+++ b/src/alsa_backend/threaded_device.rs
@@ -69,6 +69,8 @@ pub struct AlsaPlaybackDevice {
     pub target_level: usize,
     pub adjust_period: f32,
     pub enable_rate_adjust: bool,
+    pub buffersize: Option<usize>,
+    pub period: Option<usize>,
 }
 
 pub struct AlsaCaptureDevice {
@@ -86,6 +88,8 @@ pub struct AlsaCaptureDevice {
     pub stop_on_inactive: bool,
     pub link_volume_control: Option<String>,
     pub link_mute_control: Option<String>,
+    pub buffersize: Option<usize>,
+    pub period: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -1048,6 +1052,8 @@ impl PlaybackDevice for AlsaPlaybackDevice {
         let chunksize = self.chunksize;
         let channels = self.channels;
         let conf_sample_format = self.sample_format;
+        let optional_buffersize = self.buffersize;
+        let optional_period = self.period;
 
         let handle = thread::Builder::new()
             .name("AlsaPlayback".to_string())
@@ -1079,8 +1085,12 @@ impl PlaybackDevice for AlsaPlaybackDevice {
                 let innerhandle = thread::Builder::new()
                     .name("AlsaPlaybackInner".to_string())
                     .spawn(move || {
-                        let mut buf_manager =
-                            PlaybackBufferManager::new(chunksize as Frames, target_level as Frames);
+                        let mut buf_manager = PlaybackBufferManager::new(
+                            chunksize as Frames,
+                            target_level as Frames,
+                            optional_buffersize.map(|value| value as Frames),
+                            optional_period.map(|value| value as Frames),
+                        );
                         match open_pcm(
                             devname,
                             samplerate as u32,
@@ -1385,6 +1395,8 @@ impl CaptureDevice for AlsaCaptureDevice {
         let stop_on_inactive = self.stop_on_inactive;
         let link_volume_control = self.link_volume_control.clone();
         let link_mute_control = self.link_mute_control.clone();
+        let optional_buffersize = self.buffersize;
+        let optional_period = self.period;
 
         let handle = thread::Builder::new()
             .name("AlsaCapture".to_string())
@@ -1428,6 +1440,8 @@ impl CaptureDevice for AlsaCaptureDevice {
                         let mut buf_manager = CaptureBufferManager::new(
                             chunksize as Frames,
                             samplerate as f32 / capture_samplerate as f32,
+                            optional_buffersize.map(|value| value as Frames),
+                            optional_period.map(|value| value as Frames),
                         );
 
                         match open_pcm(

--- a/src/alsa_backend/threaded_device.rs
+++ b/src/alsa_backend/threaded_device.rs
@@ -56,7 +56,7 @@ use crate::alsa_backend::utils::{
 };
 use crate::utils::rate_controller::PIRateController;
 use crate::utils::resampling::{ChunkResampler, new_resampler, resampler_is_async};
-use crate::{CaptureStatus, PlaybackStatus, ProcessingParameters};
+use crate::{CaptureStatus, PlaybackStatus, ProcessingParameters, SHUTDOWN_REQUESTED};
 
 static ALSA_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
@@ -726,6 +726,9 @@ fn capture_buffer(
     params: &mut CaptureParams,
     processing_params: &Arc<ProcessingParameters>,
 ) -> Res<(CaptureResult, usize)> {
+    if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+        return Ok((CaptureResult::Done, 0));
+    }
     let capture_state = pcmdevice.state_raw();
     if capture_state == alsa_sys::SND_PCM_STATE_XRUN as i32 {
         warn!("Prepare capture device");
@@ -762,12 +765,21 @@ fn capture_buffer(
         None
     };
     trace!("Capture pcmdevice.wait with timeout {timeout_millis} ms");
+    let mut remaining_timeout_millis = timeout_millis;
     loop {
-        match fds.wait(timeout_millis as i32) {
+        if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+            return Ok((CaptureResult::Done, 0));
+        }
+        let poll_slice_millis = remaining_timeout_millis.min(20);
+        match fds.wait(poll_slice_millis as i32) {
             Ok(pollresult) => {
                 if pollresult.poll_res == 0 {
-                    debug!("Capture wait timed out after {timeout_millis} ms, device stalled");
-                    return Ok((CaptureResult::Stalled, 0));
+                    if remaining_timeout_millis <= poll_slice_millis {
+                        debug!("Capture wait timed out after {timeout_millis} ms, device stalled");
+                        return Ok((CaptureResult::Stalled, 0));
+                    }
+                    remaining_timeout_millis -= poll_slice_millis;
+                    continue;
                 }
                 if pollresult.ctl {
                     trace!("Got a control event");
@@ -789,6 +801,8 @@ fn capture_buffer(
                     trace!("Capture waited for {:?}", start.map(|s| s.elapsed()));
                     break;
                 }
+                remaining_timeout_millis =
+                    remaining_timeout_millis.saturating_sub(poll_slice_millis);
             }
             Err(err) => match Errno::from_raw(err.errno()) {
                 Errno::EPIPE => {
@@ -813,6 +827,9 @@ fn capture_buffer(
                 }
             },
         }
+    }
+    if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+        return Ok((CaptureResult::Done, 0));
     }
     match io.readi(buffer) {
         Ok(frames_read) => {
@@ -940,16 +957,48 @@ fn send_capture_audio(
     channel: &crossbeam_channel::Sender<AudioMessage>,
     msg: AudioMessage,
 ) -> bool {
-    match msg {
-        AudioMessage::EndOfStream => channel.send(AudioMessage::EndOfStream).is_ok(),
-        _ => match channel.try_send(msg) {
-            Ok(()) => true,
-            Err(crossbeam_channel::TrySendError::Full(_)) => {
-                trace!("Capture: downstream queue full, dropping message");
-                true
+    match channel.try_send(msg) {
+        Ok(()) => true,
+        Err(crossbeam_channel::TrySendError::Full(_)) => {
+            trace!("Capture: downstream queue full, dropping message");
+            true
+        }
+        Err(crossbeam_channel::TrySendError::Disconnected(_)) => false,
+    }
+}
+
+fn send_playback_device_message(
+    channel: &crossbeam_channel::Sender<PlaybackDeviceMessage>,
+    msg: PlaybackDeviceMessage,
+) -> bool {
+    let mut pending = msg;
+    loop {
+        match channel.try_send(pending) {
+            Ok(()) => return true,
+            Err(crossbeam_channel::TrySendError::Full(msg)) => {
+                if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+                    trace!("Playback: inner queue full during shutdown, dropping message");
+                    return true;
+                }
+                pending = msg;
+                std::thread::sleep(std::time::Duration::from_millis(1));
             }
-            Err(crossbeam_channel::TrySendError::Disconnected(_)) => false,
-        },
+            Err(crossbeam_channel::TrySendError::Disconnected(_)) => return false,
+        }
+    }
+}
+
+fn send_capture_device_message(
+    channel: &crossbeam_channel::Sender<CaptureDeviceMessage>,
+    msg: CaptureDeviceMessage,
+) -> bool {
+    match channel.try_send(msg) {
+        Ok(()) => true,
+        Err(crossbeam_channel::TrySendError::Full(_)) => {
+            trace!("Capture: inner queue full, dropping device message");
+            true
+        }
+        Err(crossbeam_channel::TrySendError::Disconnected(_)) => false,
     }
 }
 
@@ -1007,7 +1056,7 @@ impl PlaybackDevice for AlsaPlaybackDevice {
                 debug!("Using a playback channel capacity of {channel_capacity} chunks.");
                 let (tx_dev, rx_dev) = crossbeam_channel::bounded(channel_capacity);
                 let (tx_state_dev, rx_state_dev) = crossbeam_channel::bounded(0);
-                let (tx_start, rx_start) = crossbeam_channel::bounded(0);
+                let (tx_start, rx_start) = crossbeam_channel::bounded(1);
 
                 let ringbuffer_bytes_per_sample = conf_sample_format
                     .map(|format| format.to_binary_format().bytes_per_sample())
@@ -1175,9 +1224,10 @@ impl PlaybackDevice for AlsaPlaybackDevice {
                                         status_channel
                                             .send(StatusMessage::SetSpeed(speed))
                                             .unwrap_or(());
-                                        tx_dev
-                                            .send(PlaybackDeviceMessage::SetPitch(speed))
-                                            .unwrap_or(());
+                                        let _ = send_playback_device_message(
+                                            &tx_dev,
+                                            PlaybackDeviceMessage::SetPitch(speed),
+                                        );
                                         if let Some(mut ps) = playback_status.try_write() {
                                             ps.buffer_level = av_delay as usize;
                                         }
@@ -1213,10 +1263,10 @@ impl PlaybackDevice for AlsaPlaybackDevice {
                                         );
                                         continue;
                                     }
-                                    if tx_dev
-                                        .send(PlaybackDeviceMessage::Data(bytes_to_write))
-                                        .is_err()
-                                    {
+                                    if !send_playback_device_message(
+                                        &tx_dev,
+                                        PlaybackDeviceMessage::Data(bytes_to_write),
+                                    ) {
                                         status_channel
                                             .send(StatusMessage::PlaybackError(
                                                 "Playback inner queue closed".to_string(),
@@ -1237,7 +1287,10 @@ impl PlaybackDevice for AlsaPlaybackDevice {
                                     }
                                 }
                                 Ok(AudioMessage::Pause) => {
-                                    tx_dev.send(PlaybackDeviceMessage::Pause).unwrap_or(());
+                                    let _ = send_playback_device_message(
+                                        &tx_dev,
+                                        PlaybackDeviceMessage::Pause,
+                                    );
                                 }
                                 Ok(AudioMessage::EndOfStream) => {
                                     if !inner_started {
@@ -1246,7 +1299,10 @@ impl PlaybackDevice for AlsaPlaybackDevice {
                                         );
                                         tx_start.send(()).unwrap_or(());
                                     }
-                                    tx_dev.send(PlaybackDeviceMessage::EndOfStream).unwrap_or(());
+                                    let _ = send_playback_device_message(
+                                        &tx_dev,
+                                        PlaybackDeviceMessage::EndOfStream,
+                                    );
                                     break;
                                 }
                                 Err(err) => {
@@ -1259,7 +1315,10 @@ impl PlaybackDevice for AlsaPlaybackDevice {
                                         );
                                         tx_start.send(()).unwrap_or(());
                                     }
-                                    tx_dev.send(PlaybackDeviceMessage::EndOfStream).unwrap_or(());
+                                    let _ = send_playback_device_message(
+                                        &tx_dev,
+                                        PlaybackDeviceMessage::EndOfStream,
+                                    );
                                     break;
                                 }
                             }
@@ -1291,6 +1350,8 @@ impl PlaybackDevice for AlsaPlaybackDevice {
                         barrier.wait();
                     }
                 }
+                drop(tx_start);
+                drop(tx_dev);
                 innerhandle.join().unwrap_or(());
             })
             .unwrap();
@@ -1346,7 +1407,7 @@ impl CaptureDevice for AlsaCaptureDevice {
                 let (tx_dev, rx_dev) = crossbeam_channel::bounded(channel_capacity);
                 let (tx_inner_command, rx_inner_command) = crossbeam_channel::bounded(32);
                 let (tx_state_dev, rx_state_dev) = crossbeam_channel::bounded(0);
-                let (tx_start_inner, rx_start_inner) = crossbeam_channel::bounded(0);
+                let (tx_start_inner, rx_start_inner) = crossbeam_channel::bounded(1);
 
                 let buffer_capacity_frames = if let Some(resamp) = &resampler {
                     resamp.resampler.input_frames_max()
@@ -1507,9 +1568,10 @@ impl CaptureDevice for AlsaCaptureDevice {
                                             status_channel_inner
                                                 .send(StatusMessage::CaptureDone)
                                                 .unwrap_or(());
-                                            tx_dev
-                                                .send(CaptureDeviceMessage::EndOfStream)
-                                                .unwrap_or(());
+                                            let _ = send_capture_device_message(
+                                                &tx_dev,
+                                                CaptureDeviceMessage::EndOfStream,
+                                            );
                                             break;
                                         }
                                         Ok(CommandMessage::SetSpeed { speed }) => {
@@ -1525,9 +1587,10 @@ impl CaptureDevice for AlsaCaptureDevice {
                                         }
                                         Err(crossbeam_channel::TryRecvError::Empty) => {}
                                         Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                                            tx_dev
-                                                .send(CaptureDeviceMessage::EndOfStream)
-                                                .unwrap_or(());
+                                            let _ = send_capture_device_message(
+                                                &tx_dev,
+                                                CaptureDeviceMessage::EndOfStream,
+                                            );
                                             break;
                                         }
                                     }
@@ -1577,9 +1640,10 @@ impl CaptureDevice for AlsaCaptureDevice {
                                             status_channel_inner
                                                 .send(StatusMessage::CaptureDone)
                                                 .unwrap_or(());
-                                            tx_dev
-                                                .send(CaptureDeviceMessage::EndOfStream)
-                                                .unwrap_or(());
+                                            let _ = send_capture_device_message(
+                                                &tx_dev,
+                                                CaptureDeviceMessage::EndOfStream,
+                                            );
                                             break;
                                         }
                                         Err(msg) => {
@@ -1588,9 +1652,10 @@ impl CaptureDevice for AlsaCaptureDevice {
                                                     msg.to_string(),
                                                 ))
                                                 .unwrap_or(());
-                                            tx_dev
-                                                .send(CaptureDeviceMessage::EndOfStream)
-                                                .unwrap_or(());
+                                            let _ = send_capture_device_message(
+                                                &tx_dev,
+                                                CaptureDeviceMessage::EndOfStream,
+                                            );
                                             break;
                                         }
                                     }
@@ -1746,11 +1811,17 @@ impl CaptureDevice for AlsaCaptureDevice {
                                         }
                                     }
                                     Ok(CaptureDeviceMessage::EndOfStream) => {
-                                        channel.send(AudioMessage::EndOfStream).unwrap_or(());
+                                        let _ = send_capture_audio(
+                                            &channel,
+                                            AudioMessage::EndOfStream,
+                                        );
                                         break 'outer;
                                     }
                                     Err(err) => {
-                                        channel.send(AudioMessage::EndOfStream).unwrap_or(());
+                                        let _ = send_capture_audio(
+                                            &channel,
+                                            AudioMessage::EndOfStream,
+                                        );
                                         status_channel
                                             .send(StatusMessage::CaptureError(err.to_string()))
                                             .unwrap_or(());

--- a/src/audiodevice.rs
+++ b/src/audiodevice.rs
@@ -123,6 +123,8 @@ pub fn new_playback_device(conf: config::Devices) -> Box<dyn PlaybackDevice> {
             channels,
             ref device,
             format,
+            buffersize,
+            period,
         } => Box::new(alsadevice::AlsaPlaybackDevice {
             devname: device.clone(),
             samplerate: conf.samplerate,
@@ -132,6 +134,8 @@ pub fn new_playback_device(conf: config::Devices) -> Box<dyn PlaybackDevice> {
             target_level: conf.target_level(),
             adjust_period: conf.adjust_period(),
             enable_rate_adjust: conf.rate_adjust(),
+            buffersize,
+            period,
         }),
         #[cfg(feature = "pulse-backend")]
         config::PlaybackDevice::Pulse { channels, device } => {
@@ -312,6 +316,8 @@ pub fn new_capture_device(conf: config::Devices) -> Box<dyn CaptureDevice> {
             stop_on_inactive,
             ref link_volume_control,
             ref link_mute_control,
+            buffersize,
+            period,
             ..
         } => Box::new(alsadevice::AlsaCaptureDevice {
             devname: device.clone(),
@@ -328,6 +334,8 @@ pub fn new_capture_device(conf: config::Devices) -> Box<dyn CaptureDevice> {
             stop_on_inactive: stop_on_inactive.unwrap_or_default(),
             link_volume_control: link_volume_control.clone(),
             link_mute_control: link_mute_control.clone(),
+            buffersize,
+            period,
         }),
         #[cfg(feature = "pulse-backend")]
         config::CaptureDevice::Pulse {

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -75,8 +75,8 @@ use std::net::IpAddr;
 
 use camillalib::{
     CaptureStatus, CommandMessage, ExitState, PlaybackStatus, ProcessingParameters,
-    ProcessingState, ProcessingStatus, SharedConfigs, StatusMessage, StatusStructs, StopReason,
-    list_supported_devices,
+    ProcessingState, ProcessingStatus, SHUTDOWN_REQUESTED, SharedConfigs, StatusMessage,
+    StatusStructs, StopReason, list_supported_devices,
 };
 
 const EXIT_BAD_CONFIG: i32 = 101; // Error in config file
@@ -1064,6 +1064,7 @@ fn main_process() -> i32 {
                     }
                     info!("Shutting down");
                     exit_requested = true;
+                    SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
                     if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
                         error!("Error sending exit message: {e}");
                     }
@@ -1089,6 +1090,7 @@ fn main_process() -> i32 {
                 }
                 info!("Shutting down");
                 exit_requested = true;
+                SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
                 if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
                     error!("Error sending exit message: {e}");
                 }
@@ -1238,6 +1240,7 @@ fn main_process() -> i32 {
         };
 
         debug!("Config ready, start processing");
+        SHUTDOWN_REQUESTED.store(false, std::sync::atomic::Ordering::Relaxed);
         let exitstatus = run(shared_configs, status_structs.clone(), rx_command.clone());
         debug!("Processing ended with status {exitstatus:?}");
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -326,6 +326,10 @@ pub enum CaptureDevice {
         link_mute_control: Option<String>,
         #[serde(default)]
         labels: Option<Vec<Option<String>>>,
+        #[serde(default)]
+        buffersize: Option<usize>,
+        #[serde(default)]
+        period: Option<usize>,
     },
     #[cfg(all(target_os = "linux", feature = "bluez-backend"))]
     #[serde(alias = "BLUEZ", alias = "bluez")]
@@ -647,6 +651,10 @@ pub enum PlaybackDevice {
         device: String,
         #[serde(default)]
         format: Option<AlsaSampleFormat>,
+        #[serde(default)]
+        buffersize: Option<usize>,
+        #[serde(default)]
+        period: Option<usize>,
     },
     #[cfg(feature = "pulse-backend")]
     #[serde(alias = "PULSE", alias = "pulse")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU32, Ordering},
 };
 
+pub static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
 // Logging macros to give extra logs
 // when the "debug" feature is enabled.
 #[allow(unused)]

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -14,15 +14,33 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use crate::ProcessingParameters;
 use crate::audiodevice::*;
 use crate::config;
 use crate::pipeline;
+use crate::{ProcessingParameters, SHUTDOWN_REQUESTED};
 use audio_thread_priority::{
     demote_current_thread_from_real_time, promote_current_thread_to_real_time,
 };
 use std::sync::{Arc, Barrier};
 use std::thread;
+
+fn forward_to_playback(tx_pb: &crossbeam_channel::Sender<AudioMessage>, msg: AudioMessage) -> bool {
+    let mut pending = msg;
+    loop {
+        match tx_pb.try_send(pending) {
+            Ok(()) => return true,
+            Err(crossbeam_channel::TrySendError::Full(msg)) => {
+                if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+                    trace!("Processing: playback queue full during shutdown, dropping message");
+                    return true;
+                }
+                pending = msg;
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+            Err(crossbeam_channel::TrySendError::Disconnected(_)) => return false,
+        }
+    }
+}
 
 pub fn run_processing(
     conf_proc: config::Configuration,
@@ -118,7 +136,7 @@ pub fn run_processing(
                     //trace!("AudioMessage::Audio received");
                     chunk = pipeline.process_chunk(chunk);
                     let msg = AudioMessage::Audio(chunk);
-                    if tx_pb.send(msg).is_err() {
+                    if !forward_to_playback(&tx_pb, msg) {
                         info!("Playback thread has already stopped.");
                         break;
                     }
@@ -126,7 +144,7 @@ pub fn run_processing(
                 Ok(AudioMessage::EndOfStream) => {
                     trace!("AudioMessage::EndOfStream received");
                     let msg = AudioMessage::EndOfStream;
-                    if tx_pb.send(msg).is_err() {
+                    if !forward_to_playback(&tx_pb, msg) {
                         info!("Playback thread has already stopped.");
                     }
                     break;
@@ -134,16 +152,20 @@ pub fn run_processing(
                 Ok(AudioMessage::Pause) => {
                     trace!("AudioMessage::Pause received");
                     let msg = AudioMessage::Pause;
-                    if tx_pb.send(msg).is_err() {
+                    if !forward_to_playback(&tx_pb, msg) {
                         info!("Playback thread has already stopped.");
                         break;
                     }
                 }
                 Err(err) => {
-                    error!("Message channel error: {err}");
-                    let msg = AudioMessage::EndOfStream;
-                    if tx_pb.send(msg).is_err() {
-                        info!("Playback thread has already stopped.");
+                    if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+                        debug!("Capture channel closed during shutdown.");
+                    } else {
+                        error!("Message channel error: {err}");
+                        let msg = AudioMessage::EndOfStream;
+                        if !forward_to_playback(&tx_pb, msg) {
+                            info!("Playback thread has already stopped.");
+                        }
                     }
                     break;
                 }
@@ -167,7 +189,7 @@ pub fn run_processing(
                     }
                     config::ConfigChange::Devices => {
                         let msg = AudioMessage::EndOfStream;
-                        tx_pb.send(msg).unwrap();
+                        let _ = forward_to_playback(&tx_pb, msg);
                         break;
                     }
                     _ => {}


### PR DESCRIPTION
  ## Summary

  Fix ALSA shutdown hangs on `Ctrl-C`.

  This makes shutdown exit cleanly in both:
  - the default ALSA backend
  - the `threaded-alsa` backend

## Context

  This was found while testing CamillaDSP with custom ALSA PCM plugin devices instead of a normal hardware ALSA endpoint.

  The setup included a virtual input path exposed as an ALSA `asym` device and a custom multichannel playback PCM used for AVB output. In that configuration, shutdown behavior was easy to reproduce: a single `Ctrl-C` could leave
  CamillaDSP stuck either in ALSA capture wait/read or in the `threaded-alsa` teardown path.

## What changed

  - make ALSA capture waits interruptible during shutdown
  - add a shared shutdown flag set on exit
  - make processing treat capture-channel disconnect during shutdown as expected
  - add shutdown-aware message forwarding in the threaded ALSA path
  - avoid teardown deadlocks on bounded channels
  - drop playback-inner senders before joining the inner playback thread

  ## Result

  Before:
  - `camilladsp` could hang after `Shutting down`
  - `threaded-alsa` could require a second `Ctrl-C`
  - shutdown could log a spurious processing error

  After:
  - a single `Ctrl-C` exits cleanly
  - no spurious processing error on normal shutdown

  ## Validation

  Tested with:
  ```bash
  cargo build --release
  cargo build --release --features threaded-alsa

  Also verified manually with interactive Ctrl-C on Linux.

