### PR TITLE
add support for multiple pipelines

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -16,7 +16,11 @@ passthrough = [
 ]
 
 [target.aarch64-unknown-linux-gnu]
-image = "cross/armv8:v1"
+# image = "cross/armv8:v1"
+pre-build = [
+    "dpkg --add-architecture arm64",
+    "apt-get update && apt-get install --assume-yes libasound2-dev:arm64",
+]
 
 [target.aarch64-unknown-linux-gnu.env]
 passthrough = [

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -163,7 +163,7 @@ fn build_pipeline(chunksize: usize, multithreaded: bool, with_conv: bool) -> Pip
     let conf = config::Configuration {
         title: None,
         description: None,
-        devices: config::Devices {
+        devices: config::DeviceGroups(vec![config::Devices {
             samplerate: 48000,
             chunksize,
             queuelimit: None,
@@ -193,7 +193,7 @@ fn build_pipeline(chunksize: usize, multithreaded: bool, with_conv: bool) -> Pip
             volume_limit: None,
             multithreaded: Some(multithreaded),
             worker_threads: None,
-        },
+        }]),
         mixers: Some(mixers),
         filters: Some(filters),
         processors: None,
@@ -216,10 +216,11 @@ fn build_pipeline(chunksize: usize, multithreaded: bool, with_conv: bool) -> Pip
                 bypassed: Some(false),
             }),
         ]),
+        pipelines: None,
     };
 
     let processing_params = Arc::new(ProcessingParameters::new(&[0.0_f32; 5], &[false; 5]));
-    Pipeline::from_config(conf, processing_params)
+    Pipeline::from_config(conf, 0, processing_params)
 }
 
 fn make_chunk(channels: usize, frames: usize) -> AudioChunk {

--- a/exampleconfigs/multi_pipeline.yml
+++ b/exampleconfigs/multi_pipeline.yml
@@ -1,0 +1,82 @@
+---
+# Example: two independent I/O pipelines.
+#
+# `devices` is a list of device groups. Each group is a fully independent
+# capture -> processing -> playback chain with its own sample rate and chunk
+# size, so two soundcards can be processed separately and simultaneously.
+#
+# Each entry in `pipelines` is the processing chain for one device group,
+# selected by its `device_group` index (0 = the first group in `devices`).
+
+devices:
+  # Device group 0: first soundcard, running at 48 kHz.
+  - samplerate: 48000
+    chunksize: 1024
+    capture:
+      type: Alsa
+      channels: 2
+      device: "hw:0"
+    playback:
+      type: Alsa
+      channels: 2
+      device: "hw:0"
+  # Device group 1: second soundcard, running at 44.1 kHz.
+  - samplerate: 44100
+    chunksize: 1024
+    capture:
+      type: Alsa
+      channels: 2
+      device: "hw:1"
+    playback:
+      type: Alsa
+      channels: 2
+      device: "hw:1"
+
+filters:
+  # Two biquads used by pipeline 0.
+  hp_80hz:
+    type: Biquad
+    parameters:
+      type: Highpass
+      freq: 80
+      q: 0.7
+  dip_1k:
+    type: Biquad
+    parameters:
+      type: Peaking
+      freq: 1000
+      gain: -3.0
+      q: 1.5
+  # Two biquads used by pipeline 1.
+  bass_shelf:
+    type: Biquad
+    parameters:
+      type: Lowshelf
+      freq: 200
+      gain: 4.0
+      q: 0.7
+  treble_shelf:
+    type: Biquad
+    parameters:
+      type: Highshelf
+      freq: 5000
+      gain: -2.0
+      q: 0.7
+
+pipelines:
+  # First soundcard: high-pass, then a peaking dip.
+  - device_group: 0
+    steps:
+      - type: Filter
+        channels: [0, 1]
+        names:
+          - hp_80hz
+          - dip_1k
+  # Second soundcard: low-shelf boost, then high-shelf cut.
+  - device_group: 1
+    steps:
+      - type: Filter
+        channels: [0, 1]
+        names:
+          - bass_shelf
+          - treble_shelf

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -906,6 +906,99 @@ impl Devices {
     }
 }
 
+/// A list of device groups, describing an independent capture/playback pair
+#[derive(Clone, Debug, PartialEq)]
+pub struct DeviceGroups(pub Vec<Devices>);
+
+impl DeviceGroups {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Device group at `index`. Panics if out of range.
+    pub fn group(&self, index: usize) -> &Devices {
+        &self.0[index]
+    }
+
+    pub fn group_mut(&mut self, index: usize) -> &mut Devices {
+        &mut self.0[index]
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, Devices> {
+        self.0.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Devices> {
+        self.0.iter_mut()
+    }
+}
+
+impl std::ops::Index<usize> for DeviceGroups {
+    type Output = Devices;
+    fn index(&self, index: usize) -> &Devices {
+        &self.0[index]
+    }
+}
+
+impl Serialize for DeviceGroups {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // A single group serializes as a bare mapping, to stay byte-for-byte
+        // compatible with historical single-device configurations.
+        if self.0.len() == 1 {
+            self.0[0].serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for DeviceGroups {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct DeviceGroupsVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for DeviceGroupsVisitor {
+            type Value = DeviceGroups;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a device group mapping or a sequence of device group mappings")
+            }
+
+            // A bare mapping is a single device group. Deserializing the inner
+            // `Devices` directly (rather than via `#[serde(untagged)]`) preserves
+            // its `deny_unknown_fields` errors, e.g. "unknown field `chunksze`".
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let devices =
+                    Devices::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+                Ok(DeviceGroups(vec![devices]))
+            }
+
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let groups =
+                    Vec::<Devices>::deserialize(serde::de::value::SeqAccessDeserializer::new(seq))?;
+                Ok(DeviceGroups(groups))
+            }
+        }
+
+        deserializer.deserialize_any(DeviceGroupsVisitor)
+    }
+}
+
 /// Sinc interpolation quality for the async sinc resampler.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum AsyncSincInterpolation {
@@ -1741,6 +1834,19 @@ impl PipelineStepProcessor {
     }
 }
 
+/// A processing chain bound to one device group.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct PipelineChain {
+    /// The device group index this chain uses
+    #[serde(default)]
+    pub device_group: usize,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Same ordered list of pipeline steps as the top-level [`Configuration::pipeline`]
+    pub steps: Vec<PipelineStep>,
+}
+
 /// A complete CamillaDSP configuration: devices, filters, mixers, processors, and the pipeline.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
@@ -1749,20 +1855,58 @@ pub struct Configuration {
     pub title: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
-    pub devices: Devices,
+    pub devices: DeviceGroups,
     #[serde(default)]
     pub mixers: Option<HashMap<String, Mixer>>,
     #[serde(default)]
     pub filters: Option<HashMap<String, Filter>>,
     #[serde(default)]
     pub processors: Option<HashMap<String, Processor>>,
+    /// Processing chain for the first device group (the historical single
+    /// pipeline). Mutually exclusive with a `pipelines` entry for group 0.
     #[serde(default)]
     pub pipeline: Option<Vec<PipelineStep>>,
+    /// Additional per-device-group processing chains. Each entry carries its own
+    /// `device_group` index.
+    #[serde(default)]
+    pub pipelines: Option<Vec<PipelineChain>>,
+}
+
+impl Configuration {
+    /// Returns the processing chains in this configuration, each paired with the
+    /// index of the device group it feeds.
+    ///
+    /// The legacy top-level [`pipeline`](Configuration::pipeline) field, if
+    /// present, is yielded first as the chain for device group `0`. Entries from
+    /// the [`pipelines`](Configuration::pipelines) field follow, each carrying
+    /// its own `device_group`. Validation rejects duplicate groups, so the
+    /// result has at most one chain per group.
+    pub fn chains(&self) -> Vec<(usize, &Vec<PipelineStep>)> {
+        let mut chains = Vec::new();
+        if let Some(pipeline) = &self.pipeline {
+            chains.push((0, pipeline));
+        }
+        if let Some(pipelines) = &self.pipelines {
+            for entry in pipelines {
+                chains.push((entry.device_group, &entry.steps));
+            }
+        }
+        chains
+    }
+
+    /// Returns the steps of the processing chain feeding `device_group`, or
+    /// `None` if no chain targets that group (a passthrough group).
+    pub fn chain_for_group(&self, device_group: usize) -> Option<&Vec<PipelineStep>> {
+        self.chains()
+            .into_iter()
+            .find(|(group, _)| *group == device_group)
+            .map(|(_, steps)| steps)
+    }
 }
 
 /// Describes what changed between two successive configurations, used to decide how much of the
 /// pipeline must be rebuilt on a hot-reload.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ConfigChange {
     /// Only filter/mixer/processor coefficients changed; names in each vec were affected.
     FilterParameters {

--- a/src/config/utils.rs
+++ b/src/config/utils.rs
@@ -127,9 +127,16 @@ pub fn load_config(filename: &str) -> Res<Configuration> {
 
 fn apply_overrides(configuration: &mut Configuration) -> Res<()> {
     let mut overrides = OVERRIDES.read().clone();
+    if configuration.devices.is_empty() {
+        // No device groups to override; validation reports the missing devices.
+        return Ok(());
+    }
+    // CLI overrides (rate/channels/format/extra_samples) have no group dimension,
+    // so they apply to the first device group only.
+    let devices = configuration.devices.group_mut(0);
     // Only one match arm for now, might be more later.
     #[allow(clippy::single_match)]
-    match &configuration.devices.capture {
+    match &devices.capture {
         CaptureDevice::WavFile(dev) => {
             if let Ok(wav_info) = dev.wav_info() {
                 overrides.channels = Some(wav_info.channels);
@@ -144,12 +151,12 @@ fn apply_overrides(configuration: &mut Configuration) -> Res<()> {
         _ => {}
     }
     if let Some(rate) = overrides.samplerate {
-        let cfg_rate = configuration.devices.samplerate;
-        let cfg_chunksize = configuration.devices.chunksize;
+        let cfg_rate = devices.samplerate;
+        let cfg_chunksize = devices.chunksize;
 
-        if configuration.devices.resampler.is_none() {
+        if devices.resampler.is_none() {
             debug!("Apply override for samplerate: {rate}");
-            configuration.devices.samplerate = rate;
+            devices.samplerate = rate;
             let scaled_chunksize = if rate > cfg_rate {
                 cfg_chunksize * (rate as f32 / cfg_rate as f32).round() as usize
             } else {
@@ -158,9 +165,9 @@ fn apply_overrides(configuration: &mut Configuration) -> Res<()> {
             debug!(
                 "Samplerate changed, adjusting chunksize: {cfg_chunksize} -> {scaled_chunksize}"
             );
-            configuration.devices.chunksize = scaled_chunksize;
+            devices.chunksize = scaled_chunksize;
             #[allow(unreachable_patterns)]
-            match &mut configuration.devices.capture {
+            match &mut devices.capture {
                 CaptureDevice::RawFile(dev) => {
                     let new_extra = dev.extra_samples() * rate / cfg_rate;
                     debug!(
@@ -183,17 +190,17 @@ fn apply_overrides(configuration: &mut Configuration) -> Res<()> {
             }
         } else {
             debug!("Apply override for capture_samplerate: {rate}");
-            configuration.devices.capture_samplerate = Some(rate);
-            if rate == cfg_rate && !configuration.devices.rate_adjust() {
+            devices.capture_samplerate = Some(rate);
+            if rate == cfg_rate && !devices.rate_adjust() {
                 debug!("Disabling unneccesary 1:1 resampling");
-                configuration.devices.resampler = None;
+                devices.resampler = None;
             }
         }
     }
     if let Some(extra) = overrides.extra_samples {
         debug!("Apply override for extra_samples: {extra}");
         #[allow(unreachable_patterns)]
-        match &mut configuration.devices.capture {
+        match &mut devices.capture {
             CaptureDevice::RawFile(dev) => {
                 dev.extra_samples = Some(extra);
             }
@@ -205,7 +212,7 @@ fn apply_overrides(configuration: &mut Configuration) -> Res<()> {
     }
     if let Some(chans) = overrides.channels {
         debug!("Apply override for capture channels: {chans}");
-        match &mut configuration.devices.capture {
+        match &mut devices.capture {
             CaptureDevice::RawFile(dev) => {
                 dev.channels = chans;
             }
@@ -261,7 +268,7 @@ fn apply_overrides(configuration: &mut Configuration) -> Res<()> {
     }
     if let Some(fmt) = overrides.sample_format {
         debug!("Apply override for capture sample format: {fmt}");
-        match &mut configuration.devices.capture {
+        match &mut devices.capture {
             CaptureDevice::RawFile(dev) => {
                 dev.format = fmt;
             }
@@ -346,8 +353,16 @@ fn replace_tokens(string: &str, samplerate: usize, channels: usize) -> String {
 }
 
 fn replace_tokens_in_config(config: &mut Configuration) {
-    let samplerate = config.devices.samplerate;
-    let num_channels = config.devices.capture.channels();
+    // The `$samplerate$`/`$channels$` tokens are resolved against the first
+    // device group. Filters and mixers form a single shared library, so token
+    // substitution can only target one rate; multi-rate setups that rely on
+    // tokenized shared filters are not supported (use explicit filter names per
+    // group instead). See the multi-device notes in the README.
+    if config.devices.is_empty() {
+        return;
+    }
+    let samplerate = config.devices.group(0).samplerate;
+    let num_channels = config.devices.group(0).capture.channels();
     if let Some(filters) = &mut config.filters {
         for (_name, filter) in filters.iter_mut() {
             match filter {
@@ -367,9 +382,9 @@ fn replace_tokens_in_config(config: &mut Configuration) {
             }
         }
     }
-    if let Some(pipeline) = &mut config.pipeline {
-        for mut step in pipeline.iter_mut() {
-            match &mut step {
+    let replace_in_steps = |steps: &mut Vec<PipelineStep>| {
+        for step in steps.iter_mut() {
+            match step {
                 PipelineStep::Filter(step) => {
                     for name in step.names.iter_mut() {
                         *name = replace_tokens(name, samplerate, num_channels);
@@ -382,6 +397,14 @@ fn replace_tokens_in_config(config: &mut Configuration) {
                     step.name = replace_tokens(&step.name, samplerate, num_channels);
                 }
             }
+        }
+    };
+    if let Some(pipeline) = &mut config.pipeline {
+        replace_in_steps(pipeline);
+    }
+    if let Some(pipelines) = &mut config.pipelines {
+        for pipeline in pipelines.iter_mut() {
+            replace_in_steps(&mut pipeline.steps);
         }
     }
 }
@@ -447,7 +470,7 @@ pub fn config_diff(currentconf: &Configuration, newconf: &Configuration) -> Conf
     if currentconf.devices != newconf.devices {
         return ConfigChange::Devices;
     }
-    if currentconf.pipeline != newconf.pipeline {
+    if currentconf.pipeline != newconf.pipeline || currentconf.pipelines != newconf.pipelines {
         return ConfigChange::Pipeline;
     }
     if currentconf.mixers != newconf.mixers {
@@ -522,53 +545,47 @@ pub fn config_diff(currentconf: &Configuration, newconf: &Configuration) -> Conf
     }
 }
 
-/// Validate the loaded configuration, stop on errors and print a helpful message.
-pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<()> {
-    // pre-process by applying overrides and replacing tokens
-    apply_overrides(conf)?;
-    replace_tokens_in_config(conf);
-    if let Some(fname) = filename {
-        replace_relative_paths_in_config(conf, fname);
-    }
+/// Validate the timing and device-specific settings of a single device group.
+fn validate_device_group(devices: &Devices) -> Res<()> {
     #[cfg(target_os = "linux")]
-    let target_level_limit = if matches!(conf.devices.playback, PlaybackDevice::Alsa { .. }) {
-        (4 + conf.devices.queuelimit()) * conf.devices.chunksize
+    let target_level_limit = if matches!(devices.playback, PlaybackDevice::Alsa { .. }) {
+        (4 + devices.queuelimit()) * devices.chunksize
     } else {
-        (2 + conf.devices.queuelimit()) * conf.devices.chunksize
+        (2 + devices.queuelimit()) * devices.chunksize
     };
     #[cfg(not(target_os = "linux"))]
-    let target_level_limit = (2 + conf.devices.queuelimit()) * conf.devices.chunksize;
+    let target_level_limit = (2 + devices.queuelimit()) * devices.chunksize;
 
-    if conf.devices.target_level() > target_level_limit {
+    if devices.target_level() > target_level_limit {
         let msg = format!("target_level cannot be larger than {target_level_limit}");
         return Err(ConfigError::new(&msg).into());
     }
-    if let Some(period) = conf.devices.adjust_period
+    if let Some(period) = devices.adjust_period
         && period <= 0.0
     {
         return Err(ConfigError::new("adjust_period must be positive and > 0").into());
     }
-    if let Some(threshold) = conf.devices.silence_threshold
+    if let Some(threshold) = devices.silence_threshold
         && threshold > 0.0
     {
         return Err(ConfigError::new("silence_threshold must be less than or equal to 0").into());
     }
-    if let Some(timeout) = conf.devices.silence_timeout
+    if let Some(timeout) = devices.silence_timeout
         && timeout < 0.0
     {
         return Err(ConfigError::new("silence_timeout cannot be negative").into());
     }
-    if conf.devices.ramp_time() < 0.0 {
+    if devices.ramp_time() < 0.0 {
         return Err(ConfigError::new("Volume ramp time cannot be negative").into());
     }
-    if conf.devices.volume_limit() > 50.0 {
+    if devices.volume_limit() > 50.0 {
         return Err(ConfigError::new("Volume limit cannot be above +50 dB").into());
     }
-    if conf.devices.volume_limit() < -150.0 {
+    if devices.volume_limit() < -150.0 {
         return Err(ConfigError::new("Volume limit cannot be less than -150 dB").into());
     }
     #[cfg(target_os = "windows")]
-    if let CaptureDevice::Wasapi(dev) = &conf.devices.capture
+    if let CaptureDevice::Wasapi(dev) = &devices.capture
         && let Some(format) = dev.format
         && format != WasapiSampleFormat::F32
         && !dev.is_exclusive()
@@ -578,7 +595,7 @@ pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<
         );
     }
     #[cfg(target_os = "windows")]
-    if let CaptureDevice::Wasapi(dev) = &conf.devices.capture
+    if let CaptureDevice::Wasapi(dev) = &devices.capture
         && dev.is_loopback()
         && dev.is_exclusive()
     {
@@ -587,7 +604,7 @@ pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<
         );
     }
     #[cfg(target_os = "windows")]
-    if let PlaybackDevice::Wasapi(dev) = &conf.devices.playback
+    if let PlaybackDevice::Wasapi(dev) = &devices.playback
         && let Some(format) = dev.format
         && format != WasapiSampleFormat::F32
         && !dev.is_exclusive()
@@ -598,7 +615,7 @@ pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<
     }
     #[cfg(all(target_os = "windows", feature = "asio-backend"))]
     if let (CaptureDevice::Asio(cap_dev), PlaybackDevice::Asio(pb_dev)) =
-        (&conf.devices.capture, &conf.devices.playback)
+        (&devices.capture, &devices.playback)
     {
         if cap_dev.device != pb_dev.device {
             return Err(ConfigError::new(
@@ -607,7 +624,7 @@ pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<
             )
             .into());
         }
-        if conf.devices.resampler.is_some() {
+        if devices.resampler.is_some() {
             return Err(ConfigError::new(
                 "Resampling is not supported in full-duplex ASIO mode. \
                  Both capture and playback share the same driver and sample rate",
@@ -617,7 +634,7 @@ pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<
     }
     if let PlaybackDevice::File {
         format, wav_header, ..
-    } = &conf.devices.playback
+    } = &devices.playback
         && *format == BinarySampleFormat::S24_4_RJ_LE
         && *wav_header == Some(true)
     {
@@ -625,7 +642,7 @@ pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<
             ConfigError::new("Wav files do not support the S24_4_RJ_LE sample format").into(),
         );
     }
-    if let CaptureDevice::RawFile(dev) = &conf.devices.capture {
+    if let CaptureDevice::RawFile(dev) = &devices.capture {
         let fname = &dev.filename;
         match File::open(fname) {
             Ok(f) => f,
@@ -635,7 +652,7 @@ pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<
             }
         };
     }
-    if let CaptureDevice::WavFile(dev) = &conf.devices.capture {
+    if let CaptureDevice::WavFile(dev) = &devices.capture {
         let fname = &dev.filename;
         let f = match File::open(fname) {
             Ok(f) => f,
@@ -650,174 +667,218 @@ pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<
             ConfigError::new(&msg)
         })?;
     }
-    let mut num_channels = conf.devices.capture.channels();
-    let fs = conf.devices.samplerate;
-    if let Some(pipeline) = &conf.pipeline {
-        for step in pipeline {
-            match step {
-                PipelineStep::Mixer(step) => {
-                    if !step.is_bypassed() {
-                        if let Some(mixers) = &conf.mixers {
-                            if !mixers.contains_key(&step.name) {
+    Ok(())
+}
+
+/// Validate the loaded configuration, stop on errors and print a helpful message.
+pub fn validate_config(conf: &mut Configuration, filename: Option<&str>) -> Res<()> {
+    // pre-process by applying overrides and replacing tokens
+    apply_overrides(conf)?;
+    replace_tokens_in_config(conf);
+    if let Some(fname) = filename {
+        replace_relative_paths_in_config(conf, fname);
+    }
+    if conf.devices.is_empty() {
+        return Err(ConfigError::new("No device groups are defined").into());
+    }
+    for devices in conf.devices.iter() {
+        validate_device_group(devices)?;
+    }
+    // Validate the processing chain feeding each device group independently.
+    // Reject chains targeting a non-existent group, and groups targeted by more
+    // than one chain (e.g. both the legacy `pipeline` and a `pipelines` entry
+    // for group 0, or duplicate `pipelines` entries).
+    let chains = conf.chains();
+    let mut seen_groups = Vec::with_capacity(chains.len());
+    for (group, _) in &chains {
+        if *group >= conf.devices.len() {
+            let msg = format!(
+                "A processing chain targets device group {group}, but only {} device group(s) are defined",
+                conf.devices.len()
+            );
+            return Err(ConfigError::new(&msg).into());
+        }
+        if seen_groups.contains(group) {
+            let msg = format!("More than one processing chain targets device group {group}");
+            return Err(ConfigError::new(&msg).into());
+        }
+        seen_groups.push(*group);
+    }
+    for group in 0..conf.devices.len() {
+        let devices = conf.devices.group(group);
+        let mut num_channels = devices.capture.channels();
+        let fs = devices.samplerate;
+        if let Some(pipeline) = conf.chain_for_group(group) {
+            for step in pipeline {
+                match step {
+                    PipelineStep::Mixer(step) => {
+                        if !step.is_bypassed() {
+                            if let Some(mixers) = &conf.mixers {
+                                if !mixers.contains_key(&step.name) {
+                                    let msg = format!("Use of missing mixer '{}'", &step.name);
+                                    return Err(ConfigError::new(&msg).into());
+                                } else {
+                                    let chan_in = mixers.get(&step.name).unwrap().channels.r#in;
+                                    if chan_in != num_channels {
+                                        let msg = format!(
+                                            "Mixer '{}' has wrong number of input channels. Expected {}, found {}.",
+                                            &step.name, num_channels, chan_in
+                                        );
+                                        return Err(ConfigError::new(&msg).into());
+                                    }
+                                    num_channels = mixers.get(&step.name).unwrap().channels.out;
+                                    match mixer::validate_mixer(mixers.get(&step.name).unwrap()) {
+                                        Ok(_) => {}
+                                        Err(err) => {
+                                            let msg = format!(
+                                                "Invalid mixer '{}'. Reason: {}",
+                                                &step.name, err
+                                            );
+                                            return Err(ConfigError::new(&msg).into());
+                                        }
+                                    }
+                                }
+                            } else {
                                 let msg = format!("Use of missing mixer '{}'", &step.name);
                                 return Err(ConfigError::new(&msg).into());
-                            } else {
-                                let chan_in = mixers.get(&step.name).unwrap().channels.r#in;
-                                if chan_in != num_channels {
-                                    let msg = format!(
-                                        "Mixer '{}' has wrong number of input channels. Expected {}, found {}.",
-                                        &step.name, num_channels, chan_in
-                                    );
-                                    return Err(ConfigError::new(&msg).into());
+                            }
+                        }
+                    }
+                    PipelineStep::Filter(step) => {
+                        if !step.is_bypassed() {
+                            if let Some(channels) = &step.channels {
+                                for channel in channels {
+                                    if *channel >= num_channels {
+                                        let msg = format!("Use of non existing channel {channel}");
+                                        return Err(ConfigError::new(&msg).into());
+                                    }
                                 }
-                                num_channels = mixers.get(&step.name).unwrap().channels.out;
-                                match mixer::validate_mixer(mixers.get(&step.name).unwrap()) {
-                                    Ok(_) => {}
-                                    Err(err) => {
+                                for idx in 1..channels.len() {
+                                    if channels[idx..].contains(&channels[idx - 1]) {
                                         let msg = format!(
-                                            "Invalid mixer '{}'. Reason: {}",
-                                            &step.name, err
+                                            "Use of duplicated channel {}",
+                                            &channels[idx - 1]
                                         );
                                         return Err(ConfigError::new(&msg).into());
                                     }
                                 }
                             }
-                        } else {
-                            let msg = format!("Use of missing mixer '{}'", &step.name);
-                            return Err(ConfigError::new(&msg).into());
-                        }
-                    }
-                }
-                PipelineStep::Filter(step) => {
-                    if !step.is_bypassed() {
-                        if let Some(channels) = &step.channels {
-                            for channel in channels {
-                                if *channel >= num_channels {
-                                    let msg = format!("Use of non existing channel {channel}");
-                                    return Err(ConfigError::new(&msg).into());
-                                }
-                            }
-                            for idx in 1..channels.len() {
-                                if channels[idx..].contains(&channels[idx - 1]) {
-                                    let msg =
-                                        format!("Use of duplicated channel {}", &channels[idx - 1]);
-                                    return Err(ConfigError::new(&msg).into());
-                                }
-                            }
-                        }
-                        for name in &step.names {
-                            if let Some(filters) = &conf.filters {
-                                if !filters.contains_key(name) {
+                            for name in &step.names {
+                                if let Some(filters) = &conf.filters {
+                                    if !filters.contains_key(name) {
+                                        let msg = format!("Use of missing filter '{name}'");
+                                        return Err(ConfigError::new(&msg).into());
+                                    }
+                                    match filters::validate_filter(fs, filters.get(name).unwrap()) {
+                                        Ok(_) => {}
+                                        Err(err) => {
+                                            let msg =
+                                                format!("Invalid filter '{name}'. Reason: {err}");
+                                            return Err(ConfigError::new(&msg).into());
+                                        }
+                                    }
+                                } else {
                                     let msg = format!("Use of missing filter '{name}'");
                                     return Err(ConfigError::new(&msg).into());
                                 }
-                                match filters::validate_filter(fs, filters.get(name).unwrap()) {
-                                    Ok(_) => {}
-                                    Err(err) => {
-                                        let msg = format!("Invalid filter '{name}'. Reason: {err}");
-                                        return Err(ConfigError::new(&msg).into());
-                                    }
-                                }
-                            } else {
-                                let msg = format!("Use of missing filter '{name}'");
-                                return Err(ConfigError::new(&msg).into());
                             }
                         }
                     }
-                }
-                PipelineStep::Processor(step) => {
-                    if !step.is_bypassed() {
-                        if let Some(processors) = &conf.processors {
-                            if !processors.contains_key(&step.name) {
-                                let msg = format!("Use of missing processor '{}'", step.name);
-                                return Err(ConfigError::new(&msg).into());
-                            } else {
-                                let procconf = processors.get(&step.name).unwrap();
-                                match procconf {
-                                    Processor::Compressor { parameters, .. } => {
-                                        let channels = parameters.channels;
-                                        if channels != num_channels {
-                                            let msg = format!(
-                                                "Compressor '{}' has wrong number of channels. Expected {}, found {}.",
-                                                step.name, num_channels, channels
-                                            );
-                                            return Err(ConfigError::new(&msg).into());
-                                        }
-                                        match compressor::validate_compressor(parameters) {
-                                            Ok(_) => {}
-                                            Err(err) => {
+                    PipelineStep::Processor(step) => {
+                        if !step.is_bypassed() {
+                            if let Some(processors) = &conf.processors {
+                                if !processors.contains_key(&step.name) {
+                                    let msg = format!("Use of missing processor '{}'", step.name);
+                                    return Err(ConfigError::new(&msg).into());
+                                } else {
+                                    let procconf = processors.get(&step.name).unwrap();
+                                    match procconf {
+                                        Processor::Compressor { parameters, .. } => {
+                                            let channels = parameters.channels;
+                                            if channels != num_channels {
                                                 let msg = format!(
-                                                    "Invalid processor '{}'. Reason: {}",
-                                                    step.name, err
+                                                    "Compressor '{}' has wrong number of channels. Expected {}, found {}.",
+                                                    step.name, num_channels, channels
                                                 );
                                                 return Err(ConfigError::new(&msg).into());
                                             }
+                                            match compressor::validate_compressor(parameters) {
+                                                Ok(_) => {}
+                                                Err(err) => {
+                                                    let msg = format!(
+                                                        "Invalid processor '{}'. Reason: {}",
+                                                        step.name, err
+                                                    );
+                                                    return Err(ConfigError::new(&msg).into());
+                                                }
+                                            }
                                         }
-                                    }
-                                    Processor::NoiseGate { parameters, .. } => {
-                                        let channels = parameters.channels;
-                                        if channels != num_channels {
-                                            let msg = format!(
-                                                "NoiseGate '{}' has wrong number of channels. Expected {}, found {}.",
-                                                step.name, num_channels, channels
-                                            );
-                                            return Err(ConfigError::new(&msg).into());
-                                        }
-                                        match noisegate::validate_noise_gate(parameters) {
-                                            Ok(_) => {}
-                                            Err(err) => {
+                                        Processor::NoiseGate { parameters, .. } => {
+                                            let channels = parameters.channels;
+                                            if channels != num_channels {
                                                 let msg = format!(
-                                                    "Invalid noise gate '{}'. Reason: {}",
-                                                    step.name, err
+                                                    "NoiseGate '{}' has wrong number of channels. Expected {}, found {}.",
+                                                    step.name, num_channels, channels
                                                 );
                                                 return Err(ConfigError::new(&msg).into());
                                             }
+                                            match noisegate::validate_noise_gate(parameters) {
+                                                Ok(_) => {}
+                                                Err(err) => {
+                                                    let msg = format!(
+                                                        "Invalid noise gate '{}'. Reason: {}",
+                                                        step.name, err
+                                                    );
+                                                    return Err(ConfigError::new(&msg).into());
+                                                }
+                                            }
                                         }
-                                    }
-                                    Processor::RACE { parameters, .. } => {
-                                        let channels = parameters.channels;
-                                        if channels != num_channels {
-                                            let msg = format!(
-                                                "RACE processor '{}' has wrong number of channels. Expected {}, found {}.",
-                                                step.name, num_channels, channels
-                                            );
-                                            return Err(ConfigError::new(&msg).into());
-                                        }
-                                        match race::validate_race(parameters) {
-                                            Ok(_) => {}
-                                            Err(err) => {
+                                        Processor::RACE { parameters, .. } => {
+                                            let channels = parameters.channels;
+                                            if channels != num_channels {
                                                 let msg = format!(
-                                                    "Invalid RACE processor '{}'. Reason: {}",
-                                                    step.name, err
+                                                    "RACE processor '{}' has wrong number of channels. Expected {}, found {}.",
+                                                    step.name, num_channels, channels
                                                 );
                                                 return Err(ConfigError::new(&msg).into());
+                                            }
+                                            match race::validate_race(parameters) {
+                                                Ok(_) => {}
+                                                Err(err) => {
+                                                    let msg = format!(
+                                                        "Invalid RACE processor '{}'. Reason: {}",
+                                                        step.name, err
+                                                    );
+                                                    return Err(ConfigError::new(&msg).into());
+                                                }
                                             }
                                         }
                                     }
                                 }
+                            } else {
+                                let msg = format!("Use of missing processor '{}'", step.name);
+                                return Err(ConfigError::new(&msg).into());
                             }
-                        } else {
-                            let msg = format!("Use of missing processor '{}'", step.name);
-                            return Err(ConfigError::new(&msg).into());
                         }
                     }
                 }
             }
         }
-    }
-    let num_channels_out = conf.devices.playback.channels();
-    if num_channels != num_channels_out {
-        let msg = format!(
-            "Pipeline outputs {num_channels} channels, playback device has {num_channels_out}."
-        );
-        return Err(ConfigError::new(&msg).into());
+        let num_channels_out = devices.playback.channels();
+        if num_channels != num_channels_out {
+            let msg = format!(
+                "Pipeline for device group {group} outputs {num_channels} channels, playback device has {num_channels_out}."
+            );
+            return Err(ConfigError::new(&msg).into());
+        }
     }
     Ok(())
 }
 
-/// Get a vector telling which channels are actually used in the pipeline
-pub fn used_capture_channels(conf: &Configuration) -> Vec<bool> {
-    if let Some(pipeline) = &conf.pipeline {
+/// Get a vector telling which channels are actually used in the pipeline of the
+/// given device group.
+pub fn used_capture_channels(conf: &Configuration, device_group: usize) -> Vec<bool> {
+    if let Some(pipeline) = conf.chain_for_group(device_group) {
         for step in pipeline.iter() {
             if let PipelineStep::Mixer(mix) = step
                 && !mix.is_bypassed()
@@ -828,23 +889,29 @@ pub fn used_capture_channels(conf: &Configuration) -> Vec<bool> {
             }
         }
     }
-    let capture_channels = conf.devices.capture.channels();
+    let capture_channels = conf.devices.group(device_group).capture.channels();
     vec![true; capture_channels]
 }
 
-/// Return the capture channel labels from `config`, or `None` if no config is active.
+/// Return the capture channel labels of the first device group from `config`, or
+/// `None` if no config is active.
 pub fn capture_channel_labels(config: &Option<Configuration>) -> Option<Vec<Option<String>>> {
-    if let Some(conf) = config {
-        conf.devices.capture.labels()
+    if let Some(conf) = config
+        && !conf.devices.is_empty()
+    {
+        conf.devices.group(0).capture.labels()
     } else {
         None
     }
 }
 
-/// Return the playback channel labels from `config`, or `None` if no config is active.
+/// Return the playback channel labels of the first device group from `config`,
+/// or `None` if no config is active.
 pub fn playback_channel_labels(config: &Option<Configuration>) -> Option<Vec<Option<String>>> {
-    if let Some(conf) = config {
-        if let Some(pipeline) = &conf.pipeline {
+    if let Some(conf) = config
+        && !conf.devices.is_empty()
+    {
+        if let Some(pipeline) = conf.chain_for_group(0) {
             for step in pipeline.iter().rev() {
                 if let PipelineStep::Mixer(mixerstep) = step
                     && let Some(mixers) = &conf.mixers
@@ -854,8 +921,145 @@ pub fn playback_channel_labels(config: &Option<Configuration>) -> Option<Vec<Opt
                 }
             }
         }
-        conf.devices.capture.labels()
+        conf.devices.group(0).capture.labels()
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A single device group (two channels in and out) with no pipeline.
+    const SINGLE_GROUP: &str = "
+devices:
+  samplerate: 48000
+  chunksize: 1024
+  capture:
+    type: SignalGenerator
+    channels: 2
+    signal:
+      type: Sine
+      freq: 1000
+      level: 0.0
+  playback:
+    type: Stdout
+    channels: 2
+    format: S16_LE
+";
+
+    // Two independent device groups, with a chain for the second group provided
+    // via the `pipelines` list and the first group's chain via `pipeline`.
+    const TWO_GROUPS: &str = "
+devices:
+  - samplerate: 48000
+    chunksize: 1024
+    capture:
+      type: SignalGenerator
+      channels: 2
+      signal: {type: Sine, freq: 1000, level: 0.0}
+    playback:
+      type: Stdout
+      channels: 2
+      format: S16_LE
+  - samplerate: 44100
+    chunksize: 512
+    capture:
+      type: SignalGenerator
+      channels: 2
+      signal: {type: Sine, freq: 2000, level: 0.0}
+    playback:
+      type: Stdout
+      channels: 2
+      format: S16_LE
+pipeline: []
+pipelines:
+  - device_group: 1
+    steps: []
+";
+
+    fn parse(yaml: &str) -> Configuration {
+        yaml_serde::from_str(yaml).unwrap()
+    }
+
+    // A single device group serializes back to a bare mapping (not a sequence),
+    // keeping single-device configs byte-compatible through get/set config.
+    #[test]
+    fn single_group_round_trips_as_mapping() {
+        let conf = parse(SINGLE_GROUP);
+        assert_eq!(conf.devices.len(), 1);
+        let serialized = yaml_serde::to_string(&conf).unwrap();
+        let value: yaml_serde::Value = yaml_serde::from_str(&serialized).unwrap();
+        assert!(
+            value["devices"].is_mapping(),
+            "single group should serialize as a mapping, got:\n{serialized}"
+        );
+    }
+
+    // Multiple device groups parse from, and serialize back to, a sequence.
+    #[test]
+    fn multiple_groups_round_trip_as_sequence() {
+        let conf = parse(TWO_GROUPS);
+        assert_eq!(conf.devices.len(), 2);
+        let serialized = yaml_serde::to_string(&conf).unwrap();
+        let value: yaml_serde::Value = yaml_serde::from_str(&serialized).unwrap();
+        assert!(
+            value["devices"].is_sequence(),
+            "multiple groups should serialize as a sequence, got:\n{serialized}"
+        );
+    }
+
+    #[test]
+    fn two_group_config_validates() {
+        let mut conf = parse(TWO_GROUPS);
+        validate_config(&mut conf, None).expect("two-group config should validate");
+    }
+
+    // A chain whose device_group is out of range is rejected.
+    #[test]
+    fn pipeline_targeting_missing_group_is_rejected() {
+        let mut conf = parse(SINGLE_GROUP);
+        conf.pipelines = Some(vec![PipelineChain {
+            device_group: 5,
+            description: None,
+            steps: vec![],
+        }]);
+        let err = validate_config(&mut conf, None).unwrap_err().to_string();
+        assert!(err.contains("device group 5"), "unexpected error: {err}");
+    }
+
+    // The legacy `pipeline` field and a `pipelines` entry for group 0 are
+    // mutually exclusive.
+    #[test]
+    fn duplicate_chain_for_group_zero_is_rejected() {
+        let mut conf = parse(SINGLE_GROUP);
+        conf.pipeline = Some(vec![]);
+        conf.pipelines = Some(vec![PipelineChain {
+            device_group: 0,
+            description: None,
+            steps: vec![],
+        }]);
+        let err = validate_config(&mut conf, None).unwrap_err().to_string();
+        assert!(
+            err.contains("More than one processing chain"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // A passthrough group (no chain) whose capture and playback channel counts
+    // differ is rejected.
+    #[test]
+    fn passthrough_channel_mismatch_is_rejected() {
+        let mut conf = parse(SINGLE_GROUP);
+        // Capture stays at 2 channels; widen playback to 4.
+        if let PlaybackDevice::Stdout { channels, .. } = &mut conf.devices.group_mut(0).playback {
+            *channels = 4;
+        }
+        let err = validate_config(&mut conf, None).unwrap_err().to_string();
+        assert!(
+            err.contains("outputs 2 channels, playback device has 4"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -14,7 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use crossbeam_channel::select;
 use parking_lot::{Mutex, RwLockUpgradableReadGuard};
 #[cfg(any(windows, feature = "websocket"))]
 use std::sync::atomic::AtomicBool;
@@ -73,6 +72,100 @@ pub struct EngineConfig {
     pub ws_pass: Option<String>,
 }
 
+/// Handles for supervising one running pipeline (one device group).
+struct RunningPipeline {
+    /// Commands (set speed, exit) to this group's capture thread.
+    tx_command: crossbeam_channel::Sender<CommandMessage>,
+    /// Live config updates to this group's processing thread.
+    tx_pipeconf: crossbeam_channel::Sender<(config::ConfigChange, config::Configuration)>,
+    /// Status messages from this group's capture and playback threads.
+    rx_status: crossbeam_channel::Receiver<StatusMessage>,
+    /// 4-way startup barrier (capture, playback, processing, supervisor).
+    barrier: Arc<Barrier>,
+    pb_handle: Box<thread::JoinHandle<()>>,
+    cap_handle: Box<thread::JoinHandle<()>>,
+    proc_handle: thread::JoinHandle<()>,
+    /// Status structs for this group. Group 0 shares the process-lifetime structs
+    /// held by the WebSocket server; others share only the global run status.
+    status: StatusStructs,
+    pb_ready: bool,
+    cap_ready: bool,
+    /// Whether the supervisor has already met this group's startup barrier.
+    barrier_released: bool,
+}
+
+/// The event a supervisor `select` resolved to: either a controller command, or
+/// a status message from the pipeline at the given index.
+enum SupervisorEvent {
+    Control(Result<ControllerMessage, crossbeam_channel::RecvError>),
+    Status(usize, Result<StatusMessage, crossbeam_channel::RecvError>),
+}
+
+/// Stop every pipeline in a session: tell all capture threads to exit, release
+/// any startup barriers the supervisor has not yet satisfied (so blocked
+/// device/processing threads can reach their exit paths), then join all threads.
+fn stop_all_pipelines(pipelines: &mut Vec<RunningPipeline>) {
+    for pipeline in pipelines.iter() {
+        if pipeline.tx_command.send(CommandMessage::Exit).is_err() {
+            debug!("Capture thread has already exited");
+        }
+    }
+    for pipeline in pipelines.iter_mut() {
+        if !pipeline.barrier_released {
+            pipeline.barrier.wait();
+            pipeline.barrier_released = true;
+        }
+    }
+    for pipeline in pipelines.drain(..) {
+        let _ = pipeline.pb_handle.join();
+        let _ = pipeline.cap_handle.join();
+        let _ = pipeline.proc_handle.join();
+    }
+}
+
+/// When both capture and playback of `group` are ready, meet its startup barrier.
+/// Once every group's barrier has been met, finish startup and clear the stop
+/// reason.
+fn try_release_barrier(
+    group: usize,
+    pipelines: &mut [RunningPipeline],
+    is_starting: &mut bool,
+    status_structs: &StatusStructs,
+) {
+    let pipeline = &mut pipelines[group];
+    if pipeline.pb_ready && pipeline.cap_ready && !pipeline.barrier_released {
+        debug!("Device group {group} ready, releasing startup barrier");
+        pipeline.barrier.wait();
+        pipeline.barrier_released = true;
+    }
+    if *is_starting && pipelines.iter().all(|p| p.barrier_released) {
+        debug!("All device groups ready, supervisor loop starts now!");
+        *is_starting = false;
+        crate::set_stop_reason(&status_structs.status, StopReason::None);
+    }
+}
+
+/// Stop all pipelines after a fatal device event, record the stop reason, clear
+/// the active config, and return [`ExitState::Restart`].
+fn fail_and_restart(
+    stop_reason: StopReason,
+    shared_configs: &SharedConfigs,
+    status_structs: &StatusStructs,
+    pipelines: &mut Vec<RunningPipeline>,
+    active_config: config::Configuration,
+) -> crate::Res<ExitState> {
+    crate::set_stop_reason(&status_structs.status, stop_reason);
+    stop_all_pipelines(pipelines);
+    {
+        let mut active_cfg_shared = shared_configs.active.lock();
+        let mut prev_cfg_shared = shared_configs.previous.lock();
+        *active_cfg_shared = None;
+        *prev_cfg_shared = Some(active_config);
+    }
+    crate::set_capture_state(&status_structs.capture, ProcessingState::Inactive);
+    Ok(ExitState::Restart)
+}
+
 /// Run one processing session: open devices, process audio, and return an [`ExitState`].
 pub fn run(
     shared_configs: SharedConfigs,
@@ -87,344 +180,304 @@ pub fn run(
             return Ok(ExitState::Exit);
         }
     };
-    let (tx_pb, rx_pb) = crossbeam_channel::bounded(active_config.devices.queuelimit());
-    let (tx_cap, rx_cap) = crossbeam_channel::bounded(active_config.devices.queuelimit());
+    let num_groups = active_config.devices.len();
 
-    let (tx_status, rx_status) = crossbeam_channel::unbounded();
-    let tx_status_pb = tx_status.clone();
-    let tx_status_cap = tx_status;
+    // One independent capture -> processing -> playback pipeline per device
+    // group. Each gets its own channels and a 4-way startup barrier (capture,
+    // playback, processing, supervisor). The control channel (`rx_ctrl`) and the
+    // shared configs are global across all groups.
+    let mut pipelines: Vec<RunningPipeline> = Vec::with_capacity(num_groups);
 
-    let (tx_command_cap, rx_command_cap) = crossbeam_channel::unbounded();
-    let (tx_pipeconf, rx_pipeconf) = crossbeam_channel::unbounded();
+    for group in 0..num_groups {
+        // Group 0 reuses the process-lifetime status structs held by the
+        // WebSocket server; additional groups get fresh structs that share the
+        // global run status (stop reason).
+        let group_status = if group == 0 {
+            status_structs.clone()
+        } else {
+            status_structs.new_with_shared_run_status()
+        };
+        let group_devices = active_config.devices.group(group).clone();
 
-    let barrier = Arc::new(Barrier::new(4));
-    let barrier_pb = barrier.clone();
-    let barrier_cap = barrier.clone();
-    let barrier_proc = barrier.clone();
+        let (tx_pb, rx_pb) = crossbeam_channel::bounded(group_devices.queuelimit());
+        let (tx_cap, rx_cap) = crossbeam_channel::bounded(group_devices.queuelimit());
+        let (tx_status_group, rx_status_group) = crossbeam_channel::unbounded();
+        let (tx_cmd, rx_cmd) = crossbeam_channel::unbounded();
+        let (tx_pipeconf_group, rx_pipeconf_group) = crossbeam_channel::unbounded();
+        let barrier = Arc::new(Barrier::new(4));
 
-    let conf_pb = active_config.clone();
-    let conf_cap = active_config.clone();
-    let conf_proc = active_config.clone();
+        // Processing thread
+        let proc_handle = processing::run_processing(
+            active_config.clone(),
+            group,
+            barrier.clone(),
+            tx_pb,
+            rx_cap,
+            rx_pipeconf_group,
+            group_status.processing.clone(),
+        );
 
-    // Processing thread
-    processing::run_processing(
-        conf_proc,
-        barrier_proc,
-        tx_pb,
-        rx_cap,
-        rx_pipeconf,
-        status_structs.processing.clone(),
-    );
+        // Playback thread
+        let mut playback_dev = audiodevice::new_playback_device(group_devices.clone());
+        let pb_handle = playback_dev
+            .start(
+                rx_pb,
+                barrier.clone(),
+                tx_status_group.clone(),
+                group_status.playback.clone(),
+            )
+            .unwrap();
 
-    // Playback thread
-    let mut playback_dev = audiodevice::new_playback_device(conf_pb.devices);
-    let pb_handle = playback_dev
-        .start(rx_pb, barrier_pb, tx_status_pb, status_structs.playback)
-        .unwrap();
+        let used_channels = config::used_capture_channels(&active_config, group);
+        debug!("Device group {group} using channels {used_channels:?}");
+        {
+            let mut capture_status = group_status.capture.write();
+            crate::update_capture_state(&mut capture_status, ProcessingState::Starting);
+            capture_status.used_channels = used_channels;
+        }
 
-    let used_channels = config::used_capture_channels(&active_config);
-    debug!("Using channels {used_channels:?}");
-    {
-        let mut capture_status = status_structs.capture.write();
-        crate::update_capture_state(&mut capture_status, ProcessingState::Starting);
-        capture_status.used_channels = used_channels;
+        // Capture thread
+        let mut capture_dev = audiodevice::new_capture_device(group_devices);
+        let cap_handle = capture_dev
+            .start(
+                tx_cap,
+                barrier.clone(),
+                tx_status_group,
+                rx_cmd,
+                group_status.capture.clone(),
+                group_status.processing.clone(),
+            )
+            .unwrap();
+
+        pipelines.push(RunningPipeline {
+            tx_command: tx_cmd,
+            tx_pipeconf: tx_pipeconf_group,
+            rx_status: rx_status_group,
+            barrier,
+            pb_handle,
+            cap_handle,
+            proc_handle,
+            status: group_status,
+            pb_ready: false,
+            cap_ready: false,
+            barrier_released: false,
+        });
     }
 
-    // Capture thread
-    let mut capture_dev = audiodevice::new_capture_device(conf_cap.devices);
-    let cap_handle = capture_dev
-        .start(
-            tx_cap,
-            barrier_cap,
-            tx_status_cap,
-            rx_command_cap,
-            status_structs.capture.clone(),
-            status_structs.processing.clone(),
-        )
-        .unwrap();
-
-    let mut pb_ready = false;
-    let mut cap_ready = false;
-
     loop {
-        // If startup procedure is not finished, do not process config change or exit
-        let ctrl_ch = if is_starting {
-            crossbeam_channel::never()
-        } else {
-            rx_ctrl.clone()
+        // Wait for a status message from any group, or (once startup is done) a
+        // controller command. A fresh selector is built each iteration because
+        // the set of receivers is dynamic (one status channel per group).
+        let event = {
+            let mut sel = crossbeam_channel::Select::new();
+            for pipeline in &pipelines {
+                sel.recv(&pipeline.rx_status);
+            }
+            // Only accept controller commands once every group has started.
+            let ctrl_index = if is_starting {
+                None
+            } else {
+                Some(sel.recv(&rx_ctrl))
+            };
+            let oper = sel.select();
+            let index = oper.index();
+            if Some(index) == ctrl_index {
+                SupervisorEvent::Control(oper.recv(&rx_ctrl))
+            } else {
+                SupervisorEvent::Status(index, oper.recv(&pipelines[index].rx_status))
+            }
         };
-        select! {
-            recv(ctrl_ch) -> msg  => {
-                match msg {
-                    Ok(ControllerMessage::ConfigChanged(new_conf)) => {
-                        if !ctrl_ch.is_empty() {
-                            debug!("Dropping config change command since there are more commands in the queue");
-                            continue;
+
+        match event {
+            SupervisorEvent::Control(msg) => match msg {
+                Ok(ControllerMessage::ConfigChanged(new_conf)) => {
+                    if !rx_ctrl.is_empty() {
+                        debug!(
+                            "Dropping config change command since there are more commands in the queue"
+                        );
+                        continue;
+                    }
+                    for pipeline in &pipelines {
+                        pipeline.status.processing.set_processing_load(0.0);
+                        pipeline.status.processing.set_resampler_load(0.0);
+                    }
+                    let comp = config::config_diff(&active_config, &new_conf);
+                    match comp {
+                        config::ConfigChange::Pipeline
+                        | config::ConfigChange::MixerParameters
+                        | config::ConfigChange::FilterParameters { .. } => {
+                            // Every group's processing thread rebuilds its own
+                            // chain from the new config.
+                            for pipeline in &pipelines {
+                                pipeline
+                                    .tx_pipeconf
+                                    .send((comp.clone(), (*new_conf).clone()))
+                                    .unwrap();
+                            }
+                            active_config = *new_conf;
+                            *shared_configs.active.lock() = Some(active_config.clone());
+                            for (group, pipeline) in pipelines.iter().enumerate() {
+                                let used_channels =
+                                    config::used_capture_channels(&active_config, group);
+                                pipeline.status.capture.write().used_channels = used_channels;
+                            }
+                            debug!("Sent changes to pipelines");
                         }
-                        status_structs.processing.set_processing_load(0.0);
-                        status_structs.processing.set_resampler_load(0.0);
-                        let comp = config::config_diff(&active_config, &new_conf);
-                        match comp {
-                            config::ConfigChange::Pipeline
-                            | config::ConfigChange::MixerParameters
-                            | config::ConfigChange::FilterParameters { .. } => {
-                                tx_pipeconf.send((comp, *new_conf.clone())).unwrap();
-                                active_config = *new_conf;
-                                *shared_configs.active.lock() = Some(active_config.clone());
-                                let used_channels = config::used_capture_channels(&active_config);
-                                debug!("Using channels {used_channels:?}");
-                                status_structs.capture.write().used_channels = used_channels;
-                                debug!("Sent changes to pipeline");
-                            }
-                            config::ConfigChange::Devices => {
-                                debug!("Devices changed, restart required.");
-                                if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                                    debug!("Capture thread has already exited");
-                                }
-                                trace!("Wait for playback thread to exit..");
-                                pb_handle.join().unwrap();
-                                trace!("Wait for capture thread to exit..");
-                                cap_handle.join().unwrap();
-                                *shared_configs.active.lock() = Some(*new_conf);
-                                trace!("All threads stopped, returning");
-                                return Ok(ExitState::Restart);
-                            }
-                            config::ConfigChange::None => {
-                                debug!("No changes in config.");
-                            }
-                        };
-                    },
-                    Ok(ControllerMessage::Stop) => {
-                        debug!("Stop requested...");
-                        if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                            debug!("Capture thread has already exited");
+                        config::ConfigChange::Devices => {
+                            debug!("Devices changed, restart required.");
+                            stop_all_pipelines(&mut pipelines);
+                            *shared_configs.active.lock() = Some(*new_conf);
+                            trace!("All threads stopped, returning");
+                            return Ok(ExitState::Restart);
                         }
-                        trace!("Wait for playback thread to exit..");
-                        pb_handle.join().unwrap();
-                        trace!("Wait for capture thread to exit..");
-                        cap_handle.join().unwrap();
+                        config::ConfigChange::None => {
+                            debug!("No changes in config.");
+                        }
+                    };
+                }
+                Ok(ControllerMessage::Stop) => {
+                    debug!("Stop requested...");
+                    stop_all_pipelines(&mut pipelines);
+                    {
+                        let mut active_cfg_shared = shared_configs.active.lock();
+                        let mut prev_cfg_shared = shared_configs.previous.lock();
+                        *active_cfg_shared = None;
+                        *prev_cfg_shared = Some(active_config);
+                    }
+                    trace!("All threads stopped, stopping");
+                    return Ok(ExitState::Restart);
+                }
+                Ok(ControllerMessage::Exit) => {
+                    debug!("Exit requested...");
+                    stop_all_pipelines(&mut pipelines);
+                    *shared_configs.previous.lock() = Some(active_config);
+                    trace!("All threads stopped, exiting");
+                    return Ok(ExitState::Exit);
+                }
+                Err(err) => {
+                    return Err(Box::new(err));
+                }
+            },
+            SupervisorEvent::Status(group, msg) => match msg {
+                Ok(msg) => match msg {
+                    StatusMessage::PlaybackReady => {
+                        debug!("Playback thread for group {group} ready to start");
+                        pipelines[group].pb_ready = true;
+                        try_release_barrier(
+                            group,
+                            &mut pipelines,
+                            &mut is_starting,
+                            &status_structs,
+                        );
+                    }
+                    StatusMessage::CaptureReady => {
+                        debug!("Capture thread for group {group} ready to start");
+                        pipelines[group].cap_ready = true;
+                        try_release_barrier(
+                            group,
+                            &mut pipelines,
+                            &mut is_starting,
+                            &status_structs,
+                        );
+                    }
+                    StatusMessage::PlaybackError(message) => {
+                        error!("Playback error (group {group}): {message}");
+                        return fail_and_restart(
+                            StopReason::PlaybackError(message),
+                            &shared_configs,
+                            &status_structs,
+                            &mut pipelines,
+                            active_config,
+                        );
+                    }
+                    StatusMessage::CaptureError(message) => {
+                        error!("Capture error (group {group}): {message}");
+                        return fail_and_restart(
+                            StopReason::CaptureError(message),
+                            &shared_configs,
+                            &status_structs,
+                            &mut pipelines,
+                            active_config,
+                        );
+                    }
+                    StatusMessage::PlaybackFormatChange(rate) => {
+                        error!("Playback stopped due to external format change (group {group})");
+                        return fail_and_restart(
+                            StopReason::PlaybackFormatChange(rate),
+                            &shared_configs,
+                            &status_structs,
+                            &mut pipelines,
+                            active_config,
+                        );
+                    }
+                    StatusMessage::CaptureFormatChange(rate) => {
+                        error!("Capture stopped due to external format change (group {group})");
+                        return fail_and_restart(
+                            StopReason::CaptureFormatChange(rate),
+                            &shared_configs,
+                            &status_structs,
+                            &mut pipelines,
+                            active_config,
+                        );
+                    }
+                    StatusMessage::PlaybackDone => {
+                        info!("Playback finished (group {group})");
+                        {
+                            let stat = status_structs.status.upgradable_read();
+                            if stat.stop_reason == StopReason::None {
+                                crate::update_stop_reason(
+                                    &mut RwLockUpgradableReadGuard::upgrade(stat),
+                                    StopReason::Done,
+                                );
+                            }
+                        }
+                        stop_all_pipelines(&mut pipelines);
                         {
                             let mut active_cfg_shared = shared_configs.active.lock();
                             let mut prev_cfg_shared = shared_configs.previous.lock();
                             *active_cfg_shared = None;
                             *prev_cfg_shared = Some(active_config);
                         }
-                        trace!("All threads stopped, stopping");
+                        trace!("All threads stopped, returning");
                         return Ok(ExitState::Restart);
-                    },
-                    Ok(ControllerMessage::Exit) => {
-                        debug!("Exit requested...");
-                        if tx_command_cap.send(CommandMessage::Exit).is_err() {
+                    }
+                    StatusMessage::CaptureDone => {
+                        info!("Capture finished (group {group})");
+                    }
+                    StatusMessage::SetSpeed(speed) => {
+                        debug!("SetSpeed message received (group {group})");
+                        if pipelines[group]
+                            .tx_command
+                            .send(CommandMessage::SetSpeed { speed })
+                            .is_err()
+                        {
                             debug!("Capture thread has already exited");
                         }
-                        trace!("Wait for playback thread to exit..");
-                        pb_handle.join().unwrap();
-                        trace!("Wait for capture thread to exit..");
-                        cap_handle.join().unwrap();
-                        *shared_configs.previous.lock() = Some(active_config);
-                        trace!("All threads stopped, exiting");
-                        return Ok(ExitState::Exit);
-                    },
-                    Err(err) => {
-                        return Err(Box::new(err));
                     }
+                    StatusMessage::SetVolume(vol) => {
+                        debug!("SetVolume message to {vol} dB received (group {group})");
+                        pipelines[group].status.processing.set_target_volume(0, vol);
+                    }
+                    StatusMessage::SetMute(mute) => {
+                        debug!("SetMute message to {mute} received (group {group})");
+                        pipelines[group].status.processing.set_mute(0, mute);
+                    }
+                },
+                Err(err) => {
+                    warn!(
+                        "Capture, Playback and Processing threads of group {group} have exited: {err}"
+                    );
+                    return fail_and_restart(
+                        StopReason::UnknownError(
+                            "Capture, Playback and Processing threads have exited".to_string(),
+                        ),
+                        &shared_configs,
+                        &status_structs,
+                        &mut pipelines,
+                        active_config,
+                    );
                 }
             },
-            recv(rx_status) -> msg => {
-                match msg {
-                    Ok(msg) => match msg {
-                        StatusMessage::PlaybackReady => {
-                            debug!("Playback thread ready to start");
-                            pb_ready = true;
-                            if cap_ready {
-                                debug!("Both capture and playback ready, release barrier");
-                                barrier.wait();
-                                debug!("Supervisor loop starts now!");
-                                is_starting = false;
-                            }
-                        }
-                        StatusMessage::CaptureReady => {
-                            debug!("Capture thread ready to start");
-                            cap_ready = true;
-                            if pb_ready {
-                                debug!("Both capture and playback ready, release barrier");
-                                barrier.wait();
-                                debug!("Supervisor loop starts now!");
-                                is_starting = false;
-                                crate::set_stop_reason(
-                                    &status_structs.status,
-                                    StopReason::None,
-                                );
-                            }
-                        }
-                        StatusMessage::PlaybackError(message) => {
-                            error!("Playback error: {message}");
-                            if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                                debug!("Capture thread has already exited");
-                            }
-                            if is_starting {
-                                debug!("Error while starting, release barrier");
-                                barrier.wait();
-                            }
-                            debug!("Wait for capture thread to exit..");
-                            crate::set_stop_reason(
-                                &status_structs.status,
-                                StopReason::PlaybackError(message),
-                            );
-                            cap_handle.join().unwrap();
-                            {
-                                let mut active_cfg_shared = shared_configs.active.lock();
-                                let mut prev_cfg_shared = shared_configs.previous.lock();
-                                *active_cfg_shared = None;
-                                *prev_cfg_shared = Some(active_config);
-                            }
-                            crate::set_capture_state(
-                                &status_structs.capture,
-                                ProcessingState::Inactive,
-                            );
-                            trace!("All threads stopped, returning");
-                            return Ok(ExitState::Restart);
-                        }
-                        StatusMessage::CaptureError(message) => {
-                            error!("Capture error: {message}");
-                            if is_starting {
-                                debug!("Error while starting, release barrier");
-                                barrier.wait();
-                            }
-                            debug!("Wait for playback thread to exit..");
-                            crate::set_stop_reason(
-                                &status_structs.status,
-                                StopReason::CaptureError(message),
-                            );
-                            pb_handle.join().unwrap();
-                            {
-                                let mut active_cfg_shared = shared_configs.active.lock();
-                                let mut prev_cfg_shared = shared_configs.previous.lock();
-                                *active_cfg_shared = None;
-                                *prev_cfg_shared = Some(active_config);
-                            }
-                            crate::set_capture_state(
-                                &status_structs.capture,
-                                ProcessingState::Inactive,
-                            );
-                            trace!("All threads stopped, returning");
-                            return Ok(ExitState::Restart);
-                        }
-                        StatusMessage::PlaybackFormatChange(rate) => {
-                            error!("Playback stopped due to external format change");
-                            if tx_command_cap.send(CommandMessage::Exit).is_err() {
-                                debug!("Capture thread has already exited");
-                            }
-                            if is_starting {
-                                debug!("Error while starting, release barrier");
-                                barrier.wait();
-                            }
-                            debug!("Wait for capture thread to exit..");
-                            crate::set_stop_reason(
-                                &status_structs.status,
-                                StopReason::PlaybackFormatChange(rate),
-                            );
-                            cap_handle.join().unwrap();
-                            {
-                                let mut active_cfg_shared = shared_configs.active.lock();
-                                let mut prev_cfg_shared = shared_configs.previous.lock();
-                                *active_cfg_shared = None;
-                                *prev_cfg_shared = Some(active_config);
-                            }
-                            crate::set_capture_state(
-                                &status_structs.capture,
-                                ProcessingState::Inactive,
-                            );
-                            trace!("All threads stopped, returning");
-                            return Ok(ExitState::Restart);
-                        }
-                        StatusMessage::CaptureFormatChange(rate) => {
-                            error!("Capture stopped due to external format change");
-                            if is_starting {
-                                debug!("Error while starting, release barrier");
-                                barrier.wait();
-                            }
-                            crate::set_stop_reason(
-                                &status_structs.status,
-                                StopReason::CaptureFormatChange(rate),
-                            );
-                            debug!("Wait for playback thread to exit..");
-                            pb_handle.join().unwrap();
-                            {
-                                let mut active_cfg_shared = shared_configs.active.lock();
-                                let mut prev_cfg_shared = shared_configs.previous.lock();
-                                *active_cfg_shared = None;
-                                *prev_cfg_shared = Some(active_config);
-                            }
-                            crate::set_capture_state(
-                                &status_structs.capture,
-                                ProcessingState::Inactive,
-                            );
-                            trace!("All threads stopped, returning");
-                            return Ok(ExitState::Restart);
-                        }
-                        StatusMessage::PlaybackDone => {
-                            info!("Playback finished");
-                            {
-                                let stat = status_structs.status.upgradable_read();
-                                if stat.stop_reason == StopReason::None {
-                                    crate::update_stop_reason(
-                                        &mut RwLockUpgradableReadGuard::upgrade(stat),
-                                        StopReason::Done,
-                                    );
-                                }
-                            }
-                            {
-                                let mut active_cfg_shared = shared_configs.active.lock();
-                                let mut prev_cfg_shared = shared_configs.previous.lock();
-                                *active_cfg_shared = None;
-                                *prev_cfg_shared = Some(active_config);
-                            }
-                            trace!("Wait for playback thread to exit..");
-                            pb_handle.join().unwrap();
-                            trace!("Wait for capture thread to exit..");
-                            cap_handle.join().unwrap();
-                            trace!("All threads stopped, returning");
-                            return Ok(ExitState::Restart);
-                        }
-                        StatusMessage::CaptureDone => {
-                            info!("Capture finished");
-                        }
-                        StatusMessage::SetSpeed(speed) => {
-                            debug!("SetSpeed message received");
-                            if tx_command_cap
-                                .send(CommandMessage::SetSpeed { speed })
-                                .is_err()
-                            {
-                                debug!("Capture thread has already exited");
-                            }
-                        }
-                        StatusMessage::SetVolume(vol) => {
-                            debug!("SetVolume message to  {vol} dB received");
-                            status_structs.processing.set_target_volume(0, vol);
-                        }
-                        StatusMessage::SetMute(mute) => {
-                            debug!("SetMute message to {mute} received");
-                            status_structs.processing.set_mute(0, mute);
-                        }
-                    },
-                    Err(err) => {
-                        warn!("Capture, Playback and Processing threads have exited: {err}");
-                        crate::set_stop_reason(
-                            &status_structs.status,
-                            StopReason::UnknownError(
-                                "Capture, Playback and Processing threads have exited"
-                                    .to_string(),
-                            ),
-                        );
-                        crate::set_capture_state(
-                            &status_structs.capture,
-                            ProcessingState::Inactive,
-                        );
-                        return Ok(ExitState::Restart);
-                    }
-                }
-            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -608,6 +608,20 @@ impl Default for StatusStructs {
     }
 }
 
+impl StatusStructs {
+    /// Create a fresh set of status structs for an additional device group:
+    /// independent capture/playback/processing state, but sharing this one's
+    /// run-level [`status`](StatusStructs::status) (stop reason).
+    pub fn new_with_shared_run_status(&self) -> Self {
+        Self {
+            capture: Arc::new(RwLock::new(CaptureStatus::default())),
+            playback: Arc::new(RwLock::new(PlaybackStatus::default())),
+            processing: Arc::new(ProcessingParameters::default()),
+            status: self.status.clone(),
+        }
+    }
+}
+
 /// Shared access to the active and previous configurations, used when hot-reloading.
 pub struct SharedConfigs {
     /// The configuration currently driving the running pipeline, if any.

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -194,13 +194,19 @@ impl Pipeline {
     /// Create a new pipeline from a configuration structure.
     pub fn from_config(
         conf: config::Configuration,
+        device_group: usize,
         processing_params: Arc<ProcessingParameters>,
     ) -> Self {
-        debug!("Build new pipeline");
-        trace!("Pipeline config {:?}", conf.pipeline);
+        debug!("Build new pipeline for device group {device_group}");
+        let devices = conf.devices.group(device_group);
+        let steps_for_group: Vec<config::PipelineStep> = conf
+            .chain_for_group(device_group)
+            .cloned()
+            .unwrap_or_default();
+        trace!("Pipeline config {steps_for_group:?}");
         let mut steps = Vec::<PipelineStep>::new();
-        let mut num_channels = conf.devices.capture.channels();
-        for step in conf.pipeline.unwrap_or_default() {
+        let mut num_channels = devices.capture.channels();
+        for step in steps_for_group {
             match step {
                 config::PipelineStep::Mixer(step) => {
                     if !step.is_bypassed() {
@@ -236,8 +242,8 @@ impl Pipeline {
                                 channel,
                                 &step.names,
                                 conf.filters.as_ref().unwrap().clone(),
-                                conf.devices.chunksize,
-                                conf.devices.samplerate,
+                                devices.chunksize,
+                                devices.samplerate,
                                 processing_params.clone(),
                             );
                             steps.push(PipelineStep::FilterStep(fltgrp));
@@ -253,8 +259,8 @@ impl Pipeline {
                                 let comp = processors::compressor::Compressor::from_config(
                                     &step.name,
                                     parameters,
-                                    conf.devices.samplerate,
-                                    conf.devices.chunksize,
+                                    devices.samplerate,
+                                    devices.chunksize,
                                 );
                                 Box::new(comp) as Box<dyn Processor>
                             }
@@ -262,8 +268,8 @@ impl Pipeline {
                                 let gate = processors::noisegate::NoiseGate::from_config(
                                     &step.name,
                                     parameters,
-                                    conf.devices.samplerate,
-                                    conf.devices.chunksize,
+                                    devices.samplerate,
+                                    devices.chunksize,
                                 );
                                 Box::new(gate) as Box<dyn Processor>
                             }
@@ -271,7 +277,7 @@ impl Pipeline {
                                 let race = processors::race::RACE::from_config(
                                     &step.name,
                                     parameters,
-                                    conf.devices.samplerate,
+                                    devices.samplerate,
                                 );
                                 Box::new(race) as Box<dyn Processor>
                             }
@@ -285,18 +291,18 @@ impl Pipeline {
         let mute = processing_params.is_mute(0);
         let volume = filters::basicfilters::Volume::new(
             "default",
-            conf.devices.ramp_time(),
-            conf.devices.volume_limit(),
+            devices.ramp_time(),
+            devices.volume_limit(),
             current_volume,
             mute,
-            conf.devices.chunksize,
-            conf.devices.samplerate,
+            devices.chunksize,
+            devices.samplerate,
             processing_params.clone(),
             0,
         );
-        let secs_per_chunk = conf.devices.chunksize as f32 / conf.devices.samplerate as f32;
-        if conf.devices.multithreaded() {
-            steps = parallelize_filters(&mut steps, conf.devices.capture.channels());
+        let secs_per_chunk = devices.chunksize as f32 / devices.samplerate as f32;
+        if devices.multithreaded() {
+            steps = parallelize_filters(&mut steps, devices.capture.channels());
         }
         Pipeline {
             steps,
@@ -470,14 +476,14 @@ devices:
     format: S16_LE
 ";
         let conf: crate::config::Configuration = yaml_serde::from_str(CONFIG).unwrap();
-        let chunksize = conf.devices.chunksize;
-        let channels = conf.devices.capture.channels();
+        let chunksize = conf.devices.group(0).chunksize;
+        let channels = conf.devices.group(0).capture.channels();
 
         let params = Arc::new(ProcessingParameters::default());
         params.set_target_volume(0, -100.0);
         params.sync_volumes_to_target();
 
-        let mut pipeline = Pipeline::from_config(conf, params);
+        let mut pipeline = Pipeline::from_config(conf, 0, params);
 
         let waveforms = vec![vec![1.0 as PrcFmt; chunksize]; channels];
         let chunk = AudioChunk::new(waveforms, 1.0, -1.0, chunksize, chunksize);

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -45,6 +45,7 @@ fn forward_to_playback(tx_pb: &crossbeam_channel::Sender<AudioMessage>, msg: Aud
 /// Spawn the processing thread: builds the pipeline, runs the chunk loop, and handles config updates.
 pub fn run_processing(
     conf_proc: config::Configuration,
+    device_group: usize,
     barrier_proc: Arc<Barrier>,
     tx_pb: crossbeam_channel::Sender<AudioMessage>,
     rx_cap: crossbeam_channel::Receiver<AudioMessage>,
@@ -52,10 +53,11 @@ pub fn run_processing(
     processing_params: Arc<ProcessingParameters>,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
-        let chunksize = conf_proc.devices.chunksize;
-        let samplerate = conf_proc.devices.samplerate;
-        let multithreaded = conf_proc.devices.multithreaded();
-        let nbr_threads = conf_proc.devices.worker_threads();
+        let devices = conf_proc.devices.group(device_group);
+        let chunksize = devices.chunksize;
+        let samplerate = devices.samplerate;
+        let multithreaded = devices.multithreaded();
+        let nbr_threads = devices.worker_threads();
         let hw_threads = std::thread::available_parallelism()
             .map(|p| p.get())
             .unwrap_or_default();
@@ -77,7 +79,8 @@ pub fn run_processing(
             );
         }
         processing_params.sync_volumes_to_target();
-        let mut pipeline = pipeline::Pipeline::from_config(conf_proc, processing_params.clone());
+        let mut pipeline =
+            pipeline::Pipeline::from_config(conf_proc, device_group, processing_params.clone());
         debug!("build filters, waiting to start processing loop");
 
         let thread_handle =
@@ -92,7 +95,11 @@ pub fn run_processing(
                 }
             };
 
-        // Initialize rayon thread pool
+        // Initialize rayon thread pool. The pool is process-global, so with
+        // multiple device groups it is built once by whichever multithreaded
+        // group starts first and shared by the rest (its `worker_threads` then
+        // applies to all). A later group finding it already built is expected,
+        // not an error. (Probably this is worth reconsidering)
         if multithreaded {
             match rayon::ThreadPoolBuilder::new()
                 .num_threads(nbr_threads)
@@ -125,7 +132,7 @@ pub fn run_processing(
                     });
                 }
                 Err(err) => {
-                    warn!("Failed to build thread pool, error: {err}");
+                    debug!("Global thread pool already initialized, sharing it ({err})");
                 }
             };
         }
@@ -178,8 +185,11 @@ pub fn run_processing(
                     config::ConfigChange::Pipeline | config::ConfigChange::MixerParameters => {
                         debug!("Rebuilding pipeline.");
                         processing_params.sync_volumes_to_target();
-                        let new_pipeline =
-                            pipeline::Pipeline::from_config(new_config, processing_params.clone());
+                        let new_pipeline = pipeline::Pipeline::from_config(
+                            new_config,
+                            device_group,
+                            processing_params.clone(),
+                        );
                         pipeline = new_pipeline;
                     }
                     config::ConfigChange::FilterParameters {

--- a/src/websocket_server/mod.rs
+++ b/src/websocket_server/mod.rs
@@ -1875,7 +1875,7 @@ fn make_spectrum_subscription(
         .active_config
         .lock()
         .as_ref()
-        .map(|c| c.devices.samplerate)
+        .map(|c| c.devices.group(0).samplerate)
         .unwrap_or(0);
     if samplerate == 0 {
         return Err(WsResult::ProcessingNotRunningError);
@@ -1922,7 +1922,7 @@ fn handle_get_spectrum(req: SpectrumRequest, shared_data: &SharedData) -> WsRepl
         .active_config
         .lock()
         .as_ref()
-        .map(|c| c.devices.samplerate)
+        .map(|c| c.devices.group(0).samplerate)
         .unwrap_or(0);
     if samplerate == 0 {
         return WsReply::GetSpectrum {


### PR DESCRIPTION
# Context

I'm using camilladsp to directly front as an alsa device to multiple KVM'd computers. It works great for audio output, but I have had to resort to alsaloop for getting the mic back through to the host.

```
host A,B,C -> kvm -> pi
                   /   \
         camilladsp   alsaloop
          dac2 pro     volt1
          speakers      mic
```

Alsaloop has problems when I try to also use that secondary sound card (volt1) as a headphones output. It goes into buffer overrun and it causes the volt1 device to restart every 1-3 seconds.

```
host A,B,C -> kvm -> pi
                   /
         camilladsp
    dac2 pro     volt1
    speakers      mic
```

This change makes it possible to do the above. I have tested by running it on my raspberry pi, and it runs both the previous config and the new config with 2 device groups and 2 pipelines.

# Important stuff to note

I haven't made web ui support for this yet. I think there are probably a few different ways it could be exposed, and I'd like to contribute the capability, even if it's relegated to "advanced" users for a time. I've stubbed the websocket config references to group(0), but **it doesn't seem to work with CamillaGUI 4.1.0**. I'm not sure if this is a next4.2.0 known thing or a new regression with this change.

# Reviewing

I recommend looking at `exampleconfigs/multi_pipeline.yml` to get an idea what you're looking for. Changes are in `devices` and `pipelines`. All the other examples should still work and all the tests (that I could run) still work.

Github is rendering the diff pretty uncharitably. I did massage the related code a little to avoid making a mess with device multiplicity. Github is struggling with indentation adjustments, like in validate_config. Local git renders it a little better imo.

* Config gets `DeviceGroups` (supports single/legacy/current format and yaml array)
* new `pipelines` root element, intended to replace `pipeline` eventually. `pipeline` still works, `pipelines` just has the ability to name the device group to which it applies.
* New `RunningPipeline` struct for holding the big bag of channels, thread handles, synchronization, and status variables for each device pipeline. I did not know what needed to be extracted into this before making this change, unfortunately. I think it improves readability but it does conflate a cleanup with a feature.
