### PR TITLE
Enable realtime priority on linux

### DIFF
--- a/.github/workflows/check_ws_docs.yml
+++ b/.github/workflows/check_ws_docs.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Install ALSA development files
         run: sudo apt-get update && sudo apt-get install libasound2-dev -y
 
+      - name: Install DBus development files
+        run: sudo apt-get install libdbus-1-dev -y
+
       - name: Install Python dependencies
         run: pip install jinja2 pyyaml
 

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run cargo test for arm
         run: cross test --target arm-unknown-linux-gnueabihf
         env: 
-          LD_LIBRARY_PATH: /usr/lib/arm-linux-gnueabihf:/lib/arm-linux-gnueabihf
+          LD_LIBRARY_PATH: /usr/lib/arm-linux-gnueabihf
 
   check_test_and_lint_windows:
     name: Check and test Windows

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run cargo test for arm
         run: cross test --target arm-unknown-linux-gnueabihf
         env: 
-          LD_LIBRARY_PATH: /usr/lib/arm-linux-gnueabihf
+          LD_LIBRARY_PATH: /usr/lib/arm-linux-gnueabihf:/lib/arm-linux-gnueabihf
 
   check_test_and_lint_windows:
     name: Check and test Windows

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install Alsa devel
         run: sudo apt-get install libasound2-dev -y
 
+      - name: Install DBus development files
+        run: sudo apt-get install libdbus-1-dev -y
+
       - name: Install PipeWire development files
         run: sudo apt-get install libpipewire-0.3-dev -y
 
@@ -79,6 +82,9 @@ jobs:
 
       - name: Install Alsa devel
         run: sudo apt-get install libasound2-dev -y
+
+      - name: Install DBus development files
+        run: sudo apt-get install libdbus-1-dev -y
 
       - name: Run cargo check
         run: cargo check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install Alsa devel
         run: sudo apt-get install libasound2-dev -y
 
+      - name: Install DBus development files
+        run: sudo apt-get install libdbus-1-dev -y
+
       - name: Install OpenSSL
         run: sudo apt-get install openssl libssl-dev -y
 
@@ -121,6 +124,9 @@ jobs:
 
       - name: Install Alsa devel
         run: sudo apt-get install libasound2-dev -y
+
+      - name: Install DBus development files
+        run: sudo apt-get install libdbus-1-dev -y
 
       - name: Install OpenSSL
         run: sudo apt-get install openssl libssl-dev -y

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ parking_lot = { version = "0.12.1", features = ["hardware-lock-elision"] }
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"
 rayon = "1.10.0"
-audio_thread_priority = { version = "0.33.0", default-features = false }
+audio_thread_priority = { version = "0.33.0" }
 ringbuf = "0.4.7"
 #audioadapter = { version = "2.0.0", default-features = false, path = "../audioadapter-rs/audioadapter" }
 #audioadapter-sample = { version = "2.0.0", default-features = false,path = "../audioadapter-rs/audioadapter-sample" }

--- a/Dockerfile_armv6
+++ b/Dockerfile_armv6
@@ -5,7 +5,7 @@ ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 RUN dpkg --add-architecture armhf
-RUN apt-get update && apt-get -y install libasound2-dev:armhf libasound2:armhf libdbus-1-dev:armhf
+RUN apt-get update && apt-get -y install libasound2-dev:armhf libasound2:armhf libdbus-1-dev:armhf libsystemd0:armhf
 
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"

--- a/Dockerfile_armv6
+++ b/Dockerfile_armv6
@@ -2,11 +2,10 @@ FROM rustembedded/cross:arm-unknown-linux-gnueabihf
 
 ENV PKG_CONFIG_ALLOW_CROSS 1
 ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
-ENV LD_LIBRARY_PATH /usr/lib/arm-linux-gnueabihf:/lib/arm-linux-gnueabihf
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 RUN dpkg --add-architecture armhf
-RUN apt-get update && apt-get -y install libasound2-dev:armhf libasound2:armhf libdbus-1-dev:armhf libsystemd0:armhf
+RUN apt-get update && apt-get -y install libasound2-dev:armhf libasound2:armhf
 
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf -L /lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf,-rpath-link,/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"

--- a/Dockerfile_armv6
+++ b/Dockerfile_armv6
@@ -7,5 +7,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 RUN dpkg --add-architecture armhf
 RUN apt-get update && apt-get -y install libasound2-dev:armhf libasound2:armhf libdbus-1-dev:armhf libsystemd0:armhf
 
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
-ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf -L /lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf,-rpath-link,/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"

--- a/Dockerfile_armv6
+++ b/Dockerfile_armv6
@@ -5,7 +5,7 @@ ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 RUN dpkg --add-architecture armhf
-RUN apt-get update && apt-get -y install libasound2-dev:armhf libasound2:armhf
+RUN apt-get update && apt-get -y install libasound2-dev:armhf libasound2:armhf libdbus-1-dev:armhf
 
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-L /usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"
 ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf $CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS"

--- a/Dockerfile_armv6
+++ b/Dockerfile_armv6
@@ -2,6 +2,7 @@ FROM rustembedded/cross:arm-unknown-linux-gnueabihf
 
 ENV PKG_CONFIG_ALLOW_CROSS 1
 ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
+ENV LD_LIBRARY_PATH /usr/lib/arm-linux-gnueabihf:/lib/arm-linux-gnueabihf
 
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 RUN dpkg --add-architecture armhf

--- a/Dockerfile_armv7
+++ b/Dockerfile_armv7
@@ -5,4 +5,4 @@ ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
-    apt-get install libasound2-dev:armhf libdbus-1-dev:armhf libsystemd0:armhf openssl:armhf libssl-dev:armhf -y
+    apt-get install libasound2-dev:armhf libdbus-1-dev:armhf openssl:armhf libssl-dev:armhf -y

--- a/Dockerfile_armv7
+++ b/Dockerfile_armv7
@@ -5,4 +5,4 @@ ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
-    apt-get install libasound2-dev:armhf libdbus-1-dev:armhf openssl:armhf libssl-dev:armhf -y
+    apt-get install libasound2-dev:armhf libdbus-1-dev:armhf libsystemd0:armhf openssl:armhf libssl-dev:armhf -y

--- a/Dockerfile_armv7
+++ b/Dockerfile_armv7
@@ -5,4 +5,4 @@ ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
-    apt-get install libasound2-dev:armhf openssl:armhf libssl-dev:armhf -y \
+    apt-get install libasound2-dev:armhf libdbus-1-dev:armhf openssl:armhf libssl-dev:armhf -y


### PR DESCRIPTION
`audio_thread_priority` is a noop on linux without dbus (default) feature.
https://github.com/mozilla/audio_thread_priority/blob/c5c2d1cb5231215661ab68f3833beec4881d1604/src/lib.rs#L118

This change enables default features in audio_thread_priority, enabling dbus and rtkit on linux. It also adds dbus lib to CI build.

I would prefer a rlimit way to set rt prio, because it doesn't need dbus and can have higher limits. But dbus and rtkit is probably better suited for desktop systems.

I tried setting rt with systemd `CPUSchedulingPolicy` and `CPUSchedulingPriority` but it sets rt for all threads. Successfully prevents xruns under stress, a bit less than ideal.

I imagine there was a reason this feature was disabled (deps maybe?), so PR is draft.