### PR TITLE
tighten rayon ownership

### DIFF
--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -219,7 +219,13 @@ fn build_pipeline(chunksize: usize, multithreaded: bool, with_conv: bool) -> Pip
     };
 
     let processing_params = Arc::new(ProcessingParameters::new(&[0.0_f32; 5], &[false; 5]));
-    Pipeline::from_config(conf, processing_params)
+    let filter_pool = camillalib::processing::build_processing_threadpool(
+        multithreaded,
+        conf.devices.worker_threads(),
+        conf.devices.chunksize,
+        conf.devices.samplerate,
+    );
+    Pipeline::from_config(conf, processing_params, filter_pool)
 }
 
 fn make_chunk(channels: usize, frames: usize) -> AudioChunk {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -23,6 +23,7 @@ use crate::filters::Filter;
 use crate::mixer;
 use crate::processors;
 use crate::processors::Processor;
+use audio_thread_priority::promote_current_thread_to_real_time;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -138,6 +139,7 @@ impl FilterGroup {
 /// Merged filter groups for all channels that can run in parallel via rayon.
 pub struct ParallelFilters {
     filters: Vec<Vec<Box<dyn Filter + Send>>>,
+    filter_pool: Arc<rayon::ThreadPool>,
 }
 
 impl ParallelFilters {
@@ -158,15 +160,17 @@ impl ParallelFilters {
 
     /// Apply all the filters to an AudioChunk.
     fn process_chunk(&mut self, input: &mut AudioChunk) -> Res<()> {
-        self.filters
-            .par_iter_mut()
-            .zip(input.waveforms.par_iter_mut())
-            .filter(|(f, w)| !f.is_empty() && !w.is_empty())
-            .for_each(|(f, w)| {
-                for filt in f {
-                    let _ = filt.process_waveform(w);
-                }
-            });
+        self.filter_pool.install(|| {
+            self.filters
+                .par_iter_mut()
+                .zip(input.waveforms.par_iter_mut())
+                .filter(|(f, w)| !f.is_empty() && !w.is_empty())
+                .for_each(|(f, w)| {
+                    for filt in f {
+                        let _ = filt.process_waveform(w);
+                    }
+                });
+        });
         Ok(())
     }
 }
@@ -296,7 +300,36 @@ impl Pipeline {
         );
         let secs_per_chunk = conf.devices.chunksize as f32 / conf.devices.samplerate as f32;
         if conf.devices.multithreaded() {
-            steps = parallelize_filters(&mut steps, conf.devices.capture.channels());
+            // Worker threads are promoted to real-time priority as they start.
+            // If the pool can't be built, fall back to single-threaded processing.
+            let chunksize = conf.devices.chunksize;
+            let samplerate = conf.devices.samplerate;
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(conf.devices.worker_threads())
+                .thread_name(|i| format!("process-wrk-{i}"))
+                .start_handler(move |idx| {
+                    match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
+                        Ok(_) => debug!("Filter worker thread {idx} has real-time priority."),
+                        Err(err) => warn!(
+                            "Filter worker thread {idx} could not get real time priority, error: {err}"
+                        ),
+                    }
+                })
+                .build();
+            match pool {
+                Ok(pool) => {
+                    steps = parallelize_filters(
+                        &mut steps,
+                        conf.devices.capture.channels(),
+                        &Arc::new(pool),
+                    );
+                }
+                Err(err) => {
+                    warn!(
+                        "Failed to build filter thread pool, running single-threaded. Error: {err}"
+                    );
+                }
+            }
         }
         Pipeline {
             steps,
@@ -379,9 +412,13 @@ impl Pipeline {
     }
 }
 
-// Loop trough the pipeline to merge individual filter steps,
+// Loop through the pipeline to merge individual filter steps,
 // in order use rayon to apply them in parallel.
-fn parallelize_filters(steps: &mut Vec<PipelineStep>, nbr_channels: usize) -> Vec<PipelineStep> {
+fn parallelize_filters(
+    steps: &mut Vec<PipelineStep>,
+    nbr_channels: usize,
+    pool: &Arc<rayon::ThreadPool>,
+) -> Vec<PipelineStep> {
     debug!("Merging filter steps to enable parallel processing");
     let mut new_steps: Vec<PipelineStep> = Vec::new();
     let mut parfilt = None;
@@ -420,7 +457,10 @@ fn parallelize_filters(steps: &mut Vec<PipelineStep>, nbr_channels: usize) -> Ve
                     for _ in 0..active_channels {
                         filters.push(Vec::new());
                     }
-                    parfilt = Some(ParallelFilters { filters });
+                    parfilt = Some(ParallelFilters {
+                        filters,
+                        filter_pool: pool.clone(),
+                    });
                 }
                 if let Some(ref mut f) = parfilt {
                     debug!(

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -23,7 +23,6 @@ use crate::filters::Filter;
 use crate::mixer;
 use crate::processors;
 use crate::processors::Processor;
-use audio_thread_priority::promote_current_thread_to_real_time;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -196,9 +195,13 @@ pub struct Pipeline {
 
 impl Pipeline {
     /// Create a new pipeline from a configuration structure.
+    ///
+    /// `filter_pool` is the thread pool to use for parallel filter processing.
+    /// `None` means single-threaded processing.
     pub fn from_config(
         conf: config::Configuration,
         processing_params: Arc<ProcessingParameters>,
+        filter_pool: Option<Arc<rayon::ThreadPool>>,
     ) -> Self {
         debug!("Build new pipeline");
         trace!("Pipeline config {:?}", conf.pipeline);
@@ -299,37 +302,11 @@ impl Pipeline {
             0,
         );
         let secs_per_chunk = conf.devices.chunksize as f32 / conf.devices.samplerate as f32;
-        if conf.devices.multithreaded() {
-            // Worker threads are promoted to real-time priority as they start.
-            // If the pool can't be built, fall back to single-threaded processing.
-            let chunksize = conf.devices.chunksize;
-            let samplerate = conf.devices.samplerate;
-            let pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(conf.devices.worker_threads())
-                .thread_name(|i| format!("process-wrk-{i}"))
-                .start_handler(move |idx| {
-                    match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
-                        Ok(_) => debug!("Filter worker thread {idx} has real-time priority."),
-                        Err(err) => warn!(
-                            "Filter worker thread {idx} could not get real time priority, error: {err}"
-                        ),
-                    }
-                })
-                .build();
-            match pool {
-                Ok(pool) => {
-                    steps = parallelize_filters(
-                        &mut steps,
-                        conf.devices.capture.channels(),
-                        &Arc::new(pool),
-                    );
-                }
-                Err(err) => {
-                    warn!(
-                        "Failed to build filter thread pool, running single-threaded. Error: {err}"
-                    );
-                }
-            }
+        // When a rayon pool is available, merge the per-channel filter
+        // steps into parallel steps that run on it. With no pool the
+        // filters run sequentially.
+        if let Some(pool) = &filter_pool {
+            steps = parallelize_filters(&mut steps, conf.devices.capture.channels(), pool);
         }
         Pipeline {
             steps,
@@ -517,7 +494,7 @@ devices:
         params.set_target_volume(0, -100.0);
         params.sync_volumes_to_target();
 
-        let mut pipeline = Pipeline::from_config(conf, params);
+        let mut pipeline = Pipeline::from_config(conf, params, None);
 
         let waveforms = vec![vec![1.0 as PrcFmt; chunksize]; channels];
         let chunk = AudioChunk::new(waveforms, 1.0, -1.0, chunksize, chunksize);

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -112,42 +112,6 @@ fn processing(
             }
         };
 
-    // Initialize rayon thread pool
-    if multithreaded {
-        match rayon::ThreadPoolBuilder::new()
-            .num_threads(nbr_threads)
-            .thread_name(|i| format!("process-wrk-{i}"))
-            .build_global()
-        {
-            Ok(_) => {
-                debug!(
-                    "Initialized global thread pool with {} workers",
-                    rayon::current_num_threads()
-                );
-                rayon::broadcast(|_| {
-                    match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
-                        Ok(_) => {
-                            debug!(
-                                "Worker thread {} has real-time priority.",
-                                rayon::current_thread_index().unwrap_or_default()
-                            );
-                        }
-                        Err(err) => {
-                            warn!(
-                                "Worker thread {} could not get real time priority, error: {}",
-                                rayon::current_thread_index().unwrap_or_default(),
-                                err
-                            );
-                        }
-                    };
-                });
-            }
-            Err(err) => {
-                warn!("Failed to build thread pool, error: {err}");
-            }
-        };
-    }
-
     barrier_proc.wait();
     debug!("Processing loop starts now!");
     loop {

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -97,7 +97,14 @@ fn processing(
         );
     }
     processing_params.sync_volumes_to_target();
-    let mut pipeline = pipeline::Pipeline::from_config(conf_proc, processing_params.clone());
+    // The shared thread pool for this processing session's parallelizable tasks.
+    let processing_pool =
+        build_processing_threadpool(multithreaded, nbr_threads, chunksize, samplerate);
+    let mut pipeline = pipeline::Pipeline::from_config(
+        conf_proc,
+        processing_params.clone(),
+        processing_pool.clone(),
+    );
     debug!("build filters, waiting to start processing loop");
 
     let thread_handle =
@@ -160,8 +167,11 @@ fn processing(
                 config::ConfigChange::Pipeline | config::ConfigChange::MixerParameters => {
                     debug!("Rebuilding pipeline.");
                     processing_params.sync_volumes_to_target();
-                    let new_pipeline =
-                        pipeline::Pipeline::from_config(new_config, processing_params.clone());
+                    let new_pipeline = pipeline::Pipeline::from_config(
+                        new_config,
+                        processing_params.clone(),
+                        processing_pool.clone(),
+                    );
                     pipeline = new_pipeline;
                 }
                 config::ConfigChange::FilterParameters {
@@ -192,5 +202,40 @@ fn processing(
                 warn!("Could not bring the processing thread back to normal priority.")
             }
         };
+    }
+}
+
+/// Build the shared processing thread pool. It's used for parallel filter processing.
+///
+/// When `multithreaded` is false, or the pool fails to build, you get None.
+///
+/// Workers are promoted to real-time priority as they start.
+pub fn build_processing_threadpool(
+    multithreaded: bool,
+    worker_threads: usize,
+    chunksize: usize,
+    samplerate: usize,
+) -> Option<Arc<rayon::ThreadPool>> {
+    if !multithreaded {
+        return None;
+    }
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(worker_threads)
+        .thread_name(|i| format!("process-wrk-{i}"))
+        .start_handler(move |idx| {
+            match promote_current_thread_to_real_time(chunksize as u32, samplerate as u32) {
+                Ok(_) => debug!("Filter worker thread {idx} has real-time priority."),
+                Err(err) => warn!(
+                    "Filter worker thread {idx} could not get real time priority, error: {err}"
+                ),
+            }
+        })
+        .build();
+    match pool {
+        Ok(pool) => Some(Arc::new(pool)),
+        Err(err) => {
+            warn!("Failed to build filter thread pool, running single-threaded. Error: {err}");
+            None
+        }
     }
 }


### PR DESCRIPTION
currently, rayon is initialized once as a global pool. If it fails,
the pipeline will not work. With this change, a warning will be
logged, and the application will fall back to as-is single-thread
filters processing.

Also, this change creates the pool per processing session. There's
only one, but it may be nice for library use to not have the global
rayon pool owned by camillalib.

By making rayon pool ownership clear and referential, it's easy to
see where and how each pool is used; and it makes it easier to
safely add more pools for other use cases in the future.

Multithread filter test with signal generator -> file through parallel
biquads appears to work fine, and tests still pass.