### PR TITLE
Use fused multiply-add in biquad where the hardware has it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Bugfixes:
   `chunksize`, fixing continuous underruns when the driver requests a larger buffer than `chunksize`.
 
 Changes:
+- Biquads now use fused multiply-add on hardware that has it, about 18% faster on aarch64. The
+  fused form rounds once instead of twice, so results can differ from 4.1.3 in the last few bits.
 - Improved DSP library separation for easier external integration.
 - File playback now writes correct wav header sizes, and stops at the 4 GB limit for plain wav.
 - The `websocket` build feature is gone. The websocket server is now always built in, since every

--- a/src/filters/biquad.rs
+++ b/src/filters/biquad.rs
@@ -426,6 +426,30 @@ impl From<BiquadCoefficients> for RuntimeCoefficients {
     }
 }
 
+/// Computes `a * b + c`, fused into a single instruction where the hardware
+/// has fused multiply-add.
+///
+/// Fusing shortens the biquad feedback path and is measurably faster. It is
+/// gated because on targets without hardware FMA `mul_add` lowers to a libm
+/// `fma()` call, which is far slower than a separate multiply and add. The
+/// gate covers aarch64, where FMA is always present, and x86 built with
+/// `+fma`. Plain x86-64 falls back to `mulsd`/`addsd`, and 32-bit arm to a
+/// single unfused `vmla.f64`, so the fallback costs nothing there.
+///
+/// Note that the fused form rounds once instead of twice, so a build that
+/// takes this path differs from one that does not in the last few ulp.
+#[inline(always)]
+fn mul_add(a: CamillaFloat, b: CamillaFloat, c: CamillaFloat) -> CamillaFloat {
+    if cfg!(any(
+        all(target_arch = "aarch64", target_feature = "neon"),
+        target_feature = "fma",
+    )) {
+        a.mul_add(b, c)
+    } else {
+        a * b + c
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Biquad {
     samplerate: usize,
@@ -449,9 +473,13 @@ impl Biquad {
 
     /// Process a single sample.
     pub fn process_single(&mut self, input: CamillaFloat) -> CamillaFloat {
-        let out = self.s1 + self.coeffs.b0 * input;
-        self.s1 = self.s2 + self.coeffs.b1 * input - self.coeffs.a1 * out;
-        self.s2 = self.coeffs.b2 * input - self.coeffs.a2 * out;
+        let out = mul_add(self.coeffs.b0, input, self.s1);
+        self.s1 = mul_add(
+            -self.coeffs.a1,
+            out,
+            mul_add(self.coeffs.b1, input, self.s2),
+        );
+        self.s2 = mul_add(-self.coeffs.a2, out, self.coeffs.b2 * input);
         out
     }
 


### PR DESCRIPTION
Split out of #516, which mixes several unrelated changes. This is the fused multiply-add part
on its own.

Biquad processing now uses fused multiply-add where the hardware has it, about 18% faster
on aarch64.

- Gated on aarch64 and on x86 built with `+fma`. Other targets keep the plain multiply and
  add, since `mul_add` lowers to a libm `fma()` call there and would be far slower.
- The fused form rounds once instead of twice, so results differ from 4.1.3 in the last few
  bits. Measured deviation against an unfused reference on a high-Q resonator is 1.1e-12 at
  a peak output of 86, about -278 dB.
- Changelog entry under Changes.