### PR TITLE
tidy bin: move signals into module, name threads

### DIFF
--- a/benches/conversions.rs
+++ b/benches/conversions.rs
@@ -1,7 +1,5 @@
-extern crate criterion;
 use camillalib::utils::stash::{recycle_chunk, vec_from_stash};
 use criterion::{Criterion, criterion_group, criterion_main};
-extern crate camillalib;
 
 use camillalib::audiochunk::AudioChunk;
 use camillalib::config::BinarySampleFormat;

--- a/benches/fftconv_kernels.rs
+++ b/benches/fftconv_kernels.rs
@@ -1,10 +1,6 @@
 //! Micro-benchmarks for fftconv complex-multiply kernels.
 //! Compares scalar with AVX+FMA on x86_64 and NEON on aarch64.
 
-extern crate camillalib;
-extern crate criterion;
-extern crate num_complex;
-
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use num_complex::Complex;
 use std::hint::black_box;

--- a/benches/filters.rs
+++ b/benches/filters.rs
@@ -1,6 +1,4 @@
-extern crate criterion;
 use criterion::{Bencher, BenchmarkId, Criterion, criterion_group, criterion_main};
-extern crate camillalib;
 
 use camillalib::PrcFmt;
 use camillalib::filters::Filter;

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -1,6 +1,4 @@
-extern crate criterion;
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
-extern crate camillalib;
 
 use camillalib::PrcFmt;
 use camillalib::ProcessingParameters;

--- a/src/alsa_backend/alsa_pcm.rs
+++ b/src/alsa_backend/alsa_pcm.rs
@@ -1,5 +1,5 @@
-use std::sync::LazyLock;
 use parking_lot::Mutex;
+use std::sync::LazyLock;
 
 use alsa::{
     Direction, ValueOr,

--- a/src/alsa_backend/alsa_pcm.rs
+++ b/src/alsa_backend/alsa_pcm.rs
@@ -1,4 +1,5 @@
-use std::sync::{LazyLock, Mutex};
+use std::sync::LazyLock;
+use parking_lot::Mutex;
 
 use alsa::{
     Direction, ValueOr,
@@ -8,7 +9,7 @@ use alsa::{
 use crate::{
     Res,
     alsa_backend::{
-        threaded_buffermanager::DeviceBufferManager,
+        device_buffer_manager::DeviceBufferManager,
         utils::{
             list_channels_as_text, list_device_names, list_formats_as_text,
             list_samplerates_as_text, pick_preferred_format,

--- a/src/alsa_backend/alsa_pcm.rs
+++ b/src/alsa_backend/alsa_pcm.rs
@@ -1,0 +1,103 @@
+use std::sync::{LazyLock, Mutex};
+
+use alsa::{
+    Direction, ValueOr,
+    pcm::{Access, Format, HwParams},
+};
+
+use crate::{
+    Res,
+    alsa_backend::{
+        threaded_buffermanager::DeviceBufferManager,
+        utils::{
+            list_channels_as_text, list_device_names, list_formats_as_text,
+            list_samplerates_as_text, pick_preferred_format,
+        },
+    },
+    audiodevice::DeviceError,
+    config::AlsaSampleFormat,
+};
+
+static ALSA_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// Open an Alsa PCM device
+///
+/// Synchronized internally so you can launch playback and capture concurrently
+pub fn open_pcm(
+    devname: String,
+    samplerate: u32,
+    channels: u32,
+    sample_format: &Option<AlsaSampleFormat>,
+    buf_manager: &mut dyn DeviceBufferManager,
+    capture: bool,
+) -> Res<(alsa::PCM, AlsaSampleFormat)> {
+    let direction = if capture { "Capture" } else { "Playback" };
+    debug!(
+        "Available {} devices: {:?}",
+        direction,
+        list_device_names(capture)
+    );
+    // Acquire the lock
+    let _lock = ALSA_MUTEX.lock();
+    // Open the device
+    let pcmdev = if capture {
+        alsa::PCM::new(&devname, Direction::Capture, true)?
+    } else {
+        alsa::PCM::new(&devname, Direction::Playback, true)?
+    };
+    // Set hardware parameters
+    let chosen_format;
+    {
+        let hwp = HwParams::any(&pcmdev)?;
+
+        // Set number of channels
+        debug!("{}: {}", direction, list_channels_as_text(&hwp));
+        debug!("{direction}: setting channels to {channels}");
+        hwp.set_channels(channels)?;
+
+        // Set samplerate
+        debug!("{}: {}", direction, list_samplerates_as_text(&hwp));
+        debug!("{direction}: setting rate to {samplerate}");
+        hwp.set_rate(samplerate, ValueOr::Nearest)?;
+
+        // Set sample format
+        debug!("{}: {}", direction, list_formats_as_text(&hwp));
+        chosen_format = match sample_format {
+            Some(sfmt) => *sfmt,
+            None => {
+                let preferred = pick_preferred_format(&hwp)
+                    .ok_or(DeviceError::new("Unable to find a supported sample format"))?;
+                debug!("{direction}: Picked sample format {preferred:?}");
+                preferred
+            }
+        };
+        debug!("{direction}: setting format to {chosen_format:?}");
+        match chosen_format {
+            AlsaSampleFormat::S16_LE => hwp.set_format(Format::s16())?,
+            AlsaSampleFormat::S24_4_LE => hwp.set_format(Format::s24())?,
+            AlsaSampleFormat::S24_3_LE => hwp.set_format(Format::s24_3())?,
+            AlsaSampleFormat::S32_LE => hwp.set_format(Format::s32())?,
+            AlsaSampleFormat::F32_LE => hwp.set_format(Format::float())?,
+            AlsaSampleFormat::F64_LE => hwp.set_format(Format::float64())?,
+        }
+
+        // Set access mode, buffersize and periods
+        hwp.set_access(Access::RWInterleaved)?;
+        buf_manager.apply_buffer_size(&hwp)?;
+        buf_manager.apply_period_size(&hwp)?;
+
+        // Apply
+        pcmdev.hw_params(&hwp)?;
+    }
+    {
+        // Set software parameters
+        let hwp = pcmdev.hw_params_current()?;
+        let swp = pcmdev.sw_params_current()?;
+        buf_manager.apply_start_threshold(&swp)?;
+        buf_manager.apply_avail_min(&swp)?;
+        debug!("Opening {direction} device \"{devname}\" with parameters: {hwp:?}, {swp:?}");
+        pcmdev.sw_params(&swp)?;
+        debug!("{direction} device \"{devname}\" successfully opened");
+    }
+    Ok((pcmdev, chosen_format))
+}

--- a/src/alsa_backend/buffermanager.rs
+++ b/src/alsa_backend/buffermanager.rs
@@ -14,148 +14,28 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use alsa::pcm::{Frames, HwParams, SwParams};
+use alsa::pcm::{Frames, SwParams};
 use std::fmt::Debug;
 use std::thread;
 use std::time::Duration;
 
 use crate::Res;
+use crate::alsa_backend::device_buffer_manager::{DeviceBufferData, DeviceBufferManager};
 use crate::config;
 
-pub trait DeviceBufferManager {
-    // intended for internal use
-    fn data(&self) -> &DeviceBufferData;
-    fn data_mut(&mut self) -> &mut DeviceBufferData;
-
-    fn apply_start_threshold(&mut self, swp: &SwParams) -> Res<()>;
-
-    // Calculate a power-of-two buffer size that is large enough to accommodate any changes due to resampling,
-    // and at least 4 times the minimum period size to avoid random broken pipes.
-    fn calculate_buffer_size(&self, min_period: Frames) -> Frames {
-        let data = self.data();
-        let mut frames_needed = 3.0 * data.chunksize as f32 / data.resampling_ratio;
-        if frames_needed < 4.0 * min_period as f32 {
-            frames_needed = 4.0 * min_period as f32;
-            debug!(
-                "Minimum period is {min_period} frames, buffer size is minimum {frames_needed} frames"
-            );
-        }
-        2.0f32.powi(frames_needed.log2().ceil() as i32) as Frames
+fn synchronous_apply_avail_min(swp: &SwParams<'_>, data: &mut DeviceBufferData) -> Res<()> {
+    // maximum timing safety - headroom for one io_size only
+    if data.io_size > data.bufsize {
+        let msg = format!(
+            "Trying to set avail_min to {}, must be smaller than or equal to device buffer size of {}",
+            data.io_size, data.bufsize
+        );
+        error!("{msg}");
+        return Err(config::ConfigError::new(&msg).into());
     }
-
-    // Calculate an alternative buffer size that is 3 multiplied by a power-of-two,
-    // and at least 4 times the minimum period size to avoid random broken pipes.
-    // This is for some devices that cannot work with the default setting,
-    // and when set_buffer_size_near() does not return a working alternative near the requested one.
-    // Caused by driver bugs?
-    fn calculate_buffer_size_alt(&self, min_period: Frames) -> Frames {
-        let data = self.data();
-        let mut frames_needed = 3.0 * data.chunksize as f32 / data.resampling_ratio;
-        if frames_needed < 4.0 * min_period as f32 {
-            frames_needed = 4.0 * min_period as f32;
-            debug!(
-                "Minimum period is {min_period} frames, alternate buffer size is minimum {frames_needed} frames"
-            );
-        }
-        3 * 2.0f32.powi((frames_needed / 3.0).log2().ceil() as i32) as Frames
-    }
-
-    // Calculate a buffer size and apply it to a hwp container. Only for use when opening a device.
-    fn apply_buffer_size(&mut self, hwp: &HwParams) -> Res<()> {
-        let min_period = hwp.get_period_size_min().unwrap_or(0);
-        let buffer_frames = self.calculate_buffer_size(min_period);
-        let alt_buffer_frames = self.calculate_buffer_size_alt(min_period);
-        let data = self.data_mut();
-        debug!("Setting buffer size to {buffer_frames} frames");
-        match hwp.set_buffer_size_near(buffer_frames) {
-            Ok(frames) => {
-                data.bufsize = frames;
-            }
-            Err(_) => {
-                debug!(
-                    "Device did not accept a buffer size of {buffer_frames} frames, trying again with {alt_buffer_frames}"
-                );
-                data.bufsize = hwp.set_buffer_size_near(alt_buffer_frames)?;
-            }
-        }
-        debug!("Device is using a buffer size of {} frames", data.bufsize);
-        Ok(())
-    }
-
-    // Calculate a period size and apply it to a hwp container. Only for use when opening a device, after setting buffer size.
-    fn apply_period_size(&mut self, hwp: &HwParams) -> Res<()> {
-        let data = self.data_mut();
-        let period_frames = data.bufsize / 8;
-        debug!("Setting period size to {period_frames} frames");
-        match hwp.set_period_size_near(period_frames, alsa::ValueOr::Nearest) {
-            Ok(frames) => {
-                data.period = frames;
-            }
-            Err(_) => {
-                let alt_period_frames =
-                    3 * 2.0f32.powi((period_frames as f32 / 2.0).log2().ceil() as i32) as Frames;
-                debug!(
-                    "Device did not accept a period size of {period_frames} frames, trying again with {alt_period_frames}"
-                );
-                data.period =
-                    hwp.set_period_size_near(alt_period_frames, alsa::ValueOr::Nearest)?;
-            }
-        }
-        debug!("Device is using a period size of {} frames", data.period);
-        Ok(())
-    }
-
-    // Update avail_min so set target for snd_pcm_wait.
-    fn apply_avail_min(&mut self, swp: &SwParams) -> Res<()> {
-        let data = self.data_mut();
-        // maximum timing safety - headroom for one io_size only
-        if data.io_size > data.bufsize {
-            let msg = format!(
-                "Trying to set avail_min to {}, must be smaller than or equal to device buffer size of {}",
-                data.io_size, data.bufsize
-            );
-            error!("{msg}");
-            return Err(config::ConfigError::new(&msg).into());
-        }
-        data.avail_min = data.io_size;
-        swp.set_avail_min(data.avail_min)?;
-        Ok(())
-    }
-
-    fn update_io_size(&mut self, swp: &SwParams, io_size: Frames) -> Res<()> {
-        let data = self.data_mut();
-        data.io_size = io_size;
-        // must update avail_min
-        self.apply_avail_min(swp)?;
-        // must update threshold
-        self.apply_start_threshold(swp)?;
-        Ok(())
-    }
-
-    fn frames_to_stall(&self) -> Frames {
-        let data = self.data();
-        // +1 to make sure the device really stalls
-        data.bufsize - data.avail_min + 1
-    }
-
-    fn current_delay(&self, avail: Frames) -> Frames;
-}
-
-#[derive(Debug)]
-pub struct DeviceBufferData {
-    bufsize: Frames,
-    period: Frames,
-    threshold: Frames,
-    avail_min: Frames,
-    io_size: Frames, /* size of read/write block */
-    chunksize: Frames,
-    resampling_ratio: f32,
-}
-
-impl DeviceBufferData {
-    pub fn buffersize(&self) -> Frames {
-        self.bufsize
-    }
+    data.avail_min = data.io_size;
+    swp.set_avail_min(data.avail_min)?;
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -199,6 +79,11 @@ impl DeviceBufferManager for CaptureBufferManager {
 
     fn current_delay(&self, avail: Frames) -> Frames {
         avail
+    }
+
+    fn apply_avail_min(&mut self, swp: &SwParams) -> Res<()> {
+        let data = self.data_mut();
+        synchronous_apply_avail_min(swp, data)
     }
 }
 
@@ -253,5 +138,10 @@ impl DeviceBufferManager for PlaybackBufferManager {
 
     fn current_delay(&self, avail: Frames) -> Frames {
         self.data.bufsize - avail
+    }
+
+    fn apply_avail_min(&mut self, swp: &SwParams) -> Res<()> {
+        let data = self.data_mut();
+        synchronous_apply_avail_min(swp, data)
     }
 }

--- a/src/alsa_backend/buffermanager.rs
+++ b/src/alsa_backend/buffermanager.rs
@@ -14,8 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-extern crate alsa;
-extern crate nix;
 use alsa::pcm::{Frames, HwParams, SwParams};
 use std::fmt::Debug;
 use std::thread;

--- a/src/alsa_backend/device.rs
+++ b/src/alsa_backend/device.rs
@@ -14,8 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-extern crate alsa;
-extern crate nix;
 use crate::audiochunk::ChunkStats;
 use crate::audiodevice::*;
 use crate::config::{AlsaSampleFormat, Resampler};

--- a/src/alsa_backend/device.rs
+++ b/src/alsa_backend/device.rs
@@ -43,9 +43,8 @@ use crate::PrcFmt;
 use crate::ProcessingState;
 use crate::Res;
 use crate::StatusMessage;
-use crate::alsa_backend::buffermanager::{
-    CaptureBufferManager, DeviceBufferManager, PlaybackBufferManager,
-};
+use crate::alsa_backend::buffermanager::{CaptureBufferManager, PlaybackBufferManager};
+use crate::alsa_backend::device_buffer_manager::DeviceBufferManager;
 use crate::alsa_backend::utils::{
     CaptureElements, CaptureParams, CaptureResult, ElemData, FileDescriptors, PlaybackParams,
     find_elem, process_events, recover_suspended_pcm, state_desc, sync_linked_controls,

--- a/src/alsa_backend/device.rs
+++ b/src/alsa_backend/device.rs
@@ -14,26 +14,26 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
+use crate::alsa_backend::alsa_pcm::open_pcm;
 use crate::audiochunk::ChunkStats;
 use crate::audiodevice::*;
 use crate::config::{AlsaSampleFormat, Resampler};
 use crate::utils::conversions::{buffer_to_chunk_rawbytes, chunk_to_buffer_rawbytes};
 use crate::utils::countertimer;
+use alsa::PCM;
 use alsa::ctl::{Ctl, ElemId, ElemIface, ElemType, ElemValue};
 use alsa::hctl::{Elem, HCtl};
-use alsa::pcm::{Access, Format, Frames, HwParams};
+use alsa::pcm::Frames;
 use alsa::poll::Descriptors;
-use alsa::{Direction, PCM, ValueOr};
 use alsa_sys;
 use audio_thread_priority::{
     demote_current_thread_from_real_time, promote_current_thread_to_real_time,
 };
 use crossbeam_channel;
 use nix::errno::Errno;
-use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use std::ffi::CString;
 use std::fmt::Debug;
-use std::sync::LazyLock;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Instant;
@@ -48,15 +48,11 @@ use crate::alsa_backend::buffermanager::{
 };
 use crate::alsa_backend::utils::{
     CaptureElements, CaptureParams, CaptureResult, ElemData, FileDescriptors, PlaybackParams,
-    find_elem, list_channels_as_text, list_device_names, list_formats_as_text,
-    list_samplerates_as_text, pick_preferred_format, process_events, recover_suspended_pcm,
-    state_desc, sync_linked_controls,
+    find_elem, process_events, recover_suspended_pcm, state_desc, sync_linked_controls,
 };
 use crate::utils::rate_controller::PIRateController;
 use crate::utils::resampling::{ChunkResampler, new_resampler, resampler_is_async};
 use crate::{CaptureStatus, PlaybackStatus, ProcessingParameters};
-
-static ALSA_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 pub struct AlsaPlaybackDevice {
     pub devname: String,
@@ -389,86 +385,6 @@ fn capture_buffer(
             },
         };
     }
-}
-
-/// Open an Alsa PCM device
-fn open_pcm(
-    devname: String,
-    samplerate: u32,
-    channels: u32,
-    sample_format: &Option<AlsaSampleFormat>,
-    buf_manager: &mut dyn DeviceBufferManager,
-    capture: bool,
-) -> Res<(alsa::PCM, AlsaSampleFormat)> {
-    let direction = if capture { "Capture" } else { "Playback" };
-    debug!(
-        "Available {} devices: {:?}",
-        direction,
-        list_device_names(capture)
-    );
-    // Acquire the lock
-    let _lock = ALSA_MUTEX.lock();
-    // Open the device
-    let pcmdev = if capture {
-        alsa::PCM::new(&devname, Direction::Capture, true)?
-    } else {
-        alsa::PCM::new(&devname, Direction::Playback, true)?
-    };
-    // Set hardware parameters
-    let chosen_format;
-    {
-        let hwp = HwParams::any(&pcmdev)?;
-
-        // Set number of channels
-        debug!("{}: {}", direction, list_channels_as_text(&hwp));
-        debug!("{direction}: setting channels to {channels}");
-        hwp.set_channels(channels)?;
-
-        // Set samplerate
-        debug!("{}: {}", direction, list_samplerates_as_text(&hwp));
-        debug!("{direction}: setting rate to {samplerate}");
-        hwp.set_rate(samplerate, ValueOr::Nearest)?;
-
-        // Set sample format
-        debug!("{}: {}", direction, list_formats_as_text(&hwp));
-        chosen_format = match sample_format {
-            Some(sfmt) => *sfmt,
-            None => {
-                let preferred = pick_preferred_format(&hwp)
-                    .ok_or(DeviceError::new("Unable to find a supported sample format"))?;
-                debug!("{direction}: Picked sample format {preferred:?}");
-                preferred
-            }
-        };
-        debug!("{direction}: setting format to {chosen_format:?}");
-        match chosen_format {
-            AlsaSampleFormat::S16_LE => hwp.set_format(Format::s16())?,
-            AlsaSampleFormat::S24_4_LE => hwp.set_format(Format::s24())?,
-            AlsaSampleFormat::S24_3_LE => hwp.set_format(Format::s24_3())?,
-            AlsaSampleFormat::S32_LE => hwp.set_format(Format::s32())?,
-            AlsaSampleFormat::F32_LE => hwp.set_format(Format::float())?,
-            AlsaSampleFormat::F64_LE => hwp.set_format(Format::float64())?,
-        }
-
-        // Set access mode, buffersize and periods
-        hwp.set_access(Access::RWInterleaved)?;
-        buf_manager.apply_buffer_size(&hwp)?;
-        buf_manager.apply_period_size(&hwp)?;
-
-        // Apply
-        pcmdev.hw_params(&hwp)?;
-    }
-    {
-        // Set software parameters
-        let hwp = pcmdev.hw_params_current()?;
-        let swp = pcmdev.sw_params_current()?;
-        buf_manager.apply_start_threshold(&swp)?;
-        buf_manager.apply_avail_min(&swp)?;
-        debug!("Opening {direction} device \"{devname}\" with parameters: {hwp:?}, {swp:?}");
-        pcmdev.sw_params(&swp)?;
-        debug!("{direction} device \"{devname}\" successfully opened");
-    }
-    Ok((pcmdev, chosen_format))
 }
 
 fn playback_loop_bytes(

--- a/src/alsa_backend/device_buffer_manager.rs
+++ b/src/alsa_backend/device_buffer_manager.rs
@@ -1,0 +1,130 @@
+use alsa::pcm::{Frames, HwParams, SwParams};
+
+use crate::Res;
+
+pub trait DeviceBufferManager {
+    // intended for internal use
+    fn data(&self) -> &DeviceBufferData;
+    fn data_mut(&mut self) -> &mut DeviceBufferData;
+
+    fn apply_start_threshold(&mut self, swp: &SwParams) -> Res<()>;
+
+    // Calculate a power-of-two buffer size that is large enough to accommodate any changes due to resampling,
+    // and at least 4 times the minimum period size to avoid random broken pipes.
+    fn calculate_buffer_size(&self, min_period: Frames) -> Frames {
+        let data = self.data();
+        let mut frames_needed = 3.0 * data.chunksize as f32 / data.resampling_ratio;
+        if frames_needed < 4.0 * min_period as f32 {
+            frames_needed = 4.0 * min_period as f32;
+            debug!(
+                "Minimum period is {min_period} frames, buffer size is minimum {frames_needed} frames"
+            );
+        }
+        2.0f32.powi(frames_needed.log2().ceil() as i32) as Frames
+    }
+
+    // Calculate an alternative buffer size that is 3 multiplied by a power-of-two,
+    // and at least 4 times the minimum period size to avoid random broken pipes.
+    // This is for some devices that cannot work with the default setting,
+    // and when set_buffer_size_near() does not return a working alternative near the requested one.
+    // Caused by driver bugs?
+    fn calculate_buffer_size_alt(&self, min_period: Frames) -> Frames {
+        let data = self.data();
+        let mut frames_needed = 3.0 * data.chunksize as f32 / data.resampling_ratio;
+        if frames_needed < 4.0 * min_period as f32 {
+            frames_needed = 4.0 * min_period as f32;
+            debug!(
+                "Minimum period is {min_period} frames, alternate buffer size is minimum {frames_needed} frames"
+            );
+        }
+        3 * 2.0f32.powi((frames_needed / 3.0).log2().ceil() as i32) as Frames
+    }
+
+    // Calculate a buffer size and apply it to a hwp container. Only for use when opening a device.
+    fn apply_buffer_size(&mut self, hwp: &HwParams) -> Res<()> {
+        let min_period = hwp.get_period_size_min().unwrap_or(0);
+        let buffer_frames = self.calculate_buffer_size(min_period);
+        let alt_buffer_frames = self.calculate_buffer_size_alt(min_period);
+        let data = self.data_mut();
+        debug!("Setting buffer size to {buffer_frames} frames");
+        match hwp.set_buffer_size_near(buffer_frames) {
+            Ok(frames) => {
+                data.bufsize = frames;
+            }
+            Err(_) => {
+                debug!(
+                    "Device did not accept a buffer size of {buffer_frames} frames, trying again with {alt_buffer_frames}"
+                );
+                data.bufsize = hwp.set_buffer_size_near(alt_buffer_frames)?;
+            }
+        }
+        debug!("Device is using a buffer size of {} frames", data.bufsize);
+        Ok(())
+    }
+
+    // Calculate a period size and apply it to a hwp container. Only for use when opening a device, after setting buffer size.
+    fn apply_period_size(&mut self, hwp: &HwParams) -> Res<()> {
+        let data = self.data_mut();
+        let period_frames = data.bufsize / 8;
+        debug!("Setting period size to {period_frames} frames");
+        match hwp.set_period_size_near(period_frames, alsa::ValueOr::Nearest) {
+            Ok(frames) => {
+                data.period = frames;
+            }
+            Err(_) => {
+                let alt_period_frames =
+                    3 * 2.0f32.powi((period_frames as f32 / 2.0).log2().ceil() as i32) as Frames;
+                debug!(
+                    "Device did not accept a period size of {period_frames} frames, trying again with {alt_period_frames}"
+                );
+                data.period =
+                    hwp.set_period_size_near(alt_period_frames, alsa::ValueOr::Nearest)?;
+            }
+        }
+        debug!("Device is using a period size of {} frames", data.period);
+        Ok(())
+    }
+
+    /// Update avail_min so set target for snd_pcm_wait.
+    /// Use a fixed period-sized avail_min in threaded mode so device I/O cadence is independent of chunk handoff size.
+    fn apply_avail_min(&mut self, swp: &SwParams) -> Res<()>;
+
+    fn update_io_size(&mut self, swp: &SwParams, io_size: Frames) -> Res<()> {
+        let data = self.data_mut();
+        data.io_size = io_size;
+        // must update avail_min
+        self.apply_avail_min(swp)?;
+        // must update threshold
+        self.apply_start_threshold(swp)?;
+        Ok(())
+    }
+
+    fn frames_to_stall(&self) -> Frames {
+        let data = self.data();
+        // +1 to make sure the device really stalls
+        data.bufsize - data.avail_min + 1
+    }
+
+    fn current_delay(&self, avail: Frames) -> Frames;
+}
+
+#[derive(Debug)]
+pub struct DeviceBufferData {
+    pub(crate) bufsize: Frames,
+    pub(crate) period: Frames,
+    pub(crate) threshold: Frames,
+    pub(crate) avail_min: Frames,
+    pub(crate) io_size: Frames, /* size of read/write block */
+    pub(crate) chunksize: Frames,
+    pub(crate) resampling_ratio: f32,
+}
+
+impl DeviceBufferData {
+    pub fn buffersize(&self) -> Frames {
+        self.bufsize
+    }
+
+    pub fn periodsize(&self) -> Frames {
+        self.period
+    }
+}

--- a/src/alsa_backend/mod.rs
+++ b/src/alsa_backend/mod.rs
@@ -19,6 +19,7 @@ mod alsa_pcm;
 pub mod buffermanager;
 #[cfg(not(feature = "threaded-alsa"))]
 pub mod device;
+pub mod device_buffer_manager;
 #[cfg(feature = "threaded-alsa")]
 pub mod threaded_buffermanager;
 #[cfg(feature = "threaded-alsa")]

--- a/src/alsa_backend/mod.rs
+++ b/src/alsa_backend/mod.rs
@@ -14,6 +14,7 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
+mod alsa_pcm;
 #[cfg(not(feature = "threaded-alsa"))]
 pub mod buffermanager;
 #[cfg(not(feature = "threaded-alsa"))]

--- a/src/alsa_backend/threaded_buffermanager.rs
+++ b/src/alsa_backend/threaded_buffermanager.rs
@@ -14,152 +14,12 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use alsa::pcm::{Frames, HwParams, SwParams};
+use alsa::pcm::{Frames, SwParams};
 use std::fmt::Debug;
 
 use crate::Res;
+use crate::alsa_backend::device_buffer_manager::{DeviceBufferData, DeviceBufferManager};
 use crate::config;
-
-pub trait DeviceBufferManager {
-    // intended for internal use
-    fn data(&self) -> &DeviceBufferData;
-    fn data_mut(&mut self) -> &mut DeviceBufferData;
-
-    fn apply_start_threshold(&mut self, swp: &SwParams) -> Res<()>;
-
-    // Calculate a power-of-two buffer size that is large enough to accommodate any changes due to resampling,
-    // and at least 4 times the minimum period size to avoid random broken pipes.
-    fn calculate_buffer_size(&self, min_period: Frames) -> Frames {
-        let data = self.data();
-        let mut frames_needed = 3.0 * data.chunksize as f32 / data.resampling_ratio;
-        if frames_needed < 4.0 * min_period as f32 {
-            frames_needed = 4.0 * min_period as f32;
-            debug!(
-                "Minimum period is {min_period} frames, buffer size is minimum {frames_needed} frames"
-            );
-        }
-        2.0f32.powi(frames_needed.log2().ceil() as i32) as Frames
-    }
-
-    // Calculate an alternative buffer size that is 3 multiplied by a power-of-two,
-    // and at least 4 times the minimum period size to avoid random broken pipes.
-    // This is for some devices that cannot work with the default setting,
-    // and when set_buffer_size_near() does not return a working alternative near the requested one.
-    // Caused by driver bugs?
-    fn calculate_buffer_size_alt(&self, min_period: Frames) -> Frames {
-        let data = self.data();
-        let mut frames_needed = 3.0 * data.chunksize as f32 / data.resampling_ratio;
-        if frames_needed < 4.0 * min_period as f32 {
-            frames_needed = 4.0 * min_period as f32;
-            debug!(
-                "Minimum period is {min_period} frames, alternate buffer size is minimum {frames_needed} frames"
-            );
-        }
-        3 * 2.0f32.powi((frames_needed / 3.0).log2().ceil() as i32) as Frames
-    }
-
-    // Calculate a buffer size and apply it to a hwp container. Only for use when opening a device.
-    fn apply_buffer_size(&mut self, hwp: &HwParams) -> Res<()> {
-        let min_period = hwp.get_period_size_min().unwrap_or(0);
-        let buffer_frames = self.calculate_buffer_size(min_period);
-        let alt_buffer_frames = self.calculate_buffer_size_alt(min_period);
-        let data = self.data_mut();
-        debug!("Setting buffer size to {buffer_frames} frames");
-        match hwp.set_buffer_size_near(buffer_frames) {
-            Ok(frames) => {
-                data.bufsize = frames;
-            }
-            Err(_) => {
-                debug!(
-                    "Device did not accept a buffer size of {buffer_frames} frames, trying again with {alt_buffer_frames}"
-                );
-                data.bufsize = hwp.set_buffer_size_near(alt_buffer_frames)?;
-            }
-        }
-        debug!("Device is using a buffer size of {} frames", data.bufsize);
-        Ok(())
-    }
-
-    // Calculate a period size and apply it to a hwp container. Only for use when opening a device, after setting buffer size.
-    fn apply_period_size(&mut self, hwp: &HwParams) -> Res<()> {
-        let data = self.data_mut();
-        let period_frames = data.bufsize / 8;
-        debug!("Setting period size to {period_frames} frames");
-        match hwp.set_period_size_near(period_frames, alsa::ValueOr::Nearest) {
-            Ok(frames) => {
-                data.period = frames;
-            }
-            Err(_) => {
-                let alt_period_frames =
-                    3 * 2.0f32.powi((period_frames as f32 / 2.0).log2().ceil() as i32) as Frames;
-                debug!(
-                    "Device did not accept a period size of {period_frames} frames, trying again with {alt_period_frames}"
-                );
-                data.period =
-                    hwp.set_period_size_near(alt_period_frames, alsa::ValueOr::Nearest)?;
-            }
-        }
-        debug!("Device is using a period size of {} frames", data.period);
-        Ok(())
-    }
-
-    // Use a fixed period-sized avail_min in threaded mode so device I/O cadence is independent of chunk handoff size.
-    fn apply_avail_min(&mut self, swp: &SwParams) -> Res<()> {
-        let data = self.data_mut();
-        let fixed_io_size = if data.period > 0 { data.period } else { 1 };
-        if fixed_io_size > data.bufsize {
-            let msg = format!(
-                "Trying to set avail_min to {}, must be smaller than or equal to device buffer size of {}",
-                fixed_io_size, data.bufsize
-            );
-            error!("{msg}");
-            return Err(config::ConfigError::new(&msg).into());
-        }
-        data.io_size = fixed_io_size;
-        data.avail_min = fixed_io_size;
-        swp.set_avail_min(data.avail_min)?;
-        Ok(())
-    }
-
-    fn update_io_size(&mut self, swp: &SwParams, io_size: Frames) -> Res<()> {
-        let data = self.data_mut();
-        data.io_size = io_size;
-        // must update avail_min
-        self.apply_avail_min(swp)?;
-        // must update threshold
-        self.apply_start_threshold(swp)?;
-        Ok(())
-    }
-
-    fn frames_to_stall(&self) -> Frames {
-        let data = self.data();
-        // +1 to make sure the device really stalls
-        data.bufsize - data.avail_min + 1
-    }
-
-    fn current_delay(&self, avail: Frames) -> Frames;
-}
-
-#[derive(Debug)]
-pub struct DeviceBufferData {
-    bufsize: Frames,
-    period: Frames,
-    threshold: Frames,
-    avail_min: Frames,
-    io_size: Frames, /* size of read/write block */
-    chunksize: Frames,
-    resampling_ratio: f32,
-}
-
-impl DeviceBufferData {
-    pub fn buffersize(&self) -> Frames {
-        self.bufsize
-    }
-
-    pub fn periodsize(&self) -> Frames {
-        self.period
-    }
-}
 
 #[derive(Debug)]
 pub struct CaptureBufferManager {
@@ -183,6 +43,23 @@ impl CaptureBufferManager {
     }
 }
 
+// Use a fixed period-sized avail_min in threaded mode so device I/O cadence is independent of chunk handoff size.
+fn threaded_apply_avail_min(swp: &SwParams<'_>, data: &mut DeviceBufferData) -> Res<()> {
+    let fixed_io_size = if data.period > 0 { data.period } else { 1 };
+    if fixed_io_size > data.bufsize {
+        let msg = format!(
+            "Trying to set avail_min to {}, must be smaller than or equal to device buffer size of {}",
+            fixed_io_size, data.bufsize
+        );
+        error!("{msg}");
+        return Err(config::ConfigError::new(&msg).into());
+    }
+    data.io_size = fixed_io_size;
+    data.avail_min = fixed_io_size;
+    swp.set_avail_min(data.avail_min)?;
+    Ok(())
+}
+
 impl DeviceBufferManager for CaptureBufferManager {
     fn data(&self) -> &DeviceBufferData {
         &self.data
@@ -202,6 +79,11 @@ impl DeviceBufferManager for CaptureBufferManager {
 
     fn current_delay(&self, avail: Frames) -> Frames {
         avail
+    }
+
+    fn apply_avail_min(&mut self, swp: &SwParams) -> Res<()> {
+        let data = self.data_mut();
+        threaded_apply_avail_min(swp, data)
     }
 }
 
@@ -251,5 +133,10 @@ impl DeviceBufferManager for PlaybackBufferManager {
 
     fn current_delay(&self, avail: Frames) -> Frames {
         self.data.bufsize - avail
+    }
+
+    fn apply_avail_min(&mut self, swp: &SwParams) -> Res<()> {
+        let data = self.data_mut();
+        threaded_apply_avail_min(swp, data)
     }
 }

--- a/src/alsa_backend/threaded_buffermanager.rs
+++ b/src/alsa_backend/threaded_buffermanager.rs
@@ -14,8 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-extern crate alsa;
-extern crate nix;
 use alsa::pcm::{Frames, HwParams, SwParams};
 use std::fmt::Debug;
 

--- a/src/alsa_backend/threaded_device.rs
+++ b/src/alsa_backend/threaded_device.rs
@@ -14,6 +14,7 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
+use crate::alsa_backend::alsa_pcm::open_pcm;
 use crate::audiochunk::ChunkStats;
 use crate::audiodevice::*;
 use crate::config::{AlsaSampleFormat, BinarySampleFormat, Resampler};
@@ -21,9 +22,8 @@ use crate::utils::conversions::{buffer_to_chunk_rawbytes, chunk_to_buffer_rawbyt
 use crate::utils::countertimer;
 use alsa::ctl::{Ctl, ElemId, ElemIface, ElemType, ElemValue};
 use alsa::hctl::HCtl;
-use alsa::pcm::{Access, Format, Frames, HwParams};
+use alsa::pcm::Frames;
 use alsa::poll::Descriptors;
-use alsa::{Direction, ValueOr};
 use alsa_sys;
 use audio_thread_priority::{
     demote_current_thread_from_real_time, promote_current_thread_to_real_time,
@@ -34,7 +34,6 @@ use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use ringbuf::{HeapRb, traits::*};
 use std::ffi::CString;
 use std::fmt::Debug;
-use std::sync::LazyLock;
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -49,14 +48,11 @@ use crate::alsa_backend::threaded_buffermanager::{
 };
 use crate::alsa_backend::utils::{
     CaptureElements, CaptureParams, CaptureResult, ElemData, FileDescriptors, find_elem,
-    list_channels_as_text, list_device_names, list_formats_as_text, list_samplerates_as_text,
-    pick_preferred_format, process_events, recover_suspended_pcm, state_desc, sync_linked_controls,
+    process_events, recover_suspended_pcm, state_desc, sync_linked_controls,
 };
 use crate::utils::rate_controller::PIRateController;
 use crate::utils::resampling::{ChunkResampler, new_resampler, resampler_is_async};
 use crate::{CaptureStatus, PlaybackStatus, ProcessingParameters};
-
-static ALSA_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 pub struct AlsaPlaybackDevice {
     pub devname: String,
@@ -852,86 +848,6 @@ fn capture_buffer(
             }
         },
     }
-}
-
-/// Open an Alsa PCM device
-fn open_pcm(
-    devname: String,
-    samplerate: u32,
-    channels: u32,
-    sample_format: &Option<AlsaSampleFormat>,
-    buf_manager: &mut dyn DeviceBufferManager,
-    capture: bool,
-) -> Res<(alsa::PCM, AlsaSampleFormat)> {
-    let direction = if capture { "Capture" } else { "Playback" };
-    debug!(
-        "Available {} devices: {:?}",
-        direction,
-        list_device_names(capture)
-    );
-    // Acquire the lock
-    let _lock = ALSA_MUTEX.lock();
-    // Open the device
-    let pcmdev = if capture {
-        alsa::PCM::new(&devname, Direction::Capture, true)?
-    } else {
-        alsa::PCM::new(&devname, Direction::Playback, true)?
-    };
-    // Set hardware parameters
-    let chosen_format;
-    {
-        let hwp = HwParams::any(&pcmdev)?;
-
-        // Set number of channels
-        debug!("{}: {}", direction, list_channels_as_text(&hwp));
-        debug!("{direction}: setting channels to {channels}");
-        hwp.set_channels(channels)?;
-
-        // Set samplerate
-        debug!("{}: {}", direction, list_samplerates_as_text(&hwp));
-        debug!("{direction}: setting rate to {samplerate}");
-        hwp.set_rate(samplerate, ValueOr::Nearest)?;
-
-        // Set sample format
-        debug!("{}: {}", direction, list_formats_as_text(&hwp));
-        chosen_format = match sample_format {
-            Some(sfmt) => *sfmt,
-            None => {
-                let preferred = pick_preferred_format(&hwp)
-                    .ok_or(DeviceError::new("Unable to find a supported sample format"))?;
-                debug!("{direction}: Picked sample format {preferred:?}");
-                preferred
-            }
-        };
-        debug!("{direction}: setting format to {chosen_format:?}");
-        match chosen_format {
-            AlsaSampleFormat::S16_LE => hwp.set_format(Format::s16())?,
-            AlsaSampleFormat::S24_4_LE => hwp.set_format(Format::s24())?,
-            AlsaSampleFormat::S24_3_LE => hwp.set_format(Format::s24_3())?,
-            AlsaSampleFormat::S32_LE => hwp.set_format(Format::s32())?,
-            AlsaSampleFormat::F32_LE => hwp.set_format(Format::float())?,
-            AlsaSampleFormat::F64_LE => hwp.set_format(Format::float64())?,
-        }
-
-        // Set access mode, buffersize and periods
-        hwp.set_access(Access::RWInterleaved)?;
-        buf_manager.apply_buffer_size(&hwp)?;
-        buf_manager.apply_period_size(&hwp)?;
-
-        // Apply
-        pcmdev.hw_params(&hwp)?;
-    }
-    {
-        // Set software parameters
-        let hwp = pcmdev.hw_params_current()?;
-        let swp = pcmdev.sw_params_current()?;
-        buf_manager.apply_start_threshold(&swp)?;
-        buf_manager.apply_avail_min(&swp)?;
-        debug!("Opening {direction} device \"{devname}\" with parameters: {hwp:?}, {swp:?}");
-        pcmdev.sw_params(&swp)?;
-        debug!("{direction} device \"{devname}\" successfully opened");
-    }
-    Ok((pcmdev, chosen_format))
 }
 
 fn send_capture_audio(

--- a/src/alsa_backend/threaded_device.rs
+++ b/src/alsa_backend/threaded_device.rs
@@ -15,6 +15,7 @@
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
 use crate::alsa_backend::alsa_pcm::open_pcm;
+use crate::alsa_backend::device_buffer_manager::DeviceBufferManager;
 use crate::audiochunk::ChunkStats;
 use crate::audiodevice::*;
 use crate::config::{AlsaSampleFormat, BinarySampleFormat, Resampler};
@@ -43,9 +44,7 @@ use crate::PrcFmt;
 use crate::ProcessingState;
 use crate::Res;
 use crate::StatusMessage;
-use crate::alsa_backend::threaded_buffermanager::{
-    CaptureBufferManager, DeviceBufferManager, PlaybackBufferManager,
-};
+use crate::alsa_backend::threaded_buffermanager::{CaptureBufferManager, PlaybackBufferManager};
 use crate::alsa_backend::utils::{
     CaptureElements, CaptureParams, CaptureResult, ElemData, FileDescriptors, find_elem,
     process_events, recover_suspended_pcm, state_desc, sync_linked_controls,

--- a/src/alsa_backend/threaded_device.rs
+++ b/src/alsa_backend/threaded_device.rs
@@ -14,8 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-extern crate alsa;
-extern crate nix;
 use crate::audiochunk::ChunkStats;
 use crate::audiodevice::*;
 use crate::config::{AlsaSampleFormat, BinarySampleFormat, Resampler};

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -81,7 +81,6 @@ use camillalib::{
 
 const EXIT_BAD_CONFIG: i32 = 101; // Error in config file
 const EXIT_PROCESSING_ERROR: i32 = 102; // Error from processing
-const EXIT_FORCED: i32 = 103; // Exit was forced by a second SIGINT
 const EXIT_OK: i32 = 0; // All ok
 const GIT_HASH: &str = git_version!(fallback = "unknown");
 
@@ -1020,82 +1019,13 @@ fn main_process() -> i32 {
     let tx_command_thread = tx_command.clone();
 
     #[cfg(not(windows))]
-    let active_path_thread = active_config_path.clone();
-
-    #[cfg(not(windows))]
-    thread::spawn(move || {
-        let mut sigs = vec![SIGHUP, SIGUSR1];
-        sigs.extend(TERM_SIGNALS);
-        let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();
-        let mut exit_requested = false;
-        for info in &mut signals {
-            debug!("Received signal: {info}");
-            match info {
-                SIGHUP => {
-                    let path = (*active_path_thread.lock()).clone();
-                    if let Some(path) = path {
-                        match config::load_validate_config(path.as_str()) {
-                            Ok(conf) => {
-                                debug!("Config is valid");
-                                if let Err(e) = tx_command_thread
-                                    .try_send(ControllerMessage::ConfigChanged(Box::new(conf)))
-                                {
-                                    error!("Error sending reload message: {e}");
-                                }
-                            }
-                            Err(err) => {
-                                error!("Config error during reload: {err}");
-                            }
-                        };
-                    } else {
-                        error!("Config path not specified, cannot reload");
-                    }
-                }
-                SIGUSR1 => {
-                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Stop) {
-                        error!("Error sending stop message: {e}");
-                    }
-                }
-                _ => {
-                    if exit_requested {
-                        warn!("Forcing a shutdown");
-                        logger.flush();
-                        std::process::exit(EXIT_FORCED);
-                    }
-                    info!("Shutting down");
-                    exit_requested = true;
-                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
-                        error!("Error sending exit message: {e}");
-                    }
-                }
-            };
-        }
-    });
+    {
+        let active_path_thread = active_config_path.clone();
+        camillalib::signals::handle_signals(logger, tx_command_thread, active_path_thread);
+    }
 
     #[cfg(windows)]
-    thread::spawn(move || {
-        // On windows we don't have signal_hook::iterator, so we just poll for signal...
-        const DELAY: Duration = Duration::from_millis(100);
-        let signal_exit = Arc::new(AtomicBool::new(false));
-        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&signal_exit)).unwrap();
-        let mut exit_requested = false;
-        loop {
-            if signal_exit.load(std::sync::atomic::Ordering::Relaxed) {
-                signal_exit.store(false, std::sync::atomic::Ordering::Relaxed);
-                if exit_requested {
-                    warn!("Forcing a shutdown");
-                    logger.flush();
-                    std::process::exit(EXIT_FORCED);
-                }
-                info!("Shutting down");
-                exit_requested = true;
-                if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
-                    error!("Error sending exit message: {e}");
-                }
-            }
-            thread::sleep(DELAY);
-        }
-    });
+    camillalib::signals::handle_signals(logger, tx_command_thread);
 
     let wait = matches.get_flag("wait");
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -14,27 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-#[cfg(target_os = "linux")]
-extern crate alsa;
-extern crate camillalib;
-extern crate clap;
-#[cfg(feature = "pulse-backend")]
-extern crate libpulse_binding as pulse;
-#[cfg(feature = "pulse-backend")]
-extern crate libpulse_simple_binding as psimple;
-extern crate parking_lot;
-extern crate rand;
-extern crate rand_distr;
-extern crate realfft;
-extern crate rubato;
-extern crate serde;
-extern crate serde_with;
-extern crate signal_hook;
-#[cfg(feature = "websocket")]
-extern crate tungstenite;
-
-extern crate chrono;
-extern crate flexi_logger;
 #[macro_use]
 extern crate log;
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -26,7 +26,6 @@ use std::path::PathBuf;
 #[cfg(any(windows, feature = "websocket"))]
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Barrier};
-use std::thread;
 #[cfg(any(windows, feature = "websocket"))]
 use std::time::Duration;
 
@@ -1075,9 +1074,9 @@ fn main_process() -> i32 {
         if let Some(fname) = &statefilename {
             let fname = fname.clone();
 
-            thread::spawn(move || {
+            std::thread::spawn(move || {
                 loop {
-                    thread::sleep(Duration::from_millis(1000));
+                    std::thread::sleep(Duration::from_millis(1000));
                     match rx_state.recv() {
                         Ok(()) => {
                             debug!("saving state to {}", &fname);

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -53,12 +53,6 @@ use std::time::Duration;
 
 use flexi_logger::DeferredNow;
 use log::Record;
-#[cfg(not(windows))]
-use signal_hook::consts::TERM_SIGNALS;
-#[cfg(not(windows))]
-use signal_hook::consts::signal::*;
-#[cfg(not(windows))]
-use signal_hook::iterator::{SignalsInfo, exfiltrator::SignalOnly};
 
 use camillalib::Res;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,42 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-#[cfg(target_os = "linux")]
-extern crate alsa;
-#[cfg(target_os = "linux")]
-extern crate alsa_sys;
-extern crate clap;
-#[cfg(target_os = "macos")]
-extern crate coreaudio;
-#[cfg(feature = "cpal-backend")]
-extern crate cpal;
-extern crate crossbeam_channel;
-#[cfg(target_os = "macos")]
-extern crate dispatch;
-#[cfg(feature = "pulse-backend")]
-extern crate libpulse_binding as pulse;
-#[cfg(feature = "pulse-backend")]
-extern crate libpulse_simple_binding as psimple;
-#[cfg(feature = "secure-websocket")]
-extern crate native_tls;
-#[cfg(target_os = "linux")]
-extern crate nix;
-extern crate num_complex;
-extern crate num_traits;
-#[cfg(all(target_os = "linux", feature = "pipewire-backend"))]
-extern crate pipewire;
-extern crate rand;
-extern crate rand_distr;
-extern crate realfft;
-extern crate rubato;
-extern crate serde;
-extern crate serde_with;
-extern crate signal_hook;
-#[cfg(feature = "websocket")]
-extern crate tungstenite;
-//#[cfg(target_os = "windows")]
-//extern crate winapi;
-
 #[macro_use]
 extern crate log;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub mod processing;
 pub mod processors;
 #[cfg(all(target_os = "linux", feature = "pulse-backend"))]
 pub mod pulse_backend;
+pub mod signals;
 #[cfg(feature = "websocket")]
 pub mod socketserver;
 pub mod statefile;

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -32,159 +32,182 @@ pub fn run_processing(
     rx_pipeconf: crossbeam_channel::Receiver<(config::ConfigChange, config::Configuration)>,
     processing_params: Arc<ProcessingParameters>,
 ) -> thread::JoinHandle<()> {
-    thread::spawn(move || {
-        let chunksize = conf_proc.devices.chunksize;
-        let samplerate = conf_proc.devices.samplerate;
-        let multithreaded = conf_proc.devices.multithreaded();
-        let nbr_threads = conf_proc.devices.worker_threads();
-        let hw_threads = std::thread::available_parallelism()
-            .map(|p| p.get())
-            .unwrap_or_default();
-        if nbr_threads > hw_threads && multithreaded {
-            warn!(
-                "Requested {nbr_threads} worker threads. For optimal performance, this number should not \
+    std::thread::Builder::new()
+        .name("processing".to_string())
+        .spawn(move || {
+            actually_run_processing(
+                conf_proc,
+                barrier_proc,
+                tx_pb,
+                rx_cap,
+                rx_pipeconf,
+                processing_params,
+            )
+        })
+        .expect("processing thread can spawn")
+}
+
+fn actually_run_processing(
+    conf_proc: config::Configuration,
+    barrier_proc: Arc<Barrier>,
+    tx_pb: crossbeam_channel::Sender<AudioMessage>,
+    rx_cap: crossbeam_channel::Receiver<AudioMessage>,
+    rx_pipeconf: crossbeam_channel::Receiver<(config::ConfigChange, config::Configuration)>,
+    processing_params: Arc<ProcessingParameters>,
+) {
+    let chunksize = conf_proc.devices.chunksize;
+    let samplerate = conf_proc.devices.samplerate;
+    let multithreaded = conf_proc.devices.multithreaded();
+    let nbr_threads = conf_proc.devices.worker_threads();
+    let hw_threads = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or_default();
+    if nbr_threads > hw_threads && multithreaded {
+        warn!(
+            "Requested {nbr_threads} worker threads. For optimal performance, this number should not \
                 exceed the available CPU cores, which is {hw_threads}."
-            );
-        }
-        if hw_threads == 1 && multithreaded {
-            warn!(
-                "This system only has one CPU core, multithreaded processing is not recommended."
-            );
-        }
-        if nbr_threads == 1 && multithreaded {
-            warn!(
-                "Requested multithreaded processing with one worker thread. \
+        );
+    }
+    if hw_threads == 1 && multithreaded {
+        warn!("This system only has one CPU core, multithreaded processing is not recommended.");
+    }
+    if nbr_threads == 1 && multithreaded {
+        warn!(
+            "Requested multithreaded processing with one worker thread. \
                    Performance can improve by adding more threads or disabling multithreading."
-            );
-        }
-        let mut pipeline = pipeline::Pipeline::from_config(conf_proc, processing_params.clone());
-        debug!("build filters, waiting to start processing loop");
+        );
+    }
+    let mut pipeline = pipeline::Pipeline::from_config(conf_proc, processing_params.clone());
+    debug!("build filters, waiting to start processing loop");
 
-        let thread_handle =
-            match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
-                Ok(h) => {
-                    debug!("Processing thread has real-time priority.");
-                    Some(h)
-                }
-                Err(err) => {
-                    warn!("Processing thread could not get real time priority, error: {err}");
-                    None
-                }
-            };
+    let thread_handle =
+        match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
+            Ok(h) => {
+                debug!("Processing thread has real-time priority.");
+                Some(h)
+            }
+            Err(err) => {
+                warn!("Processing thread could not get real time priority, error: {err}");
+                None
+            }
+        };
 
-        // Initialize rayon thread pool
-        if multithreaded {
-            match rayon::ThreadPoolBuilder::new()
-                .num_threads(nbr_threads)
-                .build_global()
-            {
-                Ok(_) => {
-                    debug!(
-                        "Initialized global thread pool with {} workers",
-                        rayon::current_num_threads()
-                    );
-                    rayon::broadcast(|_| {
-                        match promote_current_thread_to_real_time(
-                            chunksize as u32,
-                            samplerate as u32,
-                        ) {
-                            Ok(_) => {
-                                debug!(
-                                    "Worker thread {} has real-time priority.",
-                                    rayon::current_thread_index().unwrap_or_default()
-                                );
-                            }
-                            Err(err) => {
-                                warn!(
-                                    "Worker thread {} could not get real time priority, error: {}",
-                                    rayon::current_thread_index().unwrap_or_default(),
-                                    err
-                                );
-                            }
-                        };
-                    });
+    // Initialize rayon thread pool
+    if multithreaded {
+        match rayon::ThreadPoolBuilder::new()
+            .num_threads(nbr_threads)
+            .thread_name(move |i| {
+                if nbr_threads == 1 {
+                    "processing-w".to_string()
+                } else {
+                    format!("processing-w-{i}")
                 }
-                Err(err) => {
-                    warn!("Failed to build thread pool, error: {err}");
-                }
-            };
-        }
+            })
+            .build_global()
+        {
+            Ok(_) => {
+                debug!(
+                    "Initialized global thread pool with {} workers",
+                    rayon::current_num_threads()
+                );
+                rayon::broadcast(|_| {
+                    match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
+                        Ok(_) => {
+                            debug!(
+                                "Worker thread {} has real-time priority.",
+                                rayon::current_thread_index().unwrap_or_default()
+                            );
+                        }
+                        Err(err) => {
+                            warn!(
+                                "Worker thread {} could not get real time priority, error: {}",
+                                rayon::current_thread_index().unwrap_or_default(),
+                                err
+                            );
+                        }
+                    };
+                });
+            }
+            Err(err) => {
+                warn!("Failed to build thread pool, error: {err}");
+            }
+        };
+    }
 
-        barrier_proc.wait();
-        debug!("Processing loop starts now!");
-        loop {
-            match rx_cap.recv() {
-                Ok(AudioMessage::Audio(mut chunk)) => {
-                    //trace!("AudioMessage::Audio received");
-                    chunk = pipeline.process_chunk(chunk);
-                    let msg = AudioMessage::Audio(chunk);
-                    if tx_pb.send(msg).is_err() {
-                        info!("Playback thread has already stopped.");
-                        break;
-                    }
-                }
-                Ok(AudioMessage::EndOfStream) => {
-                    trace!("AudioMessage::EndOfStream received");
-                    let msg = AudioMessage::EndOfStream;
-                    if tx_pb.send(msg).is_err() {
-                        info!("Playback thread has already stopped.");
-                    }
-                    break;
-                }
-                Ok(AudioMessage::Pause) => {
-                    trace!("AudioMessage::Pause received");
-                    let msg = AudioMessage::Pause;
-                    if tx_pb.send(msg).is_err() {
-                        info!("Playback thread has already stopped.");
-                        break;
-                    }
-                }
-                Err(err) => {
-                    error!("Message channel error: {err}");
-                    let msg = AudioMessage::EndOfStream;
-                    if tx_pb.send(msg).is_err() {
-                        info!("Playback thread has already stopped.");
-                    }
+    barrier_proc.wait();
+    debug!("Processing loop starts now!");
+    loop {
+        match rx_cap.recv() {
+            Ok(AudioMessage::Audio(mut chunk)) => {
+                //trace!("AudioMessage::Audio received");
+                chunk = pipeline.process_chunk(chunk);
+                let msg = AudioMessage::Audio(chunk);
+                if tx_pb.send(msg).is_err() {
+                    info!("Playback thread has already stopped.");
                     break;
                 }
             }
-            if let Ok((diff, new_config)) = rx_pipeconf.try_recv() {
-                trace!("Message received on config channel");
-                match diff {
-                    config::ConfigChange::Pipeline | config::ConfigChange::MixerParameters => {
-                        debug!("Rebuilding pipeline.");
-                        let new_pipeline =
-                            pipeline::Pipeline::from_config(new_config, processing_params.clone());
-                        pipeline = new_pipeline;
-                    }
-                    config::ConfigChange::FilterParameters {
-                        filters,
-                        mixers,
-                        processors,
-                    } => {
-                        debug!("Updating parameters of filters: {filters:?}, mixers: {mixers:?}.");
-                        pipeline.update_parameters(new_config, &filters, &mixers, &processors);
-                    }
-                    config::ConfigChange::Devices => {
-                        let msg = AudioMessage::EndOfStream;
-                        tx_pb.send(msg).unwrap();
-                        break;
-                    }
-                    _ => {}
-                };
-            };
-        }
-        processing_params.set_processing_load(0.0);
-        processing_params.set_resampler_load(0.0);
-        if let Some(h) = thread_handle {
-            match demote_current_thread_from_real_time(h) {
-                Ok(_) => {
-                    debug!("Processing thread returned to normal priority.")
+            Ok(AudioMessage::EndOfStream) => {
+                trace!("AudioMessage::EndOfStream received");
+                let msg = AudioMessage::EndOfStream;
+                if tx_pb.send(msg).is_err() {
+                    info!("Playback thread has already stopped.");
                 }
-                Err(_) => {
-                    warn!("Could not bring the processing thread back to normal priority.")
+                break;
+            }
+            Ok(AudioMessage::Pause) => {
+                trace!("AudioMessage::Pause received");
+                let msg = AudioMessage::Pause;
+                if tx_pb.send(msg).is_err() {
+                    info!("Playback thread has already stopped.");
+                    break;
                 }
-            };
+            }
+            Err(err) => {
+                error!("Message channel error: {err}");
+                let msg = AudioMessage::EndOfStream;
+                if tx_pb.send(msg).is_err() {
+                    info!("Playback thread has already stopped.");
+                }
+                break;
+            }
         }
-    })
+        if let Ok((diff, new_config)) = rx_pipeconf.try_recv() {
+            trace!("Message received on config channel");
+            match diff {
+                config::ConfigChange::Pipeline | config::ConfigChange::MixerParameters => {
+                    debug!("Rebuilding pipeline.");
+                    let new_pipeline =
+                        pipeline::Pipeline::from_config(new_config, processing_params.clone());
+                    pipeline = new_pipeline;
+                }
+                config::ConfigChange::FilterParameters {
+                    filters,
+                    mixers,
+                    processors,
+                } => {
+                    debug!("Updating parameters of filters: {filters:?}, mixers: {mixers:?}.");
+                    pipeline.update_parameters(new_config, &filters, &mixers, &processors);
+                }
+                config::ConfigChange::Devices => {
+                    let msg = AudioMessage::EndOfStream;
+                    tx_pb.send(msg).unwrap();
+                    break;
+                }
+                _ => {}
+            };
+        };
+    }
+    processing_params.set_processing_load(0.0);
+    processing_params.set_resampler_load(0.0);
+    if let Some(h) = thread_handle {
+        match demote_current_thread_from_real_time(h) {
+            Ok(_) => {
+                debug!("Processing thread returned to normal priority.")
+            }
+            Err(_) => {
+                warn!("Could not bring the processing thread back to normal priority.")
+            }
+        };
+    }
 }

--- a/src/pulse_backend/device.rs
+++ b/src/pulse_backend/device.rs
@@ -14,8 +14,8 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use psimple::Simple;
-use pulse;
+use libpulse_binding as pulse;
+use libpulse_simple_binding::Simple;
 use pulse::sample;
 use pulse::stream::Direction;
 

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -1,0 +1,12 @@
+#[cfg(not(windows))]
+mod unix_signals;
+#[cfg(windows)]
+mod windows_signals;
+
+pub(self) const EXIT_FORCED: i32 = 103; // Exit was forced by a second SIGINT
+
+#[cfg(not(windows))]
+pub use unix_signals::handle_signals;
+
+#[cfg(windows)]
+pub use windows_signals::handle_signals;

--- a/src/signals/mod.rs
+++ b/src/signals/mod.rs
@@ -3,7 +3,7 @@ mod unix_signals;
 #[cfg(windows)]
 mod windows_signals;
 
-pub(self) const EXIT_FORCED: i32 = 103; // Exit was forced by a second SIGINT
+const EXIT_FORCED: i32 = 103; // Exit was forced by a second SIGINT
 
 #[cfg(not(windows))]
 pub use unix_signals::handle_signals;

--- a/src/signals/unix_signals.rs
+++ b/src/signals/unix_signals.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, thread};
 
-use nix::libc::{SIGHUP, SIGUSR1};
+use signal_hook::consts::{SIGHUP, SIGUSR1};
 use signal_hook::{
     consts::TERM_SIGNALS,
     iterator::{SignalsInfo, exfiltrator::SignalOnly},

--- a/src/signals/unix_signals.rs
+++ b/src/signals/unix_signals.rs
@@ -1,59 +1,67 @@
 use std::{sync::Arc, thread};
 
 use nix::libc::{SIGHUP, SIGUSR1};
-use signal_hook::{consts::TERM_SIGNALS, iterator::{SignalsInfo, exfiltrator::SignalOnly}};
+use signal_hook::{
+    consts::TERM_SIGNALS,
+    iterator::{SignalsInfo, exfiltrator::SignalOnly},
+};
 
 use crate::{ControllerMessage, config, signals::EXIT_FORCED};
 
-pub fn handle_signals(logger: flexi_logger::LoggerHandle, tx_command_thread: crossbeam_channel::Sender<ControllerMessage>, active_path_thread: Arc<parking_lot::lock_api::Mutex<parking_lot::RawMutex, Option<String>>>) {
+pub fn handle_signals(
+    logger: flexi_logger::LoggerHandle,
+    tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
+    active_path_thread: Arc<parking_lot::lock_api::Mutex<parking_lot::RawMutex, Option<String>>>,
+) {
     thread::Builder::new()
         .name("signals".to_string())
         .spawn(move || {
-        let mut sigs = vec![SIGHUP, SIGUSR1];
-        sigs.extend(TERM_SIGNALS);
-        let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();
-        let mut exit_requested = false;
-        for info in &mut signals {
-            debug!("Received signal: {info}");
-            match info {
-                SIGHUP => {
-                    let path = (*active_path_thread.lock()).clone();
-                    if let Some(path) = path {
-                        match config::load_validate_config(path.as_str()) {
-                            Ok(conf) => {
-                                debug!("Config is valid");
-                                if let Err(e) = tx_command_thread
-                                    .try_send(ControllerMessage::ConfigChanged(Box::new(conf)))
-                                {
-                                    error!("Error sending reload message: {e}");
+            let mut sigs = vec![SIGHUP, SIGUSR1];
+            sigs.extend(TERM_SIGNALS);
+            let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();
+            let mut exit_requested = false;
+            for info in &mut signals {
+                debug!("Received signal: {info}");
+                match info {
+                    SIGHUP => {
+                        let path = (*active_path_thread.lock()).clone();
+                        if let Some(path) = path {
+                            match config::load_validate_config(path.as_str()) {
+                                Ok(conf) => {
+                                    debug!("Config is valid");
+                                    if let Err(e) = tx_command_thread
+                                        .try_send(ControllerMessage::ConfigChanged(Box::new(conf)))
+                                    {
+                                        error!("Error sending reload message: {e}");
+                                    }
                                 }
-                            }
-                            Err(err) => {
-                                error!("Config error during reload: {err}");
-                            }
-                        };
-                    } else {
-                        error!("Config path not specified, cannot reload");
+                                Err(err) => {
+                                    error!("Config error during reload: {err}");
+                                }
+                            };
+                        } else {
+                            error!("Config path not specified, cannot reload");
+                        }
                     }
-                }
-                SIGUSR1 => {
-                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Stop) {
-                        error!("Error sending stop message: {e}");
+                    SIGUSR1 => {
+                        if let Err(e) = tx_command_thread.try_send(ControllerMessage::Stop) {
+                            error!("Error sending stop message: {e}");
+                        }
                     }
-                }
-                _ => {
-                    if exit_requested {
-                        warn!("Forcing a shutdown");
-                        logger.flush();
-                        std::process::exit(EXIT_FORCED);
+                    _ => {
+                        if exit_requested {
+                            warn!("Forcing a shutdown");
+                            logger.flush();
+                            std::process::exit(EXIT_FORCED);
+                        }
+                        info!("Shutting down");
+                        exit_requested = true;
+                        if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
+                            error!("Error sending exit message: {e}");
+                        }
                     }
-                    info!("Shutting down");
-                    exit_requested = true;
-                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
-                        error!("Error sending exit message: {e}");
-                    }
-                }
-            };
-        }
-    }).expect("can spawn signals thread");
+                };
+            }
+        })
+        .expect("can spawn signals thread");
 }

--- a/src/signals/unix_signals.rs
+++ b/src/signals/unix_signals.rs
@@ -1,0 +1,59 @@
+use std::{sync::Arc, thread};
+
+use nix::libc::{SIGHUP, SIGUSR1};
+use signal_hook::{consts::TERM_SIGNALS, iterator::{SignalsInfo, exfiltrator::SignalOnly}};
+
+use crate::{ControllerMessage, config, signals::EXIT_FORCED};
+
+pub fn handle_signals(logger: flexi_logger::LoggerHandle, tx_command_thread: crossbeam_channel::Sender<ControllerMessage>, active_path_thread: Arc<parking_lot::lock_api::Mutex<parking_lot::RawMutex, Option<String>>>) {
+    thread::Builder::new()
+        .name("signals".to_string())
+        .spawn(move || {
+        let mut sigs = vec![SIGHUP, SIGUSR1];
+        sigs.extend(TERM_SIGNALS);
+        let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();
+        let mut exit_requested = false;
+        for info in &mut signals {
+            debug!("Received signal: {info}");
+            match info {
+                SIGHUP => {
+                    let path = (*active_path_thread.lock()).clone();
+                    if let Some(path) = path {
+                        match config::load_validate_config(path.as_str()) {
+                            Ok(conf) => {
+                                debug!("Config is valid");
+                                if let Err(e) = tx_command_thread
+                                    .try_send(ControllerMessage::ConfigChanged(Box::new(conf)))
+                                {
+                                    error!("Error sending reload message: {e}");
+                                }
+                            }
+                            Err(err) => {
+                                error!("Config error during reload: {err}");
+                            }
+                        };
+                    } else {
+                        error!("Config path not specified, cannot reload");
+                    }
+                }
+                SIGUSR1 => {
+                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Stop) {
+                        error!("Error sending stop message: {e}");
+                    }
+                }
+                _ => {
+                    if exit_requested {
+                        warn!("Forcing a shutdown");
+                        logger.flush();
+                        std::process::exit(EXIT_FORCED);
+                    }
+                    info!("Shutting down");
+                    exit_requested = true;
+                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
+                        error!("Error sending exit message: {e}");
+                    }
+                }
+            };
+        }
+    }).expect("can spawn signals thread");
+}

--- a/src/signals/windows_signals.rs
+++ b/src/signals/windows_signals.rs
@@ -1,0 +1,31 @@
+use std::{sync::{Arc, atomic::AtomicBool}, thread, time::Duration};
+
+use crate::{ControllerMessage, signals::EXIT_FORCED};
+
+pub fn handle_signals(logger: flexi_logger::LoggerHandle, tx_command_thread: crossbeam_channel::Sender<ControllerMessage>) {
+    thread::Builder::new()
+        .name("signals".to_string())
+        .spawn(move || {
+        // On windows we don't have signal_hook::iterator, so we just poll for signal...
+        const DELAY: Duration = Duration::from_millis(100);
+        let signal_exit = Arc::new(AtomicBool::new(false));
+        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&signal_exit)).unwrap();
+        let mut exit_requested = false;
+        loop {
+            if signal_exit.load(std::sync::atomic::Ordering::Relaxed) {
+                signal_exit.store(false, std::sync::atomic::Ordering::Relaxed);
+                if exit_requested {
+                    warn!("Forcing a shutdown");
+                    logger.flush();
+                    std::process::exit(EXIT_FORCED);
+                }
+                info!("Shutting down");
+                exit_requested = true;
+                if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
+                    error!("Error sending exit message: {e}");
+                }
+            }
+            thread::sleep(DELAY);
+        }
+    }).expect("can spawn signals thread");
+}

--- a/src/signals/windows_signals.rs
+++ b/src/signals/windows_signals.rs
@@ -1,31 +1,40 @@
-use std::{sync::{Arc, atomic::AtomicBool}, thread, time::Duration};
+use std::{
+    sync::{Arc, atomic::AtomicBool},
+    thread,
+    time::Duration,
+};
 
 use crate::{ControllerMessage, signals::EXIT_FORCED};
 
-pub fn handle_signals(logger: flexi_logger::LoggerHandle, tx_command_thread: crossbeam_channel::Sender<ControllerMessage>) {
+pub fn handle_signals(
+    logger: flexi_logger::LoggerHandle,
+    tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
+) {
     thread::Builder::new()
         .name("signals".to_string())
         .spawn(move || {
-        // On windows we don't have signal_hook::iterator, so we just poll for signal...
-        const DELAY: Duration = Duration::from_millis(100);
-        let signal_exit = Arc::new(AtomicBool::new(false));
-        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&signal_exit)).unwrap();
-        let mut exit_requested = false;
-        loop {
-            if signal_exit.load(std::sync::atomic::Ordering::Relaxed) {
-                signal_exit.store(false, std::sync::atomic::Ordering::Relaxed);
-                if exit_requested {
-                    warn!("Forcing a shutdown");
-                    logger.flush();
-                    std::process::exit(EXIT_FORCED);
+            // On windows we don't have signal_hook::iterator, so we just poll for signal...
+            const DELAY: Duration = Duration::from_millis(100);
+            let signal_exit = Arc::new(AtomicBool::new(false));
+            signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&signal_exit))
+                .unwrap();
+            let mut exit_requested = false;
+            loop {
+                if signal_exit.load(std::sync::atomic::Ordering::Relaxed) {
+                    signal_exit.store(false, std::sync::atomic::Ordering::Relaxed);
+                    if exit_requested {
+                        warn!("Forcing a shutdown");
+                        logger.flush();
+                        std::process::exit(EXIT_FORCED);
+                    }
+                    info!("Shutting down");
+                    exit_requested = true;
+                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
+                        error!("Error sending exit message: {e}");
+                    }
                 }
-                info!("Shutting down");
-                exit_requested = true;
-                if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
-                    error!("Error sending exit message: {e}");
-                }
+                thread::sleep(DELAY);
             }
-            thread::sleep(DELAY);
-        }
-    }).expect("can spawn signals thread");
+        })
+        .expect("can spawn signals thread");
 }


### PR DESCRIPTION
Hi @HEnquist! I've set up CamillaDSP as a little DAC appliance to go with my KVM that switches between macos, windows, and linux. I want my DSP to follow across operating systems, and I don't want to figure out all 3 os's :-). It's a pretty nice setup; I've even got a dynamic config & output swap for headphones vs speakers output.

Anyway, CamillaDSP is an incredible piece of software. I could not have reasonably made this desktop DAC without it. I'm a rust developer, and I wonder if you might be open to some janitorial PR's? I don't rely on ai for my open source pr's, so I'm hopeful these efforts won't be seen as extractive. I just like this software and I would love to see some edges (like thread names and file cohesion, maybe workspace organization eventually) cleaned up a little.

I figure to make the most of your time I can dump a few low hanging fruit cleanups in this PR. Each commit is focused on one change, and the only behavior I'm changing is to add names to threads (so my htop looks more friendly)