### PR TITLE
Publish to crates.io, and support cargo install / cargo binstall

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -212,3 +212,22 @@ jobs:
 
 
 
+
+  package:
+    name: Check crates.io package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update package list
+        run: sudo apt-get update
+
+      - name: Install Alsa devel
+        run: sudo apt-get install libasound2-dev -y
+
+      - name: Build the crate package
+        run: cargo package

--- a/.github/workflows/publish_crates_io.yml
+++ b/.github/workflows/publish_crates_io.yml
@@ -1,0 +1,27 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types:
+      - created
+  workflow_dispatch:
+
+jobs:
+  crates_io:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Update package list
+        run: sudo apt-get update
+
+      - name: Install Alsa devel
+        run: sudo apt-get install libasound2-dev -y
+
+      - name: Publish
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,57 @@
 [package]
-name = "CamillaDSP"
+name = "camilladsp"
 version = "4.1.3"
 authors = ["Henrik Enquist <henrik.enquist@gmail.com>"]
 edition = "2024"
 description = "A flexible tool for processing audio"
 rust-version = "1.90"
 license = "GPL-3.0-only OR MPL-2.0"
+repository = "https://github.com/HEnquist/camilladsp"
+homepage = "https://github.com/HEnquist/camilladsp"
+readme = "README.md"
+keywords = ["audio", "dsp", "crossover", "equalizer", "convolution"]
+categories = ["multimedia::audio", "command-line-utilities"]
+# Keep the published crate to the files needed to build, test and read about it.
+exclude = [
+    "/.github",
+    "/.vscode",
+    "/testscripts",
+    "/web",
+    "/Dockerfile_*",
+    "/*.png",
+    "/*.svg",
+    "/*.graphml",
+    "/translate_rew_xml.py",
+]
+
+# Let `cargo binstall camilladsp` fetch the pre-built binaries from the GitHub
+# releases instead of compiling. The asset names are set in publish.yml, and the
+# archives contain the executable at the top level.
+[package.metadata.binstall]
+pkg-fmt = "tgz"
+bin-dir = "{ bin }{ binary-ext }"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/camilladsp-linux-amd64.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/camilladsp-linux-aarch64.tar.gz"
+
+[package.metadata.binstall.overrides.armv7-unknown-linux-gnueabihf]
+pkg-url = "{ repo }/releases/download/v{ version }/camilladsp-linux-armv7.tar.gz"
+
+[package.metadata.binstall.overrides.arm-unknown-linux-gnueabihf]
+pkg-url = "{ repo }/releases/download/v{ version }/camilladsp-linux-armv6.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/camilladsp-macos-amd64.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/v{ version }/camilladsp-macos-aarch64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/camilladsp-windows-amd64.zip"
+pkg-fmt = "zip"
 
 [features]
 default = ["websocket"]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ and the Mozilla Public License Version 2.0:
 - **[GUI](#gui)**
 
 **[Installing](#installing)**
+- **[Installing with cargo](#installing-with-cargo)**
 
 **[Building](#building)**
 - **[Build with standard features](#building-in-linux-with-standard-features)**
@@ -321,6 +322,36 @@ Open a terminal and run:
 ```sh
 xattr -d com.apple.quarantine /path/to/camilladsp
 ```
+
+## Installing with cargo
+
+CamillaDSP is also published on [crates.io](https://crates.io/crates/camilladsp),
+which makes it possible to install and update it with cargo.
+This requires that rustc and cargo are installed, see [Building](#building).
+
+The quickest way is [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall),
+which downloads the same pre-built binary as the "Releases" page instead of compiling:
+
+```sh
+cargo binstall camilladsp
+```
+
+To compile from source instead:
+
+```sh
+cargo install camilladsp
+```
+
+This needs the same build dependencies as a manual build, see [Building](#building).
+It builds with the default features only.
+Use the `--features` option to pick others, in the same way as for `cargo build`:
+
+```sh
+cargo install camilladsp --features pulse-backend
+```
+
+Both commands install the `camilladsp` executable in `~/.cargo/bin`.
+Updating to a newer version is done by running the same command again.
 
 # Building
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -38,7 +38,7 @@ extern crate flexi_logger;
 #[macro_use]
 extern crate log;
 
-use clap::{Arg, ArgAction, Command, crate_authors, crate_description, crate_name, crate_version};
+use clap::{Arg, ArgAction, Command, crate_authors, crate_description, crate_version};
 use crossbeam_channel::select;
 use git_version::git_version;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
@@ -84,6 +84,8 @@ const EXIT_PROCESSING_ERROR: i32 = 102; // Error from processing
 const EXIT_FORCED: i32 = 103; // Exit was forced by a second SIGINT
 const EXIT_OK: i32 = 0; // All ok
 const GIT_HASH: &str = git_version!(fallback = "unknown");
+// Display name. The crates.io package name is the lowercase "camilladsp".
+const APP_NAME: &str = "CamillaDSP";
 
 // Customized version of `colored_opt_format` from flexi_logger.
 fn custom_colored_logger_format(
@@ -493,7 +495,7 @@ fn main_process() -> i32 {
 
     let longabout = format!(
         "{} v{} ({})\n{}\n{}\n\n{}\n\n{}\n\nSupported device types:\n{}\n{}",
-        crate_name!(),
+        APP_NAME,
         crate_version!(),
         GIT_HASH,
         crate_authors!(),
@@ -504,7 +506,7 @@ fn main_process() -> i32 {
         playback_types
     );
 
-    let clapapp = Command::new("CamillaDSP")
+    let clapapp = Command::new(APP_NAME)
         .version(version_with_hash)
         .about(longabout)
         .author(crate_authors!())


### PR DESCRIPTION
Picking up #350. This adds what is needed to publish CamillaDSP on crates.io, so it can be installed and updated with:

```sh
cargo binstall camilladsp   # downloads the release binary
cargo install camilladsp    # compiles from source
cargo install-update camilladsp  # via cargo-update
```

Nothing is published by this PR on its own — it only makes the crate publishable. Feel free to close it if you'd rather not be on crates.io; the name `camilladsp` is still unregistered today, so it is at least worth claiming.

### What's in it

**`Cargo.toml`**
- Renamed the package from `CamillaDSP` to lowercase `camilladsp`. crates.io names are case sensitive for `cargo install`, so this is what makes `cargo install camilladsp` work, and it matches the executable name. The `[lib] name = "camillalib"` and `[[bin]] name = "camilladsp"` targets are set explicitly, so nothing about the build output changes.
- Added `repository`, `homepage`, `readme`, `keywords` and `categories`, which is what crates.io wants for a decent listing page.
- Added an `exclude` list, so the published archive contains the sources, benches, testdata, example configs and docs, but not the images, CI files, Dockerfiles, `web/` or `testscripts/`. `testdata/` is kept, so `cargo test` works on the published crate.
- Added `[package.metadata.binstall]` mapping the seven target triples to the release asset names from `publish.yml`. The `.tar.gz` and `.zip` archives contain the executable at the top level, so `bin-dir` is just the binary name. This means `cargo binstall` downloads the same binary as the Releases page rather than compiling.

**`src/bin.rs`**
- `crate_name!()` would now expand to the lowercase `camilladsp` in the `--help` text. Replaced it with a new `APP_NAME` const, which also replaces the `"CamillaDSP"` literal that was already passed to `Command::new`. The `--help` output is unchanged.

**`.github/workflows/publish_crates_io.yml`** (new)
- Runs `cargo publish` when a release is created, and can also be triggered manually. It needs a `CARGO_REGISTRY_TOKEN` repository secret, from https://crates.io/settings/tokens — ideally a token scoped to `publish-update` for this crate only. The first publish has to be done by hand, since the token can only be scoped to a crate that already exists.

**`.github/workflows/ci_test.yml`**
- Added a job that runs `cargo package`, so a broken package is caught in CI rather than in the middle of a release.

### Notes

- Regarding your point in #350 about forks: all dependencies currently resolve to crates.io releases, the fork lines are commented out, so 4.1.3 is publishable as is. If a fork is ever needed again, that release just gets skipped on crates.io, and the workflow can be left to fail or the job skipped for that release.
- `git_version!` already has `fallback = "unknown"`, so the version string degrades gracefully when built from the crates.io tarball with no git repo present.
- I have not added a CHANGELOG entry, since there is no unreleased section — happy to add one wherever you prefer.
- I don't have a Rust toolchain on this machine, so I have not built this locally; CI on this PR is the first real check. Let me know if anything needs fixing.
