### PR TITLE
Enable real-time priority on Linux without D-Bus

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install Alsa devel
         run: sudo apt-get install libasound2-dev -y
 
-      - name: Install PipeWire development files
-        run: sudo apt-get install libpipewire-0.3-dev -y
+      - name: Install PipeWire and D-Bus development files
+        run: sudo apt-get install libpipewire-0.3-dev libdbus-1-dev -y
 
       - name: Install OpenSSL
         run: sudo apt-get install openssl libssl-dev -y

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,8 @@ jobs:
           asset_name: camilladsp-linux-amd64.tar.gz
           tag: ${{ github.event.release.tag_name }}
 
-      - name: Install PipeWire development files
-        run: DEBIAN_FRONTEND="noninteractive" sudo apt-get install libpipewire-0.3-dev -y
+      - name: Install PipeWire and D-Bus development files
+        run: DEBIAN_FRONTEND="noninteractive" sudo apt-get install libpipewire-0.3-dev libdbus-1-dev -y
 
       - name: Build with PipeWire
         run: cargo build --release --features pipewire-backend
@@ -122,8 +122,8 @@ jobs:
           asset_name: camilladsp-linux-aarch64.tar.gz
           tag: ${{ github.event.release.tag_name }}
 
-      - name: Install PipeWire development files
-        run: DEBIAN_FRONTEND="noninteractive" sudo apt-get install libpipewire-0.3-dev -y
+      - name: Install PipeWire and D-Bus development files
+        run: DEBIAN_FRONTEND="noninteractive" sudo apt-get install libpipewire-0.3-dev libdbus-1-dev -y
 
       - name: Build with PipeWire
         run: cargo build --release --features pipewire-backend

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,12 @@ repository = "https://github.com/HEnquist/camilladsp"
 [features]
 default = ["websocket"]
 threaded-alsa = []
-pipewire-backend = ["pipewire"]
+# Promote real-time threads via rtkit over D-Bus instead of natively, see
+# src/utils/rt_priority.rs. PipeWire implies a desktop system where rtkit ships as a dependency of
+# the sound server, so that backend enables it. Can also be enabled on its own, for an ALSA build
+# that runs unprivileged on a desktop.
+rtkit = ["audio_thread_priority/with_dbus"]
+pipewire-backend = ["pipewire", "rtkit"]
 asio-backend = ["asio-sys"]
 bench = []
 websocket = ["tungstenite"]
@@ -81,7 +86,9 @@ parking_lot = { version = "0.12.1", features = ["hardware-lock-elision"] }
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3"
 rayon = "1.10.0"
-audio_thread_priority = { version = "0.33.0", default-features = false }
+# Real-time thread promotion. On Linux it promotes via rtkit over D-Bus with the "rtkit" feature, and
+# natively with SCHED_FIFO without it, see src/utils/rt_priority.rs.
+audio_thread_priority = { version = "0.36.0", default-features = false }
 ringbuf = "0.4.7"
 #audioadapter = { version = "2.0.0", default-features = false, path = "../audioadapter-rs/audioadapter" }
 #audioadapter-sample = { version = "2.0.0", default-features = false,path = "../audioadapter-rs/audioadapter-sample" }

--- a/backend_alsa.md
+++ b/backend_alsa.md
@@ -282,6 +282,90 @@ For the gadget, the control can also indicate that the sample rate changed.
 When this happens, the capture can no longer continue and CamillaDSP will stop.
 The new sample rate can then be read by the `GetStopReason` websocket command.
 
+## Real-time priority
+CamillaDSP promotes its processing and audio threads to real-time priority (`SCHED_FIFO`), which helps
+avoid buffer underruns and dropouts under load. The default priority is 10, and it can be changed with
+the `CAMILLADSP_RT_PRIORITY` environment variable, see [Changing the priority](#changing-the-priority).
+
+The rest of this section applies to the plain ALSA-only build.
+There, priority is requested by calling `pthread_setschedparam` directly, without needing D-Bus or any
+running service, so it works on a minimal headless system.
+A build that includes the PipeWire backend instead uses `rtkit` over D-Bus to request the priority,
+which is the normal mechanism on a desktop system, and the setup below does not apply.
+An ALSA-only build can also be switched to `rtkit` by enabling the `rtkit` feature at build time.
+
+A process is only allowed to request real-time scheduling if it has permission to do so.
+Running as `root` works but is not recommended.
+The better option is to run CamillaDSP as a normal user and grant that user a real-time priority limit
+(`RLIMIT_RTPRIO`) that is at least as high as the priority CamillaDSP requests (10 by default).
+If the permission is missing, CamillaDSP still runs, but logs a warning that it could not get real-time
+priority.
+
+### Using systemd
+If CamillaDSP runs as a systemd service, set the limit directly in the unit file and run as a normal user:
+
+```ini
+[Service]
+User=camilladsp
+LimitRTPRIO=10
+```
+
+This is the most self-contained option, as the limit is part of the unit file.
+
+### Using PAM limits
+For a login session, or when not using systemd, grant the limit through PAM.
+Create a drop-in file:
+
+```
+# /etc/security/limits.d/95-camilladsp.conf
+@audio   -   rtprio   10
+```
+
+The limit must be at least the priority CamillaDSP requests, so raise it to match if you increase the
+priority (see below).
+
+Then add the user to the `audio` group and log in again:
+
+```sh
+sudo usermod -aG audio camilladsp
+```
+
+This is the same setup used by JACK and PipeWire for pro-audio.
+Note that PAM limits only apply to processes started through a login session, not to plain system
+services started by init. For those, use the systemd option above.
+
+### Using a file capability
+As an alternative, the binary itself can be granted the capability to raise scheduling priority:
+
+```sh
+sudo setcap 'cap_sys_nice=ep' /usr/local/bin/camilladsp
+```
+
+This works regardless of user and launcher, but has to be reapplied whenever the binary is replaced,
+and lets anyone who can run the binary request real-time priority.
+
+### Changing the priority
+The default priority of 10 is deliberately conservative. On a busy system a higher value can help,
+since it lets the audio threads preempt more other work. Set the `CAMILLADSP_RT_PRIORITY` environment
+variable to a value between 1 and 99 to change it, for example in a systemd unit:
+
+```ini
+[Service]
+Environment=CAMILLADSP_RT_PRIORITY=40
+LimitRTPRIO=40
+```
+
+Remember to raise the `RLIMIT_RTPRIO` limit to match, otherwise the higher priority is not permitted.
+
+Keep the priority below the priority of the audio interface's interrupt (IRQ) thread, which is
+typically around 50. A priority higher than the IRQ thread starves the very threads that deliver audio
+to and from the device, which causes dropouts instead of preventing them.
+
+### Verifying
+Once running, `chrt -p <thread id>` should report `SCHED_FIFO` with the configured priority (10 by
+default) for the processing and audio threads.
+The current limit can be checked with `ulimit -r`, which must be at least that priority.
+
 ## Links
 ### ALSA Documentation
 https://www.alsa-project.org/wiki/Documentation

--- a/src/alsa_backend/device.rs
+++ b/src/alsa_backend/device.rs
@@ -20,15 +20,15 @@ use crate::audiodevice::*;
 use crate::config::{AlsaSampleFormat, Resampler};
 use crate::utils::conversions::{buffer_to_chunk_rawbytes, chunk_to_buffer_rawbytes};
 use crate::utils::countertimer;
+use crate::utils::rt_priority::{
+    demote_current_thread_from_real_time, promote_current_thread_to_real_time,
+};
 use alsa::ctl::{Ctl, ElemId, ElemIface, ElemType, ElemValue};
 use alsa::hctl::{Elem, HCtl};
 use alsa::pcm::{Access, Format, Frames, HwParams};
 use alsa::poll::Descriptors;
 use alsa::{Direction, PCM, ValueOr};
 use alsa_sys;
-use audio_thread_priority::{
-    demote_current_thread_from_real_time, promote_current_thread_to_real_time,
-};
 use crossbeam_channel;
 use nix::errno::Errno;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};

--- a/src/alsa_backend/threaded_device.rs
+++ b/src/alsa_backend/threaded_device.rs
@@ -20,15 +20,15 @@ use crate::audiodevice::*;
 use crate::config::{AlsaSampleFormat, BinarySampleFormat, Resampler};
 use crate::utils::conversions::{buffer_to_chunk_rawbytes, chunk_to_buffer_rawbytes};
 use crate::utils::countertimer;
+use crate::utils::rt_priority::{
+    demote_current_thread_from_real_time, promote_current_thread_to_real_time,
+};
 use alsa::ctl::{Ctl, ElemId, ElemIface, ElemType, ElemValue};
 use alsa::hctl::HCtl;
 use alsa::pcm::{Access, Format, Frames, HwParams};
 use alsa::poll::Descriptors;
 use alsa::{Direction, ValueOr};
 use alsa_sys;
-use audio_thread_priority::{
-    demote_current_thread_from_real_time, promote_current_thread_to_real_time,
-};
 use crossbeam_channel;
 use nix::errno::Errno;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};

--- a/src/coreaudio_backend/device.rs
+++ b/src/coreaudio_backend/device.rs
@@ -64,7 +64,7 @@ use objc2_core_audio_types::{
 };
 use objc2_core_foundation::CFString;
 
-use audio_thread_priority::{
+use crate::utils::rt_priority::{
     demote_current_thread_from_real_time, promote_current_thread_to_real_time,
 };
 

--- a/src/pipewire_backend/device.rs
+++ b/src/pipewire_backend/device.rs
@@ -16,7 +16,7 @@
 
 use crate::ToF32;
 use crate::utils::ringbuffer::fill_playback_output_from_ringbuffer;
-use audio_thread_priority::{
+use crate::utils::rt_priority::{
     demote_current_thread_from_real_time, promote_current_thread_to_real_time,
 };
 use pipewire as pw;

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -17,10 +17,10 @@
 use crate::audiodevice::*;
 use crate::config;
 use crate::pipeline;
-use crate::{ProcessingParameters, SHUTDOWN_REQUESTED};
-use audio_thread_priority::{
+use crate::utils::rt_priority::{
     demote_current_thread_from_real_time, promote_current_thread_to_real_time,
 };
+use crate::{ProcessingParameters, SHUTDOWN_REQUESTED};
 use std::sync::{Arc, Barrier};
 use std::thread;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,6 +20,7 @@ pub mod decibels;
 pub mod rate_controller;
 pub mod resampling;
 pub mod ringbuffer;
+pub mod rt_priority;
 pub mod stash;
 pub mod time;
 pub mod wavtools;

--- a/src/utils/rt_priority.rs
+++ b/src/utils/rt_priority.rs
@@ -1,0 +1,86 @@
+// CamillaDSP - A flexible tool for processing audio
+// Copyright (C) 2026 Henrik Enquist
+//
+// This file is part of CamillaDSP.
+//
+// CamillaDSP is free software; you can redistribute it and/or modify it
+// under the terms of either:
+//
+// a) the GNU General Public License version 3,
+//    or
+// b) the Mozilla Public License Version 2.0.
+//
+// You should have received copies of the GNU General Public License and the
+// Mozilla Public License along with this program. If not, see
+// <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
+
+//! Thin wrapper around real-time thread priority promotion.
+//!
+//! All the actual work is done by `audio_thread_priority`, which picks the right mechanism per
+//! platform: the mach time-constraint policy on macOS, MMCSS "Pro Audio" on Windows, and on Linux
+//! either rtkit over D-Bus or a direct `pthread_setschedparam(SCHED_FIFO)` call.
+//!
+//! On Linux the choice is made by the crate's `with_dbus` feature, enabled here through the `rtkit`
+//! feature. rtkit is the right choice for unprivileged desktop processes, and it ships as a
+//! dependency of PipeWire, so the `pipewire-backend` feature enables it. The plain ALSA-only build
+//! targets minimal/headless systems that often have no D-Bus at all, and gets the native path
+//! instead. That one needs no D-Bus and no running service, and works wherever the process may
+//! request real-time scheduling (running as root, holding `CAP_SYS_NICE`, or with an `RLIMIT_RTPRIO`
+//! limit configured, e.g. via `/etc/security/limits.conf`).
+//!
+//! The only thing added on top of the crate is the `CAMILLADSP_RT_PRIORITY` environment variable,
+//! which overrides the priority the native Linux path requests.
+
+pub use audio_thread_priority::{RtPriorityHandle, demote_current_thread_from_real_time};
+
+use audio_thread_priority::AudioThreadPriorityError;
+
+/// Promote the calling thread to real-time priority.
+///
+/// The buffer size and sample rate are only used by the Linux rtkit path, which derives an
+/// `RLIMIT_RTTIME` budget from them. Pass a non-zero sample rate, since the crate rejects zero.
+pub fn promote_current_thread_to_real_time(
+    audio_buffer_frames: u32,
+    audio_samplerate_hz: u32,
+) -> Result<RtPriorityHandle, AudioThreadPriorityError> {
+    #[cfg(all(target_os = "linux", not(feature = "rtkit")))]
+    priority_override::apply();
+    audio_thread_priority::promote_current_thread_to_real_time(
+        audio_buffer_frames,
+        audio_samplerate_hz,
+    )
+}
+
+/// Applies the `CAMILLADSP_RT_PRIORITY` override to the native Linux path. Not available for the
+/// other paths: rtkit picks the priority itself, and macOS and Windows have no priority to set.
+#[cfg(all(target_os = "linux", not(feature = "rtkit")))]
+mod priority_override {
+    use std::sync::Once;
+
+    /// Environment variable used to override the real-time priority. Accepts an integer 1-99. Higher
+    /// values preempt more work but must stay below the audio interface's IRQ thread, or they starve
+    /// the very threads that deliver audio.
+    const RT_PRIORITY_ENV: &str = "CAMILLADSP_RT_PRIORITY";
+
+    static APPLIED: Once = Once::new();
+
+    /// Read the environment variable and hand the priority to `audio_thread_priority`, once per
+    /// process. Without an override the crate uses its default priority of 10, the same value the
+    /// rtkit path requests.
+    pub fn apply() {
+        APPLIED.call_once(|| {
+            let Ok(value) = std::env::var(RT_PRIORITY_ENV) else {
+                return;
+            };
+            match value.trim().parse::<u8>() {
+                Ok(priority) if (1..=99).contains(&priority) => {
+                    audio_thread_priority::set_rt_priority(Some(priority))
+                }
+                _ => warn!(
+                    "Ignoring invalid {RT_PRIORITY_ENV}=\"{value}\", \
+                     expected an integer 1-99. Using the default priority."
+                ),
+            }
+        });
+    }
+}

--- a/src/wasapi_backend/device.rs
+++ b/src/wasapi_backend/device.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 use wasapi;
 use wasapi::StreamMode;
 
-use audio_thread_priority::{
+use crate::utils::rt_priority::{
     demote_current_thread_from_real_time, promote_current_thread_to_real_time,
 };
 


### PR DESCRIPTION
Real-time priority never actually worked on the Linux ALSA build: `audio_thread_priority` only promoted via rtkit over D-Bus, which is a no-op without the dbus feature, and that is how we build it.

- Bump `audio_thread_priority` to 0.36.0, which gained a native `SCHED_FIFO` path needing no D-Bus (mozilla/audio_thread_priority#45).
- New `rtkit` feature selects the D-Bus path, enabled automatically by `pipewire-backend`.
- `CAMILLADSP_RT_PRIORITY` env var sets the priority for the native path, default 10.
- Document the `RLIMIT_RTPRIO` setup for headless ALSA users in `backend_alsa.md`.
- macOS and Windows unchanged.
