### PR TITLE
Fix ASIO ring buffer underruns when driver buffer exceeds chunksize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ New features:
 - New `Slip` resampler for very cheap rate adjust between independent clocks at the same nominal rate.
 - RF64 support for reading and writing wav files larger than 4 GB (`use_rf64` for File playback).
 
+Bugfixes:
+- ASIO: size the ring buffer and prefill from the driver's actual buffer size instead of just
+  `chunksize`, fixing continuous underruns when the driver requests a larger buffer than `chunksize`.
+
 Changes:
 - Improved DSP library separation for easier external integration.
 - File playback now writes correct wav header sizes, and stops at the 4 GB limit for plain wav.

--- a/README.md
+++ b/README.md
@@ -756,64 +756,7 @@ See [the capture device section](#file-rawfile-wavfile-stdin-stdout) for more de
 See the [separate readme for Wasapi](./backend_wasapi.md).
 
 ### ASIO
-The ASIO backend is an optional alternative audio backend for Windows.
-It provides low-latency access to audio devices via ASIO drivers.
-To use it, CamillaDSP must be compiled with the `asio-backend` feature enabled.
-
-Note that the ASIO backend is licensed under GPLv3 only,
-due to the ASIO SDK license requirements.
-See the [ASIO backend and license implications](#asio-backend-and-license-implications)
-section for details.
-
-Set the device `type` to `Asio` for both capture and playback.
-The `device` parameter should be set to the name of the ASIO driver to use.
-Available ASIO drivers are listed in the log output at startup (at debug level).
-Note that ASIO exposes drivers rather than actual device availability,
-so drivers for disconnected or powered‑off devices are still included
-in the listing.
-
-Set the `channels` property to the number of channels you want to use.
-The value may be lower than the number of channels the device provides,
-any channels above the specified count are simply ignored.
-
-The supported sample formats are:
-- `S16_LE` - 16-bit signed integer
-- `S24_4_LE` - 24-bit signed integer (in 32-bit container)
-- `S24_3_LE` - 24-bit signed integer (packed 3-byte)
-- `S32_LE` - 32-bit signed integer
-- `F32_LE` - 32-bit float
-- `F64_LE` - 64-bit float
-
-If the `format` parameter is omitted, CamillaDSP will query the device
-for its native sample format and use it automatically.
-ASIO drivers do not perform sample format conversion,
-so if a format is specified it must match the device's native format.
-A mismatch will result in an error at startup.
-
-#### Full-duplex limitations
-When both capture and playback use the ASIO backend,
-CamillaDSP operates them in full-duplex mode
-through a single shared driver instance. This implies:
-- **Same device:** Capture and playback must specify the same ASIO driver name.
-  ASIO only supports one driver loaded at a time.
-- **Same sample rate:** Resampling is not supported in full-duplex ASIO mode.
-  Both directions share the same hardware clock,
-  so `capture_samplerate` must equal `samplerate`
-  and no `resampler` should be configured.
-
-Example configuration:
-```yaml
-capture:
-  type: Asio
-  channels: 2
-  device: "My ASIO Driver"
-  format: S32_LE
-playback:
-  type: Asio
-  channels: 2
-  device: "My ASIO Driver"
-  format: S32_LE
-```
+See the [separate readme for ASIO](./backend_asio.md).
 
 ## MacOS (CoreAudio)
 See the [separate readme for CoreAudio](./backend_coreaudio.md).
@@ -1215,7 +1158,7 @@ A parameter marked (*) in any example is optional. If they are left out from the
     - [F32_LE](sample_formats.md#f32_le)
     - [F64_LE](sample_formats.md#f64_le)
 
-    For [ALSA](./backend_alsa.md), [CoreAudio](./backend_coreaudio.md), [Wasapi](./backend_wasapi.md) and [ASIO](#asio), see the respective backend documentation.
+    For [ALSA](./backend_alsa.md), [CoreAudio](./backend_coreaudio.md), [Wasapi](./backend_wasapi.md) and [ASIO](./backend_asio.md), see the respective backend documentation.
 
     __Note that there are three different 24-bit formats! Make sure to select the correct one.__
 

--- a/backend_asio.md
+++ b/backend_asio.md
@@ -1,0 +1,89 @@
+# ASIO (Windows)
+
+## Introduction
+
+The ASIO backend is an optional alternative audio backend for Windows.
+It provides low-latency access to audio devices via ASIO drivers.
+To use it, CamillaDSP must be compiled with the `asio-backend` feature enabled.
+See [Building with ASIO backend (Windows)](./README.md#building-with-asio-backend-windows).
+
+Note that the ASIO backend is licensed under GPLv3 only,
+due to the ASIO SDK license requirements.
+See the [ASIO backend and license implications](./README.md#asio-backend-and-license-implications)
+section for details.
+
+## ASIO4ALL and other generic wrapper drivers
+
+Generic wrapper drivers such as ASIO4ALL, FlexASIO and Steinberg's
+Generic Low Latency ASIO Driver are best avoided when possible.
+All they do is make a device without its own ASIO driver
+usable by applications that require ASIO, nothing more.
+Note that they don't give any sound quality improvements:
+Wasapi in exclusive mode is just as bit-perfect,
+since it also gives CamillaDSP direct control of the device without going through
+the Windows mixer. What a generic wrapper adds on top of that is an extra
+emulation layer, which has been a source of real-world bugs and quirks.
+For a device without its own ASIO driver,
+using the [Wasapi backend in exclusive mode](./backend_wasapi.md#shared-or-exclusive-mode)
+directly is usually more reliable.
+One case where Wasapi alone isn't enough is when it exposes a multichannel
+device as several separate stereo pairs instead of one multichannel device.
+Devices like this typically ship with their own ASIO driver though,
+and that native driver is almost always a better choice than a generic
+wrapper such as ASIO4ALL.
+
+## Configuration of devices
+
+Set the device `type` to `Asio` for both capture and playback.
+
+### Device names
+The `device` parameter should be set to the name of the ASIO driver to use.
+Available ASIO drivers are listed in the log output at startup (at debug level).
+Note that ASIO exposes drivers rather than actual device availability,
+so drivers for disconnected or powered‑off devices are still included
+in the listing.
+
+### Channels
+Set the `channels` property to the number of channels you want to use.
+The value may be lower than the number of channels the device provides,
+any channels above the specified count are simply ignored.
+
+### Sample format
+The supported sample formats are:
+- `S16_LE` - 16-bit signed integer
+- `S24_4_LE` - 24-bit signed integer (in 32-bit container)
+- `S24_3_LE` - 24-bit signed integer (packed 3-byte)
+- `S32_LE` - 32-bit signed integer
+- `F32_LE` - 32-bit float
+- `F64_LE` - 64-bit float
+
+If the `format` parameter is omitted, CamillaDSP will query the device
+for its native sample format and use it automatically.
+ASIO drivers do not perform sample format conversion,
+so if a format is specified it must match the device's native format.
+A mismatch will result in an error at startup.
+
+## Full-duplex limitations
+When both capture and playback use the ASIO backend,
+CamillaDSP operates them in full-duplex mode
+through a single shared driver instance. This implies:
+- **Same device:** Capture and playback must specify the same ASIO driver name.
+  ASIO only supports one driver loaded at a time.
+- **Same sample rate:** Resampling is not supported in full-duplex ASIO mode.
+  Both directions share the same hardware clock,
+  so `capture_samplerate` must equal `samplerate`
+  and no `resampler` should be configured.
+
+Example configuration:
+```yaml
+capture:
+  type: Asio
+  channels: 2
+  device: "My ASIO Driver"
+  format: S32_LE
+playback:
+  type: Asio
+  channels: 2
+  device: "My ASIO Driver"
+  format: S32_LE
+```

--- a/src/asio_backend/device.rs
+++ b/src/asio_backend/device.rs
@@ -273,7 +273,11 @@ pub unsafe extern "C" fn buffer_switch_playback(buffer_index: i32, _direct_proce
         }
         if !ctx.running {
             ctx.running = true;
-            let prefill_frames = ctx.target_level;
+            // Prefill at least one full callback's worth of frames so the loop
+            // below doesn't immediately re-drain the ring buffer to empty and
+            // re-trigger an underrun when target_level is smaller than the
+            // driver's actual buffer size (see issue #498).
+            let prefill_frames = ctx.target_level.max(ctx.buffer_size);
             // On first startup, start immediately without extra silence prefill.
             // On restart after underrun, keep target_level prefill to rebuild delay.
             let new_len = ctx.sample_queue.len() + prefill_frames * bytes_per_frame;
@@ -1380,7 +1384,7 @@ impl PlaybackDevice for AsioPlaybackDevice {
 
                 // --- Device-specific setup (full-duplex vs single-direction) ---
                 // Format is resolved inside; bytes_per_sample depends on it.
-                let setup_result: Result<(Option<usize>, BinarySampleFormat, usize), String> = if full_duplex {
+                let setup_result: Result<(usize, BinarySampleFormat, usize), String> = if full_duplex {
                     // Full-duplex: shared driver coordination
                     let (_inputs, outputs, preferred_buf) = match init_shared_asio(&devname, samplerate) {
                         Ok(result) => result,
@@ -1421,7 +1425,7 @@ impl PlaybackDevice for AsioPlaybackDevice {
                     let binary_format = resolve_binary_format(&resolved_format);
                     let bytes_per_sample = binary_format.bytes_per_sample();
                     let asio_buffer_size = preferred_buf as usize;
-                    Ok((Some(asio_buffer_size), binary_format, bytes_per_sample))
+                    Ok((asio_buffer_size, binary_format, bytes_per_sample))
                 } else {
                     // Single-direction: open device (also resolves format)
                     let resolved_format =
@@ -1439,7 +1443,22 @@ impl PlaybackDevice for AsioPlaybackDevice {
                         };
                     let binary_format = resolve_binary_format(&resolved_format);
                     let bytes_per_sample = binary_format.bytes_per_sample();
-                    Ok((None, binary_format, bytes_per_sample))
+                    // Query the driver's actual buffer size now so the ring buffer below
+                    // can be sized to fit it (see issue #498: a driver buffer larger than
+                    // chunksize used to overflow the ring buffer capacity and cause underruns).
+                    let preferred_buf = match get_preferred_buffer_size() {
+                        Ok(result) => result,
+                        Err(err) => {
+                            let msg = format!("ASIO playback buffer size query error: {err}");
+                            error!("{msg}");
+                            status_channel
+                                .send(StatusMessage::PlaybackError(msg))
+                                .unwrap_or(());
+                            barrier.wait();
+                            return;
+                        }
+                    };
+                    Ok((preferred_buf as usize, binary_format, bytes_per_sample))
                 };
 
                 let (asio_buffer_size, binary_format, bytes_per_sample) = match setup_result {
@@ -1454,9 +1473,12 @@ impl PlaybackDevice for AsioPlaybackDevice {
                     }
                 };
 
-                // Now create ring buffer and context with the resolved bytes_per_sample
+                // Size the ring buffer to fit at least the driver's actual buffer size,
+                // not just chunksize, so a single ASIO callback can never request more
+                // bytes than the ring buffer can hold.
+                let ring_frames = chunksize.max(asio_buffer_size);
                 let ringbuffer = HeapRb::<u8>::new(
-                    channels * bytes_per_sample * (2 * chunksize + 2048),
+                    channels * bytes_per_sample * (2 * ring_frames + 2048),
                 );
                 let (mut device_producer, device_consumer) = ringbuffer.split();
                 let mut _single_playback_buffer_infos: Option<Vec<ASIOBufferInfo>> = None;
@@ -1470,20 +1492,13 @@ impl PlaybackDevice for AsioPlaybackDevice {
                     let ctx = Box::new(AsioPlaybackContext {
                         device_consumer,
                         sample_queue: VecDeque::with_capacity(
-                            (16 * chunksize + target_level) * bytes_per_sample * channels,
+                            (16 * ring_frames + target_level) * bytes_per_sample * channels,
                         ),
                         buffer_infos,
                         num_channels: channels,
-                        buffer_size: asio_buffer_size.expect(
-                            "full_duplex setup must provide asio_buffer_size",
-                        ),
+                        buffer_size: asio_buffer_size,
                         bytes_per_sample,
-                        read_tmp: vec![
-                            0u8;
-                            asio_buffer_size.expect("full_duplex setup must provide asio_buffer_size")
-                                * bytes_per_sample
-                                * channels
-                        ],
+                        read_tmp: vec![0u8; asio_buffer_size * bytes_per_sample * channels],
                         target_level,
                         buffer_fill: buffer_fill_clone,
                         running: false,
@@ -1505,18 +1520,7 @@ impl PlaybackDevice for AsioPlaybackDevice {
                     }
                     ctx_raw
                 } else {
-                    let preferred_buf = match get_preferred_buffer_size() {
-                        Ok(result) => result,
-                        Err(err) => {
-                            let msg = format!("ASIO playback buffer size query error: {err}");
-                            error!("{msg}");
-                            status_channel
-                                .send(StatusMessage::PlaybackError(msg))
-                                .unwrap_or(());
-                            barrier.wait();
-                            return;
-                        }
-                    };
+                    let preferred_buf = asio_buffer_size as i32;
 
                     let mut driver_buffer_infos = make_buffer_infos(channels, false);
                     let mut callbacks_for_driver = Box::new(ASIOCallbacks {
@@ -1544,7 +1548,7 @@ impl PlaybackDevice for AsioPlaybackDevice {
                     let ctx = Box::new(AsioPlaybackContext {
                         device_consumer,
                         sample_queue: VecDeque::with_capacity(
-                            (16 * chunksize + target_level) * bytes_per_sample * channels,
+                            (16 * ring_frames + target_level) * bytes_per_sample * channels,
                         ),
                         buffer_infos: driver_buffer_infos.clone(),
                         num_channels: channels,
@@ -1784,7 +1788,7 @@ impl CaptureDevice for AsioCaptureDevice {
 
                 // --- Device-specific setup (full-duplex vs single-direction) ---
                 // Format is resolved inside; bytes_per_sample depends on it.
-                let setup_result: Result<(Option<usize>, BinarySampleFormat, usize), String> = if full_duplex {
+                let setup_result: Result<(usize, BinarySampleFormat, usize), String> = if full_duplex {
                     // Full-duplex: shared driver coordination
                     let (inputs, _outputs, preferred_buf) = match init_shared_asio(&devname, samplerate) {
                         Ok(result) => result,
@@ -1827,7 +1831,7 @@ impl CaptureDevice for AsioCaptureDevice {
                     };
                     let binary_format = resolve_binary_format(&resolved_format);
                     let bytes_per_sample = binary_format.bytes_per_sample();
-                    Ok((Some(preferred_buf as usize), binary_format, bytes_per_sample))
+                    Ok((preferred_buf as usize, binary_format, bytes_per_sample))
                 } else {
                     // Single-direction: open device (also resolves format)
                     let resolved_format =
@@ -1846,7 +1850,22 @@ impl CaptureDevice for AsioCaptureDevice {
                         };
                     let binary_format = resolve_binary_format(&resolved_format);
                     let bytes_per_sample = binary_format.bytes_per_sample();
-                    Ok((None, binary_format, bytes_per_sample))
+                    // Query the driver's actual buffer size now so the ring buffer below
+                    // can be sized to fit it (see issue #498).
+                    let preferred_buf = match get_preferred_buffer_size() {
+                        Ok(result) => result,
+                        Err(err) => {
+                            let msg = format!("ASIO capture buffer size query error: {err}");
+                            error!("{msg}");
+                            channel.send(AudioMessage::EndOfStream).unwrap_or(());
+                            status_channel
+                                .send(StatusMessage::CaptureError(msg))
+                                .unwrap_or(());
+                            barrier.wait();
+                            return;
+                        }
+                    };
+                    Ok((preferred_buf as usize, binary_format, bytes_per_sample))
                 };
 
                 let (asio_buffer_size, binary_format, bytes_per_sample) = match setup_result {
@@ -1868,8 +1887,11 @@ impl CaptureDevice for AsioCaptureDevice {
                 } else {
                     chunksize
                 };
-                let ringbuffer =
-                    HeapRb::<u8>::new(blockalign * (2 * buffer_capacity_frames + 2048));
+                // Size the ring buffer to fit at least the driver's actual buffer size,
+                // not just chunksize/resampler input, so a single ASIO callback can
+                // never push more bytes than the ring buffer can hold (see issue #498).
+                let ring_frames = buffer_capacity_frames.max(asio_buffer_size);
+                let ringbuffer = HeapRb::<u8>::new(blockalign * (2 * ring_frames + 2048));
                 let (device_producer, mut device_consumer) = ringbuffer.split();
                 let mut _single_capture_buffer_infos: Option<Vec<ASIOBufferInfo>> = None;
                 let mut _single_capture_callbacks: Option<Box<ASIOCallbacks>> = None;
@@ -1883,15 +1905,9 @@ impl CaptureDevice for AsioCaptureDevice {
                         tx_dev,
                         buffer_infos,
                         num_channels: channels,
-                        buffer_size: asio_buffer_size
-                            .expect("full_duplex setup must provide asio_buffer_size"),
+                        buffer_size: asio_buffer_size,
                         bytes_per_sample,
-                        interleaved_tmp: vec![
-                            0u8;
-                            asio_buffer_size.expect("full_duplex setup must provide asio_buffer_size")
-                                * bytes_per_sample
-                                * channels
-                        ],
+                        interleaved_tmp: vec![0u8; asio_buffer_size * bytes_per_sample * channels],
                         chunk_counter: 0,
                     });
                     let ctx_raw = Box::into_raw(ctx);
@@ -1912,19 +1928,7 @@ impl CaptureDevice for AsioCaptureDevice {
                     }
                     ctx_raw
                 } else {
-                    let preferred_buf = match get_preferred_buffer_size() {
-                        Ok(result) => result,
-                        Err(err) => {
-                            let msg = format!("ASIO capture buffer size query error: {err}");
-                            error!("{msg}");
-                            channel.send(AudioMessage::EndOfStream).unwrap_or(());
-                            status_channel
-                                .send(StatusMessage::CaptureError(msg))
-                                .unwrap_or(());
-                            barrier.wait();
-                            return;
-                        }
-                    };
+                    let preferred_buf = asio_buffer_size as i32;
 
                     let mut driver_buffer_infos = make_buffer_infos(channels, true);
                     let mut callbacks_for_driver = Box::new(ASIOCallbacks {


### PR DESCRIPTION
Refs #498

Fixes the ASIO ring buffer sizing bug from that issue (other backends mentioned there are unaffected/out of scope).

- Size the ASIO ring buffer and prefill from the driver's actual buffer size, not just chunksize
- Split the ASIO section out of README.md into backend_asio.md, matching the other backends
- Note that ASIO4ALL/FlexASIO/Steinberg's generic driver give no quality benefit over Wasapi exclusive mode