### PR TITLE
Engine tidying

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -379,23 +379,26 @@ pub fn run_engine(engine_params: EngineConfig, logger: flexi_logger::LoggerHandl
         if let Some(fname) = &statefilename {
             let fname = fname.clone();
 
-            thread::spawn(move || {
-                loop {
-                    thread::sleep(Duration::from_millis(1000));
-                    match rx_state.recv() {
-                        Ok(()) => {
-                            debug!("saving state to {}", &fname);
-                            statefile::save_state(
-                                &fname,
-                                &active_config_path_clone,
-                                &processing_params_clone,
-                                &unsaved_state_changes,
-                            );
+            thread::Builder::new()
+                .name("statefile".to_string())
+                .spawn(move || {
+                    loop {
+                        thread::sleep(Duration::from_millis(1000));
+                        match rx_state.recv() {
+                            Ok(()) => {
+                                debug!("saving state to {}", &fname);
+                                statefile::save_state(
+                                    &fname,
+                                    &active_config_path_clone,
+                                    &processing_params_clone,
+                                    &unsaved_state_changes,
+                                );
+                            }
+                            Err(_) => break,
                         }
-                        Err(_) => break,
                     }
-                }
-            });
+                })
+                .expect("can spawn statefile thread");
         }
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -23,14 +23,8 @@ use std::thread;
 #[cfg(any(windows, feature = "websocket"))]
 use std::time::Duration;
 
-#[cfg(not(windows))]
-use signal_hook::consts::TERM_SIGNALS;
-#[cfg(not(windows))]
-use signal_hook::consts::signal::*;
-#[cfg(not(windows))]
-use signal_hook::iterator::{SignalsInfo, exfiltrator::SignalOnly};
-
 use crate::engine_pipeline::{EnginePipeline, start_pipeline};
+use crate::engine_process_signals::launch_process_signals_thread;
 #[cfg(feature = "websocket")]
 use crate::websocket_server;
 use crate::{
@@ -328,90 +322,9 @@ pub fn run_engine(engine_params: EngineConfig, logger: flexi_logger::LoggerHandl
         }
     }
 
-    #[cfg(any(not(windows), feature = "websocket"))]
     let active_config_path = Arc::new(Mutex::new(configname));
 
-    let tx_command_thread = tx_command.clone();
-
-    #[cfg(not(windows))]
-    let active_path_thread = active_config_path.clone();
-
-    #[cfg(not(windows))]
-    thread::spawn(move || {
-        let mut sigs = vec![SIGHUP, SIGUSR1];
-        sigs.extend(TERM_SIGNALS);
-        let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();
-        let mut exit_requested = false;
-        for info in &mut signals {
-            debug!("Received signal: {info}");
-            match info {
-                SIGHUP => {
-                    let path = (*active_path_thread.lock()).clone();
-                    if let Some(path) = path {
-                        match config::load_validate_config(path.as_str()) {
-                            Ok(conf) => {
-                                debug!("Config is valid");
-                                if let Err(e) = tx_command_thread
-                                    .try_send(ControllerMessage::ConfigChanged(Box::new(conf)))
-                                {
-                                    error!("Error sending reload message: {e}");
-                                }
-                            }
-                            Err(err) => {
-                                error!("Config error during reload: {err}");
-                            }
-                        };
-                    } else {
-                        error!("Config path not specified, cannot reload");
-                    }
-                }
-                SIGUSR1 => {
-                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Stop) {
-                        error!("Error sending stop message: {e}");
-                    }
-                }
-                _ => {
-                    if exit_requested {
-                        warn!("Forcing a shutdown");
-                        logger.flush();
-                        std::process::exit(EXIT_FORCED);
-                    }
-                    info!("Shutting down");
-                    exit_requested = true;
-                    SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
-                    if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
-                        error!("Error sending exit message: {e}");
-                    }
-                }
-            };
-        }
-    });
-
-    #[cfg(windows)]
-    thread::spawn(move || {
-        // On windows we don't have signal_hook::iterator, so we just poll for signal...
-        const DELAY: Duration = Duration::from_millis(100);
-        let signal_exit = Arc::new(AtomicBool::new(false));
-        signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&signal_exit)).unwrap();
-        let mut exit_requested = false;
-        loop {
-            if signal_exit.load(std::sync::atomic::Ordering::Relaxed) {
-                signal_exit.store(false, std::sync::atomic::Ordering::Relaxed);
-                if exit_requested {
-                    warn!("Forcing a shutdown");
-                    logger.flush();
-                    std::process::exit(EXIT_FORCED);
-                }
-                info!("Shutting down");
-                exit_requested = true;
-                SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
-                if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
-                    error!("Error sending exit message: {e}");
-                }
-            }
-            thread::sleep(DELAY);
-        }
-    });
+    launch_process_signals_thread(active_config_path.clone(), tx_command.clone(), logger);
 
     let status_structs = StatusStructs::default();
     let capture_status = status_structs.capture.clone();

--- a/src/engine_process_signals.rs
+++ b/src/engine_process_signals.rs
@@ -1,0 +1,126 @@
+// CamillaDSP - A flexible tool for processing audio
+// Copyright (C) 2026 Henrik Enquist
+//
+// This file is part of CamillaDSP.
+//
+// CamillaDSP is free software; you can redistribute it and/or modify it
+// under the terms of either:
+//
+// a) the GNU General Public License version 3,
+//    or
+// b) the Mozilla Public License Version 2.0.
+//
+// You should have received copies of the GNU General Public License and the
+// Mozilla Public License along with this program. If not, see
+// <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
+
+use parking_lot::lock_api::Mutex;
+use signal_hook::consts::{SIGHUP, SIGUSR1, TERM_SIGNALS};
+use signal_hook::iterator::{SignalsInfo, exfiltrator::SignalOnly};
+use std::sync::Arc;
+use std::thread;
+
+use crate::engine::EXIT_FORCED;
+use crate::{ControllerMessage, SHUTDOWN_REQUESTED, config};
+
+/// Launch a thread that watches for sigint, sighup, etc.
+pub fn launch_process_signals_thread(
+    active_path_thread: Arc<Mutex<parking_lot::RawMutex, Option<String>>>,
+    tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
+    logger: flexi_logger::LoggerHandle,
+) {
+    if let Err(e) = thread::Builder::new()
+        .name("signal-monitor".to_string())
+        .spawn(move || {
+            if cfg!(not(windows)) {
+                monitor_unix_signals(active_path_thread, tx_command_thread, logger);
+            } else {
+                monitor_windows_signals(tx_command_thread, logger);
+            }
+        })
+    {
+        error!("could not launch process signals monitor thread: {e:?}");
+    }
+}
+
+fn monitor_unix_signals(
+    active_path_thread: Arc<Mutex<parking_lot::RawMutex, Option<String>>>,
+    tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
+    logger: flexi_logger::LoggerHandle,
+) {
+    let mut sigs = vec![SIGHUP, SIGUSR1];
+    sigs.extend(TERM_SIGNALS);
+    let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();
+    let mut exit_requested = false;
+    for info in &mut signals {
+        debug!("Received signal: {info}");
+        match info {
+            SIGHUP => {
+                let path = (*active_path_thread.lock()).clone();
+                if let Some(path) = path {
+                    match config::load_validate_config(path.as_str()) {
+                        Ok(conf) => {
+                            debug!("Config is valid");
+                            if let Err(e) = tx_command_thread
+                                .try_send(ControllerMessage::ConfigChanged(Box::new(conf)))
+                            {
+                                error!("Error sending reload message: {e}");
+                            }
+                        }
+                        Err(err) => {
+                            error!("Config error during reload: {err}");
+                        }
+                    };
+                } else {
+                    error!("Config path not specified, cannot reload");
+                }
+            }
+            SIGUSR1 => {
+                if let Err(e) = tx_command_thread.try_send(ControllerMessage::Stop) {
+                    error!("Error sending stop message: {e}");
+                }
+            }
+            _ => {
+                if exit_requested {
+                    warn!("Forcing a shutdown");
+                    logger.flush();
+                    std::process::exit(EXIT_FORCED);
+                }
+                info!("Shutting down");
+                exit_requested = true;
+                SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
+                if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
+                    error!("Error sending exit message: {e}");
+                }
+            }
+        };
+    }
+}
+
+fn monitor_windows_signals(
+    tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
+    logger: flexi_logger::LoggerHandle,
+) {
+    // On windows we don't have signal_hook::iterator, so we just poll for signal...
+    const DELAY: std::time::Duration = std::time::Duration::from_millis(100);
+    let signal_exit = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&signal_exit)).unwrap();
+    let mut exit_requested = false;
+    loop {
+        if signal_exit.load(std::sync::atomic::Ordering::Relaxed) {
+            signal_exit.store(false, std::sync::atomic::Ordering::Relaxed);
+            if exit_requested {
+                warn!("Forcing a shutdown");
+                logger.flush();
+                std::process::exit(EXIT_FORCED);
+            }
+            info!("Shutting down");
+            exit_requested = true;
+            SHUTDOWN_REQUESTED.store(true, std::sync::atomic::Ordering::Relaxed);
+            if let Err(e) = tx_command_thread.try_send(ControllerMessage::Exit) {
+                error!("Error sending exit message: {e}");
+            }
+        }
+        thread::sleep(DELAY);
+    }
+}

--- a/src/engine_process_signals.rs
+++ b/src/engine_process_signals.rs
@@ -15,6 +15,13 @@
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
 use parking_lot::Mutex;
+// `signal_hook` gates these to non-windows internally, so the import carries the
+// same gate to keep them out of the windows build.
+#[cfg(not(windows))]
+use signal_hook::{
+    consts::{SIGHUP, SIGUSR1, TERM_SIGNALS},
+    iterator::{SignalsInfo, exfiltrator::SignalOnly},
+};
 use std::sync::Arc;
 use std::thread;
 
@@ -43,11 +50,6 @@ fn monitor_signals(
     tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
     logger: flexi_logger::LoggerHandle,
 ) {
-    // these are internally gated to non-windows configs in signal-hook.
-    // they're only used in this fn, so local import keeps the gate trim.
-    use signal_hook::consts::{SIGHUP, SIGUSR1, TERM_SIGNALS};
-    use signal_hook::iterator::{SignalsInfo, exfiltrator::SignalOnly};
-
     let mut sigs = vec![SIGHUP, SIGUSR1];
     sigs.extend(TERM_SIGNALS);
     let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();

--- a/src/engine_process_signals.rs
+++ b/src/engine_process_signals.rs
@@ -14,40 +14,40 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use parking_lot::lock_api::Mutex;
-use signal_hook::consts::{SIGHUP, SIGUSR1, TERM_SIGNALS};
-use signal_hook::iterator::{SignalsInfo, exfiltrator::SignalOnly};
+use parking_lot::Mutex;
 use std::sync::Arc;
 use std::thread;
 
 use crate::engine::EXIT_FORCED;
-use crate::{ControllerMessage, SHUTDOWN_REQUESTED, config};
+use crate::{ControllerMessage, SHUTDOWN_REQUESTED};
 
 /// Launch a thread that watches for sigint, sighup, etc.
 pub fn launch_process_signals_thread(
-    active_path_thread: Arc<Mutex<parking_lot::RawMutex, Option<String>>>,
+    active_path_thread: Arc<Mutex<Option<String>>>,
     tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
     logger: flexi_logger::LoggerHandle,
 ) {
     if let Err(e) = thread::Builder::new()
         .name("signal-monitor".to_string())
         .spawn(move || {
-            if cfg!(not(windows)) {
-                monitor_unix_signals(active_path_thread, tx_command_thread, logger);
-            } else {
-                monitor_windows_signals(tx_command_thread, logger);
-            }
+            monitor_signals(active_path_thread, tx_command_thread, logger);
         })
     {
         error!("could not launch process signals monitor thread: {e:?}");
     }
 }
 
-fn monitor_unix_signals(
-    active_path_thread: Arc<Mutex<parking_lot::RawMutex, Option<String>>>,
+#[cfg(not(windows))]
+fn monitor_signals(
+    active_path_thread: Arc<Mutex<Option<String>>>,
     tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
     logger: flexi_logger::LoggerHandle,
 ) {
+    // these are internally gated to non-windows configs in signal-hook.
+    // they're only used in this fn, so local import keeps the gate trim.
+    use signal_hook::consts::{SIGHUP, SIGUSR1, TERM_SIGNALS};
+    use signal_hook::iterator::{SignalsInfo, exfiltrator::SignalOnly};
+
     let mut sigs = vec![SIGHUP, SIGUSR1];
     sigs.extend(TERM_SIGNALS);
     let mut signals = SignalsInfo::<SignalOnly>::new(&sigs).unwrap();
@@ -58,7 +58,7 @@ fn monitor_unix_signals(
             SIGHUP => {
                 let path = (*active_path_thread.lock()).clone();
                 if let Some(path) = path {
-                    match config::load_validate_config(path.as_str()) {
+                    match crate::config::load_validate_config(path.as_str()) {
                         Ok(conf) => {
                             debug!("Config is valid");
                             if let Err(e) = tx_command_thread
@@ -97,7 +97,9 @@ fn monitor_unix_signals(
     }
 }
 
-fn monitor_windows_signals(
+#[cfg(windows)]
+fn monitor_signals(
+    _active_path_thread: Arc<Mutex<Option<String>>>,
     tx_command_thread: crossbeam_channel::Sender<ControllerMessage>,
     logger: flexi_logger::LoggerHandle,
 ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,8 @@ pub mod cpal_backend;
 pub mod engine;
 /// Structural wrapper for pipeline signals and channels.
 pub mod engine_pipeline;
+/// The thread that watches for process signals.
+pub mod engine_process_signals;
 /// File, stdin/stdout, and WAV audio backends.
 pub mod file_backend;
 /// Audio filter implementations and the [`filters::Filter`] trait.

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -51,165 +51,182 @@ pub fn run_processing(
     rx_pipeconf: crossbeam_channel::Receiver<(config::ConfigChange, config::Configuration)>,
     processing_params: Arc<ProcessingParameters>,
 ) -> thread::JoinHandle<()> {
-    thread::spawn(move || {
-        let chunksize = conf_proc.devices.chunksize;
-        let samplerate = conf_proc.devices.samplerate;
-        let multithreaded = conf_proc.devices.multithreaded();
-        let nbr_threads = conf_proc.devices.worker_threads();
-        let hw_threads = std::thread::available_parallelism()
-            .map(|p| p.get())
-            .unwrap_or_default();
-        if nbr_threads > hw_threads && multithreaded {
-            warn!(
-                "Requested {nbr_threads} worker threads. For optimal performance, this number should not \
-                exceed the available CPU cores, which is {hw_threads}."
+    thread::Builder::new()
+        .name("processing".to_string())
+        .spawn(move || {
+            processing(
+                conf_proc,
+                barrier_proc,
+                tx_pb,
+                rx_cap,
+                rx_pipeconf,
+                processing_params,
             );
-        }
-        if hw_threads == 1 && multithreaded {
-            warn!(
-                "This system only has one CPU core, multithreaded processing is not recommended."
-            );
-        }
-        if nbr_threads == 1 && multithreaded {
-            warn!(
-                "Requested multithreaded processing with one worker thread. \
-                   Performance can improve by adding more threads or disabling multithreading."
-            );
-        }
-        processing_params.sync_volumes_to_target();
-        let mut pipeline = pipeline::Pipeline::from_config(conf_proc, processing_params.clone());
-        debug!("build filters, waiting to start processing loop");
+        })
+        .expect("can spawn processing thread")
+}
 
-        let thread_handle =
-            match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
-                Ok(h) => {
-                    debug!("Processing thread has real-time priority.");
-                    Some(h)
-                }
-                Err(err) => {
-                    warn!("Processing thread could not get real time priority, error: {err}");
-                    None
-                }
-            };
+fn processing(
+    conf_proc: config::Configuration,
+    barrier_proc: Arc<Barrier>,
+    tx_pb: crossbeam_channel::Sender<AudioMessage>,
+    rx_cap: crossbeam_channel::Receiver<AudioMessage>,
+    rx_pipeconf: crossbeam_channel::Receiver<(config::ConfigChange, config::Configuration)>,
+    processing_params: Arc<ProcessingParameters>,
+) {
+    let chunksize = conf_proc.devices.chunksize;
+    let samplerate = conf_proc.devices.samplerate;
+    let multithreaded = conf_proc.devices.multithreaded();
+    let nbr_threads = conf_proc.devices.worker_threads();
+    let hw_threads = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or_default();
+    if nbr_threads > hw_threads && multithreaded {
+        warn!(
+            "Requested {nbr_threads} worker threads. For optimal performance, this number should not \
+            exceed the available CPU cores, which is {hw_threads}."
+        );
+    }
+    if hw_threads == 1 && multithreaded {
+        warn!("This system only has one CPU core, multithreaded processing is not recommended.");
+    }
+    if nbr_threads == 1 && multithreaded {
+        warn!(
+            "Requested multithreaded processing with one worker thread. \
+                Performance can improve by adding more threads or disabling multithreading."
+        );
+    }
+    processing_params.sync_volumes_to_target();
+    let mut pipeline = pipeline::Pipeline::from_config(conf_proc, processing_params.clone());
+    debug!("build filters, waiting to start processing loop");
 
-        // Initialize rayon thread pool
-        if multithreaded {
-            match rayon::ThreadPoolBuilder::new()
-                .num_threads(nbr_threads)
-                .build_global()
-            {
-                Ok(_) => {
-                    debug!(
-                        "Initialized global thread pool with {} workers",
-                        rayon::current_num_threads()
-                    );
-                    rayon::broadcast(|_| {
-                        match promote_current_thread_to_real_time(
-                            chunksize as u32,
-                            samplerate as u32,
-                        ) {
-                            Ok(_) => {
-                                debug!(
-                                    "Worker thread {} has real-time priority.",
-                                    rayon::current_thread_index().unwrap_or_default()
-                                );
-                            }
-                            Err(err) => {
-                                warn!(
-                                    "Worker thread {} could not get real time priority, error: {}",
-                                    rayon::current_thread_index().unwrap_or_default(),
-                                    err
-                                );
-                            }
-                        };
-                    });
-                }
-                Err(err) => {
-                    warn!("Failed to build thread pool, error: {err}");
-                }
-            };
-        }
+    let thread_handle =
+        match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
+            Ok(h) => {
+                debug!("Processing thread has real-time priority.");
+                Some(h)
+            }
+            Err(err) => {
+                warn!("Processing thread could not get real time priority, error: {err}");
+                None
+            }
+        };
 
-        barrier_proc.wait();
-        debug!("Processing loop starts now!");
-        loop {
-            match rx_cap.recv() {
-                Ok(AudioMessage::Audio(mut chunk)) => {
-                    //trace!("AudioMessage::Audio received");
-                    chunk = pipeline.process_chunk(chunk);
-                    let msg = AudioMessage::Audio(chunk);
-                    if !forward_to_playback(&tx_pb, msg) {
-                        info!("Playback thread has already stopped.");
-                        break;
-                    }
+    // Initialize rayon thread pool
+    if multithreaded {
+        match rayon::ThreadPoolBuilder::new()
+            .num_threads(nbr_threads)
+            .thread_name(|i| format!("process-wrk-{i}"))
+            .build_global()
+        {
+            Ok(_) => {
+                debug!(
+                    "Initialized global thread pool with {} workers",
+                    rayon::current_num_threads()
+                );
+                rayon::broadcast(|_| {
+                    match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
+                        Ok(_) => {
+                            debug!(
+                                "Worker thread {} has real-time priority.",
+                                rayon::current_thread_index().unwrap_or_default()
+                            );
+                        }
+                        Err(err) => {
+                            warn!(
+                                "Worker thread {} could not get real time priority, error: {}",
+                                rayon::current_thread_index().unwrap_or_default(),
+                                err
+                            );
+                        }
+                    };
+                });
+            }
+            Err(err) => {
+                warn!("Failed to build thread pool, error: {err}");
+            }
+        };
+    }
+
+    barrier_proc.wait();
+    debug!("Processing loop starts now!");
+    loop {
+        match rx_cap.recv() {
+            Ok(AudioMessage::Audio(mut chunk)) => {
+                //trace!("AudioMessage::Audio received");
+                chunk = pipeline.process_chunk(chunk);
+                let msg = AudioMessage::Audio(chunk);
+                if !forward_to_playback(&tx_pb, msg) {
+                    info!("Playback thread has already stopped.");
+                    break;
                 }
-                Ok(AudioMessage::EndOfStream) => {
-                    trace!("AudioMessage::EndOfStream received");
+            }
+            Ok(AudioMessage::EndOfStream) => {
+                trace!("AudioMessage::EndOfStream received");
+                let msg = AudioMessage::EndOfStream;
+                if !forward_to_playback(&tx_pb, msg) {
+                    info!("Playback thread has already stopped.");
+                }
+                break;
+            }
+            Ok(AudioMessage::Pause) => {
+                trace!("AudioMessage::Pause received");
+                let msg = AudioMessage::Pause;
+                if !forward_to_playback(&tx_pb, msg) {
+                    info!("Playback thread has already stopped.");
+                    break;
+                }
+            }
+            Err(err) => {
+                if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
+                    debug!("Capture channel closed during shutdown.");
+                } else {
+                    error!("Message channel error: {err}");
                     let msg = AudioMessage::EndOfStream;
                     if !forward_to_playback(&tx_pb, msg) {
                         info!("Playback thread has already stopped.");
                     }
-                    break;
                 }
-                Ok(AudioMessage::Pause) => {
-                    trace!("AudioMessage::Pause received");
-                    let msg = AudioMessage::Pause;
-                    if !forward_to_playback(&tx_pb, msg) {
-                        info!("Playback thread has already stopped.");
-                        break;
-                    }
-                }
-                Err(err) => {
-                    if SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Relaxed) {
-                        debug!("Capture channel closed during shutdown.");
-                    } else {
-                        error!("Message channel error: {err}");
-                        let msg = AudioMessage::EndOfStream;
-                        if !forward_to_playback(&tx_pb, msg) {
-                            info!("Playback thread has already stopped.");
-                        }
-                    }
-                    break;
-                }
+                break;
             }
-            if let Ok((diff, new_config)) = rx_pipeconf.try_recv() {
-                trace!("Message received on config channel");
-                match diff {
-                    config::ConfigChange::Pipeline | config::ConfigChange::MixerParameters => {
-                        debug!("Rebuilding pipeline.");
-                        processing_params.sync_volumes_to_target();
-                        let new_pipeline =
-                            pipeline::Pipeline::from_config(new_config, processing_params.clone());
-                        pipeline = new_pipeline;
-                    }
-                    config::ConfigChange::FilterParameters {
-                        filters,
-                        mixers,
-                        processors,
-                    } => {
-                        debug!("Updating parameters of filters: {filters:?}, mixers: {mixers:?}.");
-                        pipeline.update_parameters(new_config, &filters, &mixers, &processors);
-                    }
-                    config::ConfigChange::Devices => {
-                        let msg = AudioMessage::EndOfStream;
-                        let _ = forward_to_playback(&tx_pb, msg);
-                        break;
-                    }
-                    _ => {}
-                };
-            };
         }
-        processing_params.set_processing_load(0.0);
-        processing_params.set_resampler_load(0.0);
-        if let Some(h) = thread_handle {
-            match demote_current_thread_from_real_time(h) {
-                Ok(_) => {
-                    debug!("Processing thread returned to normal priority.")
+        if let Ok((diff, new_config)) = rx_pipeconf.try_recv() {
+            trace!("Message received on config channel");
+            match diff {
+                config::ConfigChange::Pipeline | config::ConfigChange::MixerParameters => {
+                    debug!("Rebuilding pipeline.");
+                    processing_params.sync_volumes_to_target();
+                    let new_pipeline =
+                        pipeline::Pipeline::from_config(new_config, processing_params.clone());
+                    pipeline = new_pipeline;
                 }
-                Err(_) => {
-                    warn!("Could not bring the processing thread back to normal priority.")
+                config::ConfigChange::FilterParameters {
+                    filters,
+                    mixers,
+                    processors,
+                } => {
+                    debug!("Updating parameters of filters: {filters:?}, mixers: {mixers:?}.");
+                    pipeline.update_parameters(new_config, &filters, &mixers, &processors);
                 }
+                config::ConfigChange::Devices => {
+                    let msg = AudioMessage::EndOfStream;
+                    let _ = forward_to_playback(&tx_pb, msg);
+                    break;
+                }
+                _ => {}
             };
-        }
-    })
+        };
+    }
+    processing_params.set_processing_load(0.0);
+    processing_params.set_resampler_load(0.0);
+    if let Some(h) = thread_handle {
+        match demote_current_thread_from_real_time(h) {
+            Ok(_) => {
+                debug!("Processing thread returned to normal priority.")
+            }
+            Err(_) => {
+                warn!("Could not bring the processing thread back to normal priority.")
+            }
+        };
+    }
 }


### PR DESCRIPTION
separate signals handling, name thread:

I pulled the signals handling code out of engine; it has very few
dependencies, and I noticed that signal_hook is compiled in both
windows and unix builds. To help make it easier to statically
verify compilation on windows, I removed the conditional
compilation blocks and pulled the decision into a compile-time
decided const if {} block. This keeps the code there to satisfy
clippy w.r.t. symbol use.

This does have the side effect of also creating an active_config_path
pointer whether or not it will be used. It's benign and would be
dropped immediately on a windows non-websocket build. It also
names the signal thread. I kept the thread name below 16 characters
so it renders nicely on htop et al.

I added a couple more thread names while I was in here too.