### PR TITLE
Measure capture rate over rate_measure_interval, not the update interval

### DIFF
--- a/src/alsa_backend/device.rs
+++ b/src/alsa_backend/device.rs
@@ -873,6 +873,9 @@ fn capture_loop_bytes(
     );
     let rate_measure_interval_ms = (1000.0 * params.rate_measure_interval) as u64;
     let mut rate_adjust = 0.0;
+    // Sample rate measured over the last completed `rate_measure_interval` window.
+    // Published to the capture status, kept separate from the short update cadence.
+    let mut measured_rate = 0.0;
     let mut silence_counter = countertimer::SilenceCounter::new(
         params.silence_threshold,
         params.silence_timeout,
@@ -975,15 +978,11 @@ fn capture_loop_bytes(
                 if let Some(capture_status) = params.capture_status.try_upgradable_read() {
                     if averager.larger_than_millis(capture_status.update_interval as u64) {
                         device_stalled = false;
-                        let bytes_per_sec = averager.average();
                         averager.restart();
-                        let measured_rate_f = bytes_per_sec
-                            / (params.channels * params.store_bytes_per_sample) as f64;
-                        trace!("Measured sample rate is {measured_rate_f:.1} Hz");
                         if let Ok(mut capture_status) =
                             RwLockUpgradableReadGuard::try_upgrade(capture_status)
                         {
-                            capture_status.measured_samplerate = measured_rate_f as usize;
+                            capture_status.measured_samplerate = measured_rate as usize;
                             capture_status.signal_range = value_range as f32;
                             capture_status.rate_adjust = rate_adjust as f32;
                             crate::update_capture_state(&mut capture_status, state);
@@ -1000,6 +999,7 @@ fn capture_loop_bytes(
                     watcher_averager.restart();
                     let measured_rate_f =
                         bytes_per_sec / (params.channels * params.store_bytes_per_sample) as f64;
+                    measured_rate = measured_rate_f;
                     let changed = valuewatcher.check_value(measured_rate_f as f32);
                     if changed {
                         warn!("sample rate change detected, last rate was {measured_rate_f} Hz");

--- a/src/alsa_backend/threaded_device.rs
+++ b/src/alsa_backend/threaded_device.rs
@@ -1691,6 +1691,9 @@ impl CaptureDevice for AlsaCaptureDevice {
                         let mut rms_values = Vec::new();
                         let mut peak_values = Vec::new();
                         let mut rate_adjust = 0.0;
+                        // Sample rate measured over the last completed `rate_measure_interval`
+                        // window, kept separate from the short update cadence.
+                        let mut measured_rate = 0.0;
                         let mut silence_counter = countertimer::SilenceCounter::new(
                             silence_threshold,
                             silence_timeout,
@@ -1824,14 +1827,11 @@ impl CaptureDevice for AlsaCaptureDevice {
                             if let Some(capture_status_guard) = capture_status.try_upgradable_read()
                                 && averager.larger_than_millis(capture_status_guard.update_interval as u64)
                             {
-                                let bytes_per_sec = averager.average();
                                 averager.restart();
-                                let measured_rate_f =
-                                    bytes_per_sec / (channels * bytes_per_sample) as f64;
                                 if let Ok(mut capture_status) =
                                     RwLockUpgradableReadGuard::try_upgrade(capture_status_guard)
                                 {
-                                    capture_status.measured_samplerate = measured_rate_f as usize;
+                                    capture_status.measured_samplerate = measured_rate as usize;
                                     capture_status.signal_range = value_range as f32;
                                     capture_status.rate_adjust = rate_adjust as f32;
                                     crate::update_capture_state(&mut capture_status, state);
@@ -1845,6 +1845,7 @@ impl CaptureDevice for AlsaCaptureDevice {
                                 watcher_averager.restart();
                                 let measured_rate_f =
                                     bytes_per_sec / (channels * bytes_per_sample) as f64;
+                                measured_rate = measured_rate_f;
                                 let changed = valuewatcher.check_value(measured_rate_f as f32);
                                 if changed && stop_on_rate_change {
                                     let _ = send_capture_audio(&channel, AudioMessage::EndOfStream);

--- a/src/asio_backend/device.rs
+++ b/src/asio_backend/device.rs
@@ -2003,6 +2003,9 @@ impl CaptureDevice for AsioCaptureDevice {
                 let mut rms_values = Vec::new();
                 let mut peak_values = Vec::new();
                 let mut rate_adjust = 0.0;
+                // Sample rate measured over the last completed `rate_measure_interval` window,
+                // kept separate from the short update cadence.
+                let mut measured_rate = 0.0;
                 let mut silence_counter = countertimer::SilenceCounter::new(
                     silence_threshold,
                     silence_timeout,
@@ -2126,14 +2129,12 @@ impl CaptureDevice for AsioCaptureDevice {
                         if averager
                             .larger_than_millis(capture_status.update_interval as u64)
                         {
-                            let samples_per_sec = averager.average();
                             averager.restart();
-                            let measured_rate_f = samples_per_sec;
                             if let Ok(mut capture_status) =
                                 RwLockUpgradableReadGuard::try_upgrade(capture_status)
                             {
                                 capture_status.measured_samplerate =
-                                    measured_rate_f as usize;
+                                    measured_rate as usize;
                                 capture_status.signal_range = value_range as f32;
                                 capture_status.rate_adjust = rate_adjust as f32;
                                 crate::update_capture_state(&mut capture_status, state);
@@ -2151,6 +2152,7 @@ impl CaptureDevice for AsioCaptureDevice {
                         let samples_per_sec = watcher_averager.average();
                         watcher_averager.restart();
                         let measured_rate_f = samples_per_sec;
+                        measured_rate = measured_rate_f;
                         debug!(
                             "Capture, measured sample rate is {measured_rate_f:.1} Hz."
                         );

--- a/src/audiodevice.rs
+++ b/src/audiodevice.rs
@@ -306,6 +306,7 @@ pub fn new_capture_device(conf: config::Devices) -> Box<dyn CaptureDevice> {
             channels,
             silence_threshold: conf.silence_threshold(),
             silence_timeout: conf.silence_timeout_s(),
+            rate_measure_interval: conf.rate_measure_interval_s(),
         }),
         config::CaptureDevice::RawFile(ref dev) => Box::new(filedevice::FileCaptureDevice {
             source: filedevice::CaptureSource::Filename(dev.filename.clone()),

--- a/src/coreaudio_backend/device.rs
+++ b/src/coreaudio_backend/device.rs
@@ -998,6 +998,9 @@ impl CaptureDevice for CoreaudioCaptureDevice {
                 let mut rms_values = Vec::new();
                 let mut peak_values = Vec::new();
                 let mut rate_adjust = 0.0;
+                // Sample rate measured over the last completed `rate_measure_interval` window,
+                // kept separate from the short update cadence.
+                let mut measured_rate = 0.0;
                 let mut silence_counter = countertimer::SilenceCounter::new(silence_threshold, silence_timeout, capture_samplerate, chunksize);
                 let mut state = ProcessingState::Running;
                 let blockalign = 4*channels;
@@ -1118,6 +1121,7 @@ impl CaptureDevice for CoreaudioCaptureDevice {
                         tries += 1;
                     }
                     if device_consumer.occupied_len() < (blockalign * capture_frames) {
+                        measured_rate = 0.0;
                         if let Some(mut capture_status) = capture_status.try_write() {
                             capture_status.measured_samplerate = 0;
                             capture_status.signal_range = 0.0;
@@ -1150,14 +1154,9 @@ impl CaptureDevice for CoreaudioCaptureDevice {
                     if let Some(capture_status) = capture_status.try_upgradable_read() {
                         if averager.larger_than_millis(capture_status.update_interval as u64)
                         {
-                            let samples_per_sec = averager.average();
                             averager.restart();
-                            let measured_rate_f = samples_per_sec;
-                            debug!(
-                                "Measured sample rate is {measured_rate_f:.1} Hz."
-                            );
                             if let Ok(mut capture_status) = RwLockUpgradableReadGuard::try_upgrade(capture_status) {
-                                capture_status.measured_samplerate = measured_rate_f as usize;
+                                capture_status.measured_samplerate = measured_rate as usize;
                                 capture_status.signal_range = value_range as f32;
                                 capture_status.rate_adjust = rate_adjust as f32;
                                 crate::update_capture_state(&mut capture_status, state);
@@ -1176,6 +1175,7 @@ impl CaptureDevice for CoreaudioCaptureDevice {
                         let samples_per_sec = watcher_averager.average();
                         watcher_averager.restart();
                         let measured_rate_f = samples_per_sec;
+                        measured_rate = measured_rate_f;
                         debug!(
                             "Rate watcher, measured sample rate is {measured_rate_f:.1} Hz."
                         );

--- a/src/file_backend/device.rs
+++ b/src/file_backend/device.rs
@@ -422,6 +422,9 @@ fn capture_loop(
     let mut peak_values = Vec::new();
     let mut value_range = 0.0;
     let mut rate_adjust = 0.0;
+    // Sample rate measured over the last completed `rate_measure_interval` window,
+    // kept separate from the short update cadence.
+    let mut measured_rate = 0.0;
     let mut state = ProcessingState::Running;
     let mut prev_state = ProcessingState::Running;
     let mut stalled = false;
@@ -552,15 +555,11 @@ fn capture_loop(
 
                 if let Some(capture_status) = params.capture_status.try_upgradable_read() {
                     if averager.larger_than_millis(capture_status.update_interval as u64) {
-                        let bytes_per_sec = averager.average();
                         averager.restart();
-                        let measured_rate_f = bytes_per_sec
-                            / (params.channels * params.store_bytes_per_sample) as f64;
-                        trace!("Measured sample rate is {measured_rate_f:.1} Hz");
                         if let Ok(mut capture_status) =
                             RwLockUpgradableReadGuard::try_upgrade(capture_status)
                         {
-                            capture_status.measured_samplerate = measured_rate_f as usize;
+                            capture_status.measured_samplerate = measured_rate as usize;
                             capture_status.signal_range = value_range as f32;
                             capture_status.rate_adjust = rate_adjust as f32;
                             crate::update_capture_state(&mut capture_status, state);
@@ -577,6 +576,7 @@ fn capture_loop(
                     watcher_averager.restart();
                     let measured_rate_f =
                         bytes_per_sec / (params.channels * params.store_bytes_per_sample) as f64;
+                    measured_rate = measured_rate_f;
                     let changed = valuewatcher.check_value(measured_rate_f as f32);
                     if changed {
                         warn!("sample rate change detected, last rate was {measured_rate_f} Hz");

--- a/src/pipewire_backend/device.rs
+++ b/src/pipewire_backend/device.rs
@@ -134,6 +134,7 @@ pub struct PipeWireCaptureDevice {
     pub channels: usize,
     pub silence_threshold: PrcFmt,
     pub silence_timeout: PrcFmt,
+    pub rate_measure_interval: f32,
 }
 
 /// Build audio format POD for stream parameters
@@ -748,6 +749,7 @@ impl CaptureDevice for PipeWireCaptureDevice {
         let async_src = resampler_is_async(&resampler_config);
         let silence_timeout = self.silence_timeout;
         let silence_threshold = self.silence_threshold;
+        let rate_measure_interval_ms = (1000.0 * self.rate_measure_interval) as u64;
 
         let handle = thread::Builder::new()
             .name("PipeWireCapture".to_string())
@@ -1002,6 +1004,10 @@ impl CaptureDevice for PipeWireCaptureDevice {
                         }
                     };
                     let mut averager = countertimer::TimeAverage::new();
+                    let mut watcher_averager = countertimer::TimeAverage::new();
+                    // Sample rate measured over the last completed `rate_measure_interval`
+                    // window, kept separate from the short update cadence.
+                    let mut measured_rate = 0.0;
                     let mut silence_counter = countertimer::SilenceCounter::new(
                         silence_threshold,
                         silence_timeout,
@@ -1087,6 +1093,14 @@ impl CaptureDevice for PipeWireCaptureDevice {
                         // Pop exactly the needed bytes into pre-allocated buffer
                         rb_consumer.pop_slice(&mut data_buffer[0..capture_bytes]);
                         averager.add_value(capture_bytes);
+                        watcher_averager.add_value(capture_bytes);
+                        if watcher_averager.larger_than_millis(rate_measure_interval_ms) {
+                            let bytes_per_sec = watcher_averager.average();
+                            watcher_averager.restart();
+                            measured_rate =
+                                bytes_per_sec / (channels * store_bytes_per_sample) as f64;
+                            trace!("Measured sample rate is {measured_rate:.1} Hz");
+                        }
 
                         // Update channel mask from capture status
                         {
@@ -1110,16 +1124,9 @@ impl CaptureDevice for PipeWireCaptureDevice {
                         // Update capture status
                         if let Some(capture_status) = capture_status_clone.try_upgradable_read() {
                             if averager.larger_than_millis(capture_status.update_interval as u64) {
-                                let bytes_per_sec = averager.average();
                                 averager.restart();
-                                let measured_rate_f = bytes_per_sec / (channels * store_bytes_per_sample) as f64;
-                                trace!(
-                                    "Measured sample rate is {:.1} Hz, signal RMS is {:?}",
-                                    measured_rate_f,
-                                    capture_status.signal_rms.last_sqrt(),
-                                );
                                 if let Ok(mut capture_status) = RwLockUpgradableReadGuard::try_upgrade(capture_status) {
-                                    capture_status.measured_samplerate = measured_rate_f as usize;
+                                    capture_status.measured_samplerate = measured_rate as usize;
                                     capture_status.signal_range = value_range as f32;
                                     capture_status.rate_adjust = rate_adjust as f32;
                                     crate::update_capture_state(&mut capture_status, state);

--- a/src/wasapi_backend/device.rs
+++ b/src/wasapi_backend/device.rs
@@ -1300,6 +1300,9 @@ impl CaptureDevice for WasapiCaptureDevice {
                 let mut rms_values = Vec::new();
                 let mut peak_values = Vec::new();
                 let mut rate_adjust = 0.0;
+                // Sample rate measured over the last completed `rate_measure_interval` window,
+                // kept separate from the short update cadence.
+                let mut measured_rate = 0.0;
                 let mut silence_counter = countertimer::SilenceCounter::new(silence_threshold, silence_timeout, capture_samplerate, chunksize);
                 let mut state = ProcessingState::Running;
                 let mut saved_state = state;
@@ -1418,11 +1421,9 @@ impl CaptureDevice for WasapiCaptureDevice {
                         if let Some(capture_status) = capture_status.try_upgradable_read() {
                             if averager.larger_than_millis(capture_status.update_interval as u64)
                             {
-                                let samples_per_sec = averager.average();
                                 averager.restart();
-                                let measured_rate_f = samples_per_sec;
                                 if let Ok(mut capture_status) = RwLockUpgradableReadGuard::try_upgrade(capture_status) {
-                                    capture_status.measured_samplerate = measured_rate_f as usize;
+                                    capture_status.measured_samplerate = measured_rate as usize;
                                     capture_status.signal_range = value_range as f32;
                                     capture_status.rate_adjust = rate_adjust as f32;
                                     crate::update_capture_state(&mut capture_status, state);
@@ -1441,6 +1442,7 @@ impl CaptureDevice for WasapiCaptureDevice {
                             let samples_per_sec = watcher_averager.average();
                             watcher_averager.restart();
                             let measured_rate_f = samples_per_sec;
+                            measured_rate = measured_rate_f;
                             debug!(
                                 "Capture, measured sample rate is {measured_rate_f:.1} Hz."
                             );


### PR DESCRIPTION
Fixes #502.

- `GetCaptureRate` now reports the estimate from the completed `rate_measure_interval` window instead of the short `SetUpdateInterval` cadence, so a stable 48 kHz stream no longer drifts into pyCamillaDSP's 44.1 kHz normalization band.
- `signal_range`, `rate_adjust` and `state` stay on the short update path.
- Applies to all rate-reporting capture backends; PipeWire had no long window, so `rate_measure_interval` is plumbed into it.