### PR TITLE
Check if volume filters missed a vol change

### DIFF
--- a/src/filters/basicfilters.rs
+++ b/src/filters/basicfilters.rs
@@ -31,6 +31,7 @@ use crate::NewValue;
 use crate::PrcFmt;
 use crate::ProcessingParameters;
 use crate::Res;
+use crate::nanos_since_epoch;
 use crate::utils::decibels::gain_from_value;
 
 #[derive(Clone, Debug)]
@@ -60,6 +61,7 @@ pub struct Volume {
     processing_params: Arc<ProcessingParameters>,
     fader: usize,
     volume_limit: f32,
+    stale_ramp_threshold_ns: u64,
 }
 
 impl Volume {
@@ -78,6 +80,7 @@ impl Volume {
         let name = name.to_string();
         let ramptime_in_chunks =
             (ramp_time_ms / (1000.0 * chunksize as f32 / samplerate as f32)).round() as usize;
+        let stale_ramp_threshold_ns = 1_500_000_000u64 * chunksize as u64 / samplerate as u64;
         let current_volume_with_mute = if mute { -100.0 } else { current_volume };
         let target_linear_gain = if mute {
             0.0
@@ -99,6 +102,7 @@ impl Volume {
             processing_params,
             fader,
             volume_limit: limit,
+            stale_ramp_threshold_ns,
         }
     }
 
@@ -156,7 +160,10 @@ impl Volume {
 
         // Volume setting changed
         if (target_volume - self.target_volume).abs() > 0.01 || self.mute != shared_mute {
-            if self.ramptime_in_chunks > 0 {
+            let set_at = self.processing_params.target_volume_set_at(self.fader);
+            let ramp_is_stale =
+                nanos_since_epoch().saturating_sub(set_at) > self.stale_ramp_threshold_ns;
+            if self.ramptime_in_chunks > 0 && !ramp_is_stale {
                 trace!(
                     "starting ramp: {} -> {}, mute: {}",
                     self.current_volume, target_volume, shared_mute

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,6 +383,13 @@ impl ProcessingParameters {
         f32::from_bits(self.current_volume[fader].load(Ordering::Relaxed))
     }
 
+    pub fn sync_volumes_to_target(&self) {
+        for fader in 0..Self::NUM_FADERS {
+            let target = self.target_volume(fader);
+            self.set_current_volume(fader, target);
+        }
+    }
+
     pub fn set_current_volume(&self, fader: usize, current: f32) {
         self.current_volume[fader].store(current.to_bits(), Ordering::Relaxed)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,10 @@ use serde::Serialize;
 use std::error;
 use std::fmt;
 use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicU32, Ordering},
+    Arc, OnceLock,
+    atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
 };
+use std::time::Instant;
 
 pub static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
@@ -305,12 +306,19 @@ pub(crate) fn update_playback_signal_status(
     }
 }
 
+static PARAMS_EPOCH: OnceLock<Instant> = OnceLock::new();
+
+pub fn nanos_since_epoch() -> u64 {
+    PARAMS_EPOCH.get_or_init(Instant::now).elapsed().as_nanos() as u64
+}
+
 #[derive(Debug)]
 pub struct ProcessingParameters {
     // Optimization: volumes are actually `f32`s, but by representing their
     // bits as a `u32` of equal size we can use atomic operations instead of a
     // mutex.
     target_volume: [AtomicU32; Self::NUM_FADERS],
+    target_volume_set_at: [AtomicU64; Self::NUM_FADERS],
     current_volume: [AtomicU32; Self::NUM_FADERS],
     mute: [AtomicBool; Self::NUM_FADERS],
     processing_load: AtomicU32,
@@ -331,6 +339,13 @@ impl ProcessingParameters {
                 AtomicU32::new(initial_volumes[2].to_bits()),
                 AtomicU32::new(initial_volumes[3].to_bits()),
                 AtomicU32::new(initial_volumes[4].to_bits()),
+            ],
+            target_volume_set_at: [
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
             ],
             current_volume: [
                 AtomicU32::new(initial_volumes[0].to_bits()),
@@ -356,7 +371,12 @@ impl ProcessingParameters {
     }
 
     pub fn set_target_volume(&self, fader: usize, target: f32) {
-        self.target_volume[fader].store(target.to_bits(), Ordering::Relaxed)
+        self.target_volume[fader].store(target.to_bits(), Ordering::Relaxed);
+        self.target_volume_set_at[fader].store(nanos_since_epoch(), Ordering::Relaxed);
+    }
+
+    pub fn target_volume_set_at(&self, fader: usize) -> u64 {
+        self.target_volume_set_at[fader].load(Ordering::Relaxed)
     }
 
     pub fn current_volume(&self, fader: usize) -> f32 {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -424,3 +424,59 @@ fn parallelize_filters(steps: &mut Vec<PipelineStep>, nbr_channels: usize) -> Ve
     }
     new_steps
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Pipeline;
+    use crate::PrcFmt;
+    use crate::ProcessingParameters;
+    use crate::audiochunk::AudioChunk;
+    use std::sync::Arc;
+
+    // Regression test: volume set before config load must be applied to the very first chunk.
+    // Set volume to -100 dB, then load a config,
+    // and verify no full-scale burst comes out of the first processed chunk.
+    #[test]
+    fn volume_preset_before_pipeline_build() {
+        const CONFIG: &str = "
+devices:
+  samplerate: 44100
+  chunksize: 1024
+  capture:
+    type: SignalGenerator
+    channels: 2
+    signal:
+      type: Sine
+      freq: 1000
+      level: 0.0
+  playback:
+    type: Stdout
+    channels: 2
+    format: S16_LE
+";
+        let conf: crate::config::Configuration = yaml_serde::from_str(CONFIG).unwrap();
+        let chunksize = conf.devices.chunksize;
+        let channels = conf.devices.capture.channels();
+
+        let params = Arc::new(ProcessingParameters::default());
+        params.set_target_volume(0, -100.0);
+        params.sync_volumes_to_target();
+
+        let mut pipeline = Pipeline::from_config(conf, params);
+
+        let waveforms = vec![vec![1.0 as PrcFmt; chunksize]; channels];
+        let chunk = AudioChunk::new(waveforms, 1.0, -1.0, chunksize, chunksize);
+        let out = pipeline.process_chunk(chunk);
+
+        let max_val = out
+            .waveforms
+            .iter()
+            .flat_map(|w| w.iter())
+            .map(|x| x.abs())
+            .fold(0.0_f64 as PrcFmt, PrcFmt::max);
+        assert!(
+            max_val < 1e-3,
+            "First chunk after preset volume should be near-silent, got max={max_val}"
+        );
+    }
+}

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -75,6 +75,7 @@ pub fn run_processing(
                    Performance can improve by adding more threads or disabling multithreading."
             );
         }
+        processing_params.sync_volumes_to_target();
         let mut pipeline = pipeline::Pipeline::from_config(conf_proc, processing_params.clone());
         debug!("build filters, waiting to start processing loop");
 
@@ -175,6 +176,7 @@ pub fn run_processing(
                 match diff {
                     config::ConfigChange::Pipeline | config::ConfigChange::MixerParameters => {
                         debug!("Rebuilding pipeline.");
+                        processing_params.sync_volumes_to_target();
                         let new_pipeline =
                             pipeline::Pipeline::from_config(new_config, processing_params.clone());
                         pipeline = new_pipeline;


### PR DESCRIPTION
Fix: skip volume ramp when processing was stopped during the ramp window
Fixes #469.

When processing is inactive and a volume change arrives, the Volume filter had no way to know that audio wasn't playing when the ramp should have started. On the next processing run it would ramp from the previous volume to the new target, even though no audio had played at the old level — causing an audible sweep that the user didn't expect.

Approach
Rather than patching every call site that sets target_volume (websocket handlers, engine, ALSA backend) to also check processing state and mirror the write to current_volume, the fix lives entirely inside the Volume filter itself.

ProcessingParameters::set_target_volume now records a timestamp (nanoseconds since a program-lifetime epoch, stored as an AtomicU64 per fader). When Volume::prepare_processing detects a target change, it checks whether the request is stale: if more than 1.5× the chunk duration has elapsed since the volume was set without the filter having processed any audio, the ramp is skipped and the new volume is applied immediately.

This makes the fix self-contained and foolproof — it handles every code path that sets volume (including the ALSA hardware volume callback and any future additions) without requiring each one to reason about processing state.

What changes
src/lib.rs: ProcessingParameters gains a target_volume_set_at field ([AtomicU64; NUM_FADERS]), updated atomically on every set_target_volume call. A shared nanos_since_epoch() helper (backed by a lazy OnceLock<Instant>) provides the timestamps.
src/filters/basicfilters.rs: Volume gains stale_ramp_threshold_ns (1.5 × chunk duration, computed once in new()). In prepare_processing, a stale request bypasses the ramp and snaps to the new target directly.