### PR TITLE
Make filter and processor processing infallible

### DIFF
--- a/benches/conv_parallel.rs
+++ b/benches/conv_parallel.rs
@@ -136,13 +136,13 @@ fn bench_conv_parallel(c: &mut Criterion) {
                                     pool.install(|| {
                                         filters.par_iter_mut().zip(waves.par_iter_mut()).for_each(
                                             |(filter, wave)| {
-                                                filter.process_waveform(wave).unwrap();
+                                                filter.process_waveform(wave);
                                             },
                                         );
                                     });
                                 } else {
                                     for (filter, wave) in filters.iter_mut().zip(waves.iter_mut()) {
-                                        filter.process_waveform(wave).unwrap();
+                                        filter.process_waveform(wave);
                                     }
                                 }
                                 black_box(&waves[0][0]);

--- a/src/filters/basicfilters.rs
+++ b/src/filters/basicfilters.rs
@@ -242,7 +242,7 @@ impl Filter for Volume {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         self.prepare_processing();
 
         // Not in a ramp
@@ -274,7 +274,6 @@ impl Filter for Volume {
         // same question.
         self.processing_params
             .set_current_volume(self.fader, self.current_volume.to_f32());
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
@@ -323,11 +322,10 @@ impl Filter for Gain {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         for item in waveform.iter_mut() {
             *item *= self.gain;
         }
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
@@ -448,7 +446,7 @@ impl Filter for Delay {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         if let Some(q) = &mut self.queue {
             for item in waveform.iter_mut() {
                 // this returns the item that was popped while pushing
@@ -456,9 +454,8 @@ impl Filter for Delay {
             }
         }
         if let Some(bq) = &mut self.biquad {
-            bq.process_waveform(waveform)?;
+            bq.process_waveform(waveform);
         }
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
@@ -534,7 +531,7 @@ mod tests {
         let mut waveform = vec![-0.5, 0.0, 0.5];
         let waveform_inv = vec![0.5, 0.0, -0.5];
         let mut gain = Gain::new("test", 0.0, true, false, false);
-        gain.process_waveform(&mut waveform).unwrap();
+        gain.process_waveform(&mut waveform);
         assert_eq!(waveform, waveform_inv);
     }
 
@@ -543,7 +540,7 @@ mod tests {
         let mut waveform = vec![-0.5, 0.0, 0.5];
         let waveform_ampl = vec![-5.0, 0.0, 5.0];
         let mut gain = Gain::new("test", 20.0, false, false, false);
-        gain.process_waveform(&mut waveform).unwrap();
+        gain.process_waveform(&mut waveform);
         assert_eq!(waveform, waveform_ampl);
     }
 
@@ -552,7 +549,7 @@ mod tests {
         let mut waveform = vec![0.0, -0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let waveform_delayed = vec![0.0, 0.0, 0.0, 0.0, -0.5, 1.0, 0.0, 0.0];
         let mut delay = Delay::new("test", 44100, 3.0, false);
-        delay.process_waveform(&mut waveform).unwrap();
+        delay.process_waveform(&mut waveform);
         assert_eq!(waveform, waveform_delayed);
     }
 
@@ -561,7 +558,7 @@ mod tests {
         let mut waveform = vec![0.0, -0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let waveform_delayed = waveform.clone();
         let mut delay = Delay::new("test", 44100, 0.1, false);
-        delay.process_waveform(&mut waveform).unwrap();
+        delay.process_waveform(&mut waveform);
         assert_eq!(waveform, waveform_delayed);
     }
 
@@ -571,8 +568,8 @@ mod tests {
         let mut waveform2 = vec![0.0; 8];
         let waveform_delayed = vec![0.0, 0.0, -0.5, 1.0, 0.0, 0.0, 0.0, 0.0];
         let mut delay = Delay::new("test", 44100, 9.0, false);
-        delay.process_waveform(&mut waveform1).unwrap();
-        delay.process_waveform(&mut waveform2).unwrap();
+        delay.process_waveform(&mut waveform1);
+        delay.process_waveform(&mut waveform2);
         assert_eq!(waveform1, vec![0.0; 8]);
         assert_eq!(waveform2, waveform_delayed);
     }
@@ -593,7 +590,7 @@ mod tests {
             -0.001882310318672015,
         ];
         let mut delay = Delay::new("test", 44100, 1.7, true);
-        delay.process_waveform(&mut waveform).unwrap();
+        delay.process_waveform(&mut waveform);
         assert!(compare_waveforms(waveform, expected_waveform, 1.0e-6));
     }
 
@@ -642,27 +639,27 @@ mod tests {
 
         // No change yet, unity gain.
         let mut chunk = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk).unwrap();
+        filter.process_waveform(&mut chunk);
         assert!(chunk.iter().all(|s| (s - 1.0).abs() < 1e-10));
 
         params.set_target_volume(0, -20.0);
 
         // First ramp chunk: stays inside the range and falls across the chunk.
         let mut chunk1 = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk1).unwrap();
+        filter.process_waveform(&mut chunk1);
         assert!(chunk1.iter().all(|s| *s <= gain_at(0.0) + 1e-6));
         assert!(chunk1.iter().all(|s| *s >= gain_at(-20.0) - 1e-6));
         assert!(chunk1[0] > chunk1[VOL_CHUNKSIZE - 1]);
 
         // Second ramp chunk continues downwards.
         let mut chunk2 = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk2).unwrap();
+        filter.process_waveform(&mut chunk2);
         assert!(chunk2[VOL_CHUNKSIZE - 1] < chunk1[VOL_CHUNKSIZE - 1]);
         assert!(chunk2[VOL_CHUNKSIZE - 1] >= gain_at(-20.0) - 1e-6);
 
         // Ramp is done, the target is applied flat.
         let mut chunk3 = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk3).unwrap();
+        filter.process_waveform(&mut chunk3);
         assert!(chunk3.iter().all(|s| (s - gain_at(-20.0)).abs() < 1e-6));
     }
 
@@ -674,7 +671,7 @@ mod tests {
         let mut filter = make_volume(&params, 2.0);
 
         let mut chunk = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk).unwrap();
+        filter.process_waveform(&mut chunk);
 
         // Audio stops, volume is changed while paused, then playback resumes.
         params.bump_pause_count();
@@ -682,7 +679,7 @@ mod tests {
         params.set_target_volume(0, -20.0);
 
         let mut resumed = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut resumed).unwrap();
+        filter.process_waveform(&mut resumed);
         assert!(resumed.iter().all(|s| (s - gain_at(-20.0)).abs() < 1e-6));
     }
 
@@ -695,17 +692,17 @@ mod tests {
         let mut filter = make_volume(&params, 2.0);
 
         let mut chunk = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk).unwrap();
+        filter.process_waveform(&mut chunk);
 
         // A pause happens, but no volume change is made during it.
         params.bump_pause_count();
         let mut resumed = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut resumed).unwrap();
+        filter.process_waveform(&mut resumed);
 
         // Now change the volume while running, this must ramp.
         params.set_target_volume(0, -20.0);
         let mut chunk1 = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk1).unwrap();
+        filter.process_waveform(&mut chunk1);
         assert!(chunk1[0] > chunk1[VOL_CHUNKSIZE - 1]);
         assert!(chunk1[VOL_CHUNKSIZE - 1] > gain_at(-20.0) + 1e-6);
     }
@@ -718,11 +715,11 @@ mod tests {
         let mut filter = make_volume(&params, 0.0);
 
         let mut chunk = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk).unwrap();
+        filter.process_waveform(&mut chunk);
 
         params.set_target_volume(0, -20.0);
         let mut chunk1 = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk1).unwrap();
+        filter.process_waveform(&mut chunk1);
         assert!(chunk1.iter().all(|s| (s - gain_at(-20.0)).abs() < 1e-6));
     }
 
@@ -734,13 +731,13 @@ mod tests {
         let mut filter = make_volume(&params, 2.0);
 
         let mut chunk = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut chunk).unwrap();
+        filter.process_waveform(&mut chunk);
 
         params.bump_pause_count();
         params.set_mute(0, true);
 
         let mut resumed = vec![1.0; VOL_CHUNKSIZE];
-        filter.process_waveform(&mut resumed).unwrap();
+        filter.process_waveform(&mut resumed);
         assert!(resumed.iter().all(|s| s.abs() < 1e-10));
     }
 
@@ -752,7 +749,7 @@ mod tests {
         let mut filter = make_volume_full(&params, 0.0, 50.0, -20.0, false, 4);
 
         let mut waveform: Vec<CamillaFloat> = vec![1.0, -1.0, 0.5, -0.5];
-        filter.process_waveform(&mut waveform).unwrap();
+        filter.process_waveform(&mut waveform);
 
         let gain = gain_at(-20.0);
         let expected: Vec<CamillaFloat> = vec![gain, -gain, 0.5 * gain, -0.5 * gain];
@@ -768,7 +765,7 @@ mod tests {
         let mut filter = make_volume_full(&params, 0.0, 50.0, 0.0, true, 4);
 
         let mut waveform: Vec<CamillaFloat> = vec![1.0, 0.5, -0.5, -1.0];
-        filter.process_waveform(&mut waveform).unwrap();
+        filter.process_waveform(&mut waveform);
         assert!(waveform.iter().all(|s| s.abs() < 1e-10));
     }
 
@@ -780,18 +777,18 @@ mod tests {
         let mut filter = make_volume_full(&params, 0.0, 50.0, 0.0, false, 4);
 
         let mut wave1: Vec<CamillaFloat> = vec![1.0; 4];
-        filter.process_waveform(&mut wave1).unwrap();
+        filter.process_waveform(&mut wave1);
 
         // Below the threshold, so the gain stays at unity.
         params.set_target_volume(0, 0.005);
         let mut wave2: Vec<CamillaFloat> = vec![1.0; 4];
-        filter.process_waveform(&mut wave2).unwrap();
+        filter.process_waveform(&mut wave2);
         assert!(wave2.iter().all(|s| (s - 1.0).abs() < 1e-10));
 
         // Above the threshold, so it is applied.
         params.set_target_volume(0, 0.02);
         let mut wave3: Vec<CamillaFloat> = vec![1.0; 4];
-        filter.process_waveform(&mut wave3).unwrap();
+        filter.process_waveform(&mut wave3);
         assert!(wave3.iter().all(|s| (s - gain_at(0.02)).abs() < 1e-6));
     }
 
@@ -804,7 +801,7 @@ mod tests {
 
         params.set_target_volume(0, 20.0);
         let mut waveform: Vec<CamillaFloat> = vec![1.0; 4];
-        filter.process_waveform(&mut waveform).unwrap();
+        filter.process_waveform(&mut waveform);
         assert!(waveform.iter().all(|s| (s - gain_at(10.0)).abs() < 1e-6));
     }
 
@@ -819,23 +816,23 @@ mod tests {
         let mut filter = make_volume_full(&params, 2.0, 50.0, 0.0, false, 4);
 
         let mut chunk0: Vec<CamillaFloat> = vec![1.0; 4];
-        filter.process_waveform(&mut chunk0).unwrap();
+        filter.process_waveform(&mut chunk0);
         assert!(chunk0.iter().all(|s| (s - 1.0).abs() < 1e-10));
 
         params.set_target_volume(0, -20.0);
 
         let mut chunk1: Vec<CamillaFloat> = vec![1.0; 4];
-        filter.process_waveform(&mut chunk1).unwrap();
+        filter.process_waveform(&mut chunk1);
         assert!(chunk1[0] > chunk1[3]);
         assert!(chunk1.iter().all(|s| *s <= gain_at(0.0) + 1e-6));
         assert!(chunk1.iter().all(|s| *s >= gain_at(-20.0) - 1e-6));
 
         let mut chunk2: Vec<CamillaFloat> = vec![1.0; 4];
-        filter.process_waveform(&mut chunk2).unwrap();
+        filter.process_waveform(&mut chunk2);
         assert!(chunk2[3] < chunk1[3]);
 
         let mut chunk3: Vec<CamillaFloat> = vec![1.0; 4];
-        filter.process_waveform(&mut chunk3).unwrap();
+        filter.process_waveform(&mut chunk3);
         assert!(chunk3.iter().all(|s| (s - gain_at(-20.0)).abs() < 1e-6));
     }
 }

--- a/src/filters/biquad.rs
+++ b/src/filters/biquad.rs
@@ -501,12 +501,11 @@ impl Filter for Biquad {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         for item in waveform.iter_mut() {
             *item = self.process_single(*item);
         }
         self.flush_subnormals();
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
@@ -688,7 +687,7 @@ mod tests {
         let mut wave = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let expected = vec![0.215, 0.461, 0.281, 0.039, 0.004, 0.0, 0.0, 0.0];
         let mut filter = Biquad::new("test", 44100, coeffs);
-        filter.process_waveform(&mut wave).unwrap();
+        filter.process_waveform(&mut wave);
         assert!(compare_waveforms(wave, expected, 1e-3));
     }
 

--- a/src/filters/biquadcombo.rs
+++ b/src/filters/biquadcombo.rs
@@ -279,11 +279,10 @@ impl Filter for BiquadCombo {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         for filter in self.filters.iter_mut() {
-            filter.process_waveform(waveform)?;
+            filter.process_waveform(waveform);
         }
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {

--- a/src/filters/clipper.rs
+++ b/src/filters/clipper.rs
@@ -79,9 +79,8 @@ impl Filter for Clipper {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         self.apply_clip(waveform);
-        Ok(())
     }
 
     fn update_parameters(&mut self, config: config::Filter) {

--- a/src/filters/diffeq.rs
+++ b/src/filters/diffeq.rs
@@ -124,12 +124,11 @@ impl Filter for DiffEq {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         for item in waveform.iter_mut() {
             *item = self.process_single(*item);
         }
         self.flush_subnormals();
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
@@ -184,7 +183,7 @@ mod tests {
         );
         let mut wave = vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
         let expected = vec![0.215, 0.461, 0.281, 0.039, 0.004, 0.0, 0.0, 0.0];
-        filter.process_waveform(&mut wave).unwrap();
+        filter.process_waveform(&mut wave);
         assert!(compare_waveforms(wave, expected, 1e-3));
     }
 }

--- a/src/filters/dither.rs
+++ b/src/filters/dither.rs
@@ -575,7 +575,7 @@ impl Filter for Dither<'_> {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         for item in waveform.iter_mut() {
             let scaled = *item * self.scalefact;
             let dither = self.ditherer.sample();
@@ -589,8 +589,6 @@ impl Filter for Dither<'_> {
 
             *item = result_r / self.scalefact;
         }
-
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
@@ -790,7 +788,7 @@ mod tests {
         let waveform2 = waveform.clone();
         let conf = DitherParameters::None { bits: 8 };
         let mut dith = Dither::from_config("test", conf);
-        dith.process_waveform(&mut waveform).unwrap();
+        dith.process_waveform(&mut waveform);
         assert!(compare_waveforms(waveform.clone(), waveform2, 1.0 / 128.0));
         assert!(is_close(
             (128.0 * waveform[2]).round(),
@@ -808,7 +806,7 @@ mod tests {
             amplitude: 2.0,
         };
         let mut dith = Dither::from_config("test", conf);
-        dith.process_waveform(&mut waveform).unwrap();
+        dith.process_waveform(&mut waveform);
         assert!(compare_waveforms(waveform.clone(), waveform2, 1.0 / 64.0));
         assert!(is_close(
             (128.0 * waveform[2]).round(),
@@ -823,7 +821,7 @@ mod tests {
         let waveform2 = waveform.clone();
         let conf = DitherParameters::Highpass { bits: 8 };
         let mut dith = Dither::from_config("test", conf);
-        dith.process_waveform(&mut waveform).unwrap();
+        dith.process_waveform(&mut waveform);
         assert!(compare_waveforms(waveform.clone(), waveform2, 1.0 / 32.0));
         assert!(is_close(
             (128.0 * waveform[2]).round(),
@@ -838,7 +836,7 @@ mod tests {
         let waveform2 = waveform.clone();
         let conf = DitherParameters::Lipshitz441 { bits: 8 };
         let mut dith = Dither::from_config("test", conf);
-        dith.process_waveform(&mut waveform).unwrap();
+        dith.process_waveform(&mut waveform);
         assert!(compare_waveforms(waveform.clone(), waveform2, 1.0 / 16.0));
         assert!(is_close(
             (128.0 * waveform[2]).round(),

--- a/src/filters/fftconv.rs
+++ b/src/filters/fftconv.rs
@@ -451,7 +451,7 @@ impl Filter for FftConv {
     }
 
     /// Process a waveform by FT, then multiply transform with transform of filter, and then transform back.
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         // Copy to input buffer and clear overlap area
         self.input_buf[0..self.npoints].copy_from_slice(waveform);
         for item in self
@@ -503,7 +503,6 @@ impl Filter for FftConv {
         }
         self.overlap
             .copy_from_slice(&self.output_buf[self.npoints..]);
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
@@ -697,7 +696,7 @@ mod tests {
         let mut filter = FftConv::from_config("test", 8, conf);
         let mut wave1 = vec![1.0, 1.0, 1.0, 0.0, 0.0, -1.0, 0.0, 0.0];
         let expected = vec![0.5, 1.0, 1.0, 0.5, 0.0, -0.5, -0.5, 0.0];
-        filter.process_waveform(&mut wave1).unwrap();
+        filter.process_waveform(&mut wave1);
         assert!(compare_waveforms(wave1, expected, 1e-7));
     }
 
@@ -716,8 +715,8 @@ mod tests {
                     .collect();
                 let mut wave_first = input.clone();
                 let mut wave_second = input;
-                first.process_waveform(&mut wave_first).unwrap();
-                second.process_waveform(&mut wave_second).unwrap();
+                first.process_waveform(&mut wave_first);
+                second.process_waveform(&mut wave_second);
                 assert!(
                     compare_waveforms(wave_first, wave_second, 1e-9),
                     "length {data_length}, block {block}"
@@ -741,7 +740,7 @@ mod tests {
         // Built directly, bypassing validation, it must be silent not fatal.
         let mut filter = FftConv::from_config("empty", 8, conf);
         let mut wave: Vec<CamillaFloat> = (0..8).map(|n| n as CamillaFloat).collect();
-        filter.process_waveform(&mut wave).unwrap();
+        filter.process_waveform(&mut wave);
         assert!(
             wave.iter().all(|v| *v == 0.0),
             "expected silence, got {wave:?}"
@@ -764,8 +763,8 @@ mod tests {
         short_wave[0] = 1.0;
         let mut long_wave = vec![0.0 as CamillaFloat; 16];
         long_wave[0] = 1.0;
-        short.process_waveform(&mut short_wave).unwrap();
-        long.process_waveform(&mut long_wave).unwrap();
+        short.process_waveform(&mut short_wave);
+        long.process_waveform(&mut long_wave);
         // An impulse in, so what comes out is the impulse response itself.
         // Both lengths must give it, which they cannot if either took the
         // other's coefficients.
@@ -813,9 +812,9 @@ mod tests {
                 wave_ref[0] = 1.0;
             }
             let mut wave_right = vec![0.0 as CamillaFloat; 8];
-            left.process_waveform(&mut wave_left).unwrap();
-            right.process_waveform(&mut wave_right).unwrap();
-            reference.process_waveform(&mut wave_ref).unwrap();
+            left.process_waveform(&mut wave_left);
+            right.process_waveform(&mut wave_right);
+            reference.process_waveform(&mut wave_ref);
             assert!(
                 compare_waveforms(wave_left, wave_ref, 1e-5),
                 "shared build changed the result, block {block}"
@@ -852,7 +851,7 @@ mod tests {
 
         // A one sample delay now, so an impulse comes back shifted by one.
         let mut wave = vec![1.0 as CamillaFloat, 0.0, 0.0, 0.0];
-        left.process_waveform(&mut wave).unwrap();
+        left.process_waveform(&mut wave);
         assert!(compare_waveforms(wave, vec![0.0, 1.0, 0.0, 0.0], 1e-5));
     }
 
@@ -870,11 +869,11 @@ mod tests {
         let mut wave5 = vec![0.0 as CamillaFloat; 8];
 
         wave1[0] = 1.0;
-        filter.process_waveform(&mut wave1).unwrap();
-        filter.process_waveform(&mut wave2).unwrap();
-        filter.process_waveform(&mut wave3).unwrap();
-        filter.process_waveform(&mut wave4).unwrap();
-        filter.process_waveform(&mut wave5).unwrap();
+        filter.process_waveform(&mut wave1);
+        filter.process_waveform(&mut wave2);
+        filter.process_waveform(&mut wave3);
+        filter.process_waveform(&mut wave4);
+        filter.process_waveform(&mut wave5);
 
         let exp1 = Vec::from(&coeffs[0..8]);
         let exp2 = Vec::from(&coeffs[8..16]);

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -319,9 +319,8 @@ impl Filter for LookaheadLimiter {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         self.gain.process_waveform(waveform);
-        Ok(())
     }
 
     fn update_parameters(&mut self, config: config::Filter) {
@@ -407,7 +406,7 @@ mod tests {
             0.5_f64.powf(1.0 / 16.0) as CamillaFloat,
             0.5_f64.powf(1.0 / 32.0) as CamillaFloat,
         ];
-        limiter.process_waveform(&mut input).unwrap();
+        limiter.process_waveform(&mut input);
         assert_close(&input, &expected, 1e-6);
     }
 
@@ -433,9 +432,7 @@ mod tests {
         let mut lookahead_input = vec![0.5, 1.0, 2.0, -2.0, -1.0, -0.5, 1.5, -1.5, 0.0];
         let mut clipper_input = lookahead_input.clone();
 
-        lookahead_limiter
-            .process_waveform(&mut lookahead_input)
-            .unwrap();
+        lookahead_limiter.process_waveform(&mut lookahead_input);
         clipper.apply_clip(&mut clipper_input);
 
         assert_eq!(lookahead_input, clipper_input);
@@ -483,7 +480,7 @@ mod tests {
             limiter_input.len(),
         );
 
-        limiter.process_waveform(&mut limiter_input).unwrap();
+        limiter.process_waveform(&mut limiter_input);
         compressor.process_chunk(&mut compressor_chunk).unwrap();
 
         // The values are not exactly equal because compressor works in the dB domain and has 1e-6 bias.
@@ -501,7 +498,7 @@ mod tests {
         };
         let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 1024);
         let mut input = vec![1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.0, 1.0, 1.0];
-        limiter.process_waveform(&mut input).unwrap();
+        limiter.process_waveform(&mut input);
         for &val in &input {
             assert!(val.abs() <= 1.0);
         }
@@ -520,7 +517,7 @@ mod tests {
         let mut buf1 = vec![1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0];
         let expected1: Vec<CamillaFloat> =
             vec![0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.9, 0.8, 0.7, 0.6, 1.0];
-        limiter.process_waveform(&mut buf1).unwrap();
+        limiter.process_waveform(&mut buf1);
         assert_close(&buf1, &expected1, 1e-6);
 
         let mut buf2 = vec![1.0, 1.0, 1.0, 1.0];
@@ -530,7 +527,7 @@ mod tests {
             0.5_f64.powf(1.0 / 8.0) as CamillaFloat,
             0.5_f64.powf(1.0 / 16.0) as CamillaFloat,
         ];
-        limiter.process_waveform(&mut buf2).unwrap();
+        limiter.process_waveform(&mut buf2);
         assert_close(&buf2, &expected2, 1e-6);
     }
 
@@ -560,7 +557,7 @@ mod tests {
         let mut limiter = LookaheadLimiter::from_config("test", config, samplerate, chunksize);
         let mut input = vec![1.0, 1.0, 2.0, 1.0, 1.0, -2.0, 1.0, 1.0];
 
-        limiter.process_waveform(&mut input).unwrap();
+        limiter.process_waveform(&mut input);
 
         assert_eq!(input.len(), chunksize);
     }

--- a/src/filters/lookahead_limiter.rs
+++ b/src/filters/lookahead_limiter.rs
@@ -481,7 +481,7 @@ mod tests {
         );
 
         limiter.process_waveform(&mut limiter_input);
-        compressor.process_chunk(&mut compressor_chunk).unwrap();
+        compressor.process_chunk(&mut compressor_chunk);
 
         // The values are not exactly equal because compressor works in the dB domain and has 1e-6 bias.
         assert_close(&limiter_input, &compressor_chunk.waveforms[0], 1e-6);

--- a/src/filters/loudness.rs
+++ b/src/filters/loudness.rs
@@ -107,7 +107,7 @@ impl Filter for Loudness {
         &self.name
     }
 
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()> {
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
         // Written by `Volume` while it processes, so the two are
         // order-sensitive across channels. See `parallelize_filters` in
         // pipeline.rs, which changes that order and says why the one chunk of
@@ -160,13 +160,12 @@ impl Filter for Loudness {
         }
         if self.active {
             trace!("Applying loudness biquads");
-            self.high_biquad.process_waveform(waveform).unwrap();
-            self.low_biquad.process_waveform(waveform).unwrap();
+            self.high_biquad.process_waveform(waveform);
+            self.low_biquad.process_waveform(waveform);
             if let Some(gain) = &mut self.gain {
-                gain.process_waveform(waveform).unwrap();
+                gain.process_waveform(waveform);
             }
         }
-        Ok(())
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -50,7 +50,11 @@ use waveadapter::read_wav_file;
 /// Trait implemented by all single-channel audio filters.
 pub trait Filter {
     /// Apply the filter to `waveform` in place.
-    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) -> Res<()>;
+    ///
+    /// Infallible. A filter that was accepted at construction cannot start
+    /// failing on a later chunk, and nothing could be done about it part way
+    /// through a chunk in the processing thread if it did.
+    fn process_waveform(&mut self, waveform: &mut [CamillaFloat]);
 
     /// Hot-reload filter coefficients from a new configuration without rebuilding.
     fn update_parameters(&mut self, config: config::Filter);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -15,7 +15,6 @@
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
 use crate::ProcessingParameters;
-use crate::Res;
 use crate::audiochunk::AudioChunk;
 use crate::config;
 use crate::filters;
@@ -133,13 +132,14 @@ impl FilterGroup {
     }
 
     /// Apply all the filters to an AudioChunk.
-    fn process_chunk(&mut self, input: &mut AudioChunk) -> Res<()> {
-        if !input.waveforms[self.channel].is_empty() {
-            for filter in &mut self.filters {
-                filter.process_waveform(&mut input.waveforms[self.channel])?;
-            }
+    fn process_chunk(&mut self, input: &mut AudioChunk) {
+        let waveform = &mut input.waveforms[self.channel];
+        if waveform.is_empty() {
+            return;
         }
-        Ok(())
+        for filter in &mut self.filters {
+            filter.process_waveform(waveform);
+        }
     }
 }
 
@@ -167,7 +167,7 @@ impl ParallelFilters {
     }
 
     /// Apply all the filters to an AudioChunk.
-    fn process_chunk(&mut self, input: &mut AudioChunk) -> Res<()> {
+    fn process_chunk(&mut self, input: &mut AudioChunk) {
         self.filter_pool.install(|| {
             self.filters
                 .par_iter_mut()
@@ -175,11 +175,10 @@ impl ParallelFilters {
                 .filter(|(f, w)| !f.is_empty() && !w.is_empty())
                 .for_each(|(f, w)| {
                     for filt in f {
-                        let _ = filt.process_waveform(w);
+                        filt.process_waveform(w);
                     }
                 });
         });
-        Ok(())
     }
 }
 
@@ -395,10 +394,10 @@ impl Pipeline {
                     chunk = mix.process_chunk(chunk);
                 }
                 PipelineStep::FilterStep(flt) => {
-                    flt.process_chunk(&mut chunk).unwrap();
+                    flt.process_chunk(&mut chunk);
                 }
                 PipelineStep::ParallelFiltersStep(flt) => {
-                    flt.process_chunk(&mut chunk).unwrap();
+                    flt.process_chunk(&mut chunk);
                 }
                 PipelineStep::ProcessorStep(comp) => {
                     comp.process_chunk(&mut chunk).unwrap();

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -400,7 +400,7 @@ impl Pipeline {
                     flt.process_chunk(&mut chunk);
                 }
                 PipelineStep::ProcessorStep(comp) => {
-                    comp.process_chunk(&mut chunk).unwrap();
+                    comp.process_chunk(&mut chunk);
                 }
             }
         }

--- a/src/processors/compressor.rs
+++ b/src/processors/compressor.rs
@@ -169,7 +169,7 @@ impl Processor for Compressor {
     }
 
     /// Apply a Compressor to an AudioChunk, modifying it in-place.
-    fn process_chunk(&mut self, input: &mut AudioChunk) -> Res<()> {
+    fn process_chunk(&mut self, input: &mut AudioChunk) {
         self.sum_monitor_channels(input);
         self.estimate_loudness();
         self.calculate_linear_gain();
@@ -177,7 +177,6 @@ impl Processor for Compressor {
             self.apply_gain(&mut input.waveforms[*ch]);
             self.apply_clipper(&mut input.waveforms[*ch]);
         }
-        Ok(())
     }
 
     fn update_parameters(&mut self, config: config::Processor) {

--- a/src/processors/lookahead_limiter.rs
+++ b/src/processors/lookahead_limiter.rs
@@ -146,7 +146,7 @@ impl Processor for LookaheadLimiter {
         // Unless disabled, delay the unprocessed channels too, to keep all channels time aligned.
         for (ch, delay) in self.delays.iter_mut().enumerate() {
             if !self.delay_processed_only || self.process_channels.contains(&ch) {
-                delay.process_waveform(&mut input.waveforms[ch])?;
+                delay.process_waveform(&mut input.waveforms[ch]);
             }
         }
         for ch in self.process_channels.iter() {
@@ -317,7 +317,7 @@ mod tests {
         let mut filter_waveform = waveform;
 
         processor.process_chunk(&mut processor_chunk).unwrap();
-        filter.process_waveform(&mut filter_waveform).unwrap();
+        filter.process_waveform(&mut filter_waveform);
 
         assert_close(&processor_chunk.waveforms[0], &filter_waveform, 1e-12);
     }

--- a/src/processors/lookahead_limiter.rs
+++ b/src/processors/lookahead_limiter.rs
@@ -140,7 +140,7 @@ impl Processor for LookaheadLimiter {
     }
 
     /// Apply a LookaheadLimiter to an AudioChunk, modifying it in-place.
-    fn process_chunk(&mut self, input: &mut AudioChunk) -> Res<()> {
+    fn process_chunk(&mut self, input: &mut AudioChunk) {
         self.detect_peaks(input);
         self.gain.process_detection(&self.scratch);
         // Unless disabled, delay the unprocessed channels too, to keep all channels time aligned.
@@ -152,7 +152,6 @@ impl Processor for LookaheadLimiter {
         for ch in self.process_channels.iter() {
             Self::apply_gain(self.gain.envelope(), &mut input.waveforms[*ch]);
         }
-        Ok(())
     }
 
     fn update_parameters(&mut self, config: config::Processor) {
@@ -316,7 +315,7 @@ mod tests {
         let mut processor_chunk = chunk(vec![waveform.clone()]);
         let mut filter_waveform = waveform;
 
-        processor.process_chunk(&mut processor_chunk).unwrap();
+        processor.process_chunk(&mut processor_chunk);
         filter.process_waveform(&mut filter_waveform);
 
         assert_close(&processor_chunk.waveforms[0], &filter_waveform, 1e-12);
@@ -328,7 +327,7 @@ mod tests {
         let mut limiter =
             LookaheadLimiter::from_config("test", params(None, None, 0.0, 0.0), 48000, 4);
         let mut input = chunk(vec![vec![0.25, 0.25, 0.25, 0.25], vec![0.5, 1.0, 2.0, 4.0]]);
-        limiter.process_chunk(&mut input).unwrap();
+        limiter.process_chunk(&mut input);
 
         // Channel 1 is limited to 1.0, channel 0 gets the same gain reduction.
         assert_close(&input.waveforms[1], &[0.5, 1.0, 1.0, 1.0], 1e-12);
@@ -341,7 +340,7 @@ mod tests {
         let mut limiter =
             LookaheadLimiter::from_config("test", params(Some(vec![0]), None, 0.0, 0.0), 48000, 2);
         let mut input = chunk(vec![vec![1.0, 2.0], vec![4.0, 1.0]]);
-        limiter.process_chunk(&mut input).unwrap();
+        limiter.process_chunk(&mut input);
 
         assert_close(&input.waveforms[0], &[1.0, 1.0], 1e-12);
         assert_close(&input.waveforms[1], &[4.0, 0.5], 1e-12);
@@ -357,7 +356,7 @@ mod tests {
             4,
         );
         let mut input = chunk(vec![vec![0.0, 0.0, 2.0, 0.0], vec![1.0, 2.0, 3.0, 4.0]]);
-        limiter.process_chunk(&mut input).unwrap();
+        limiter.process_chunk(&mut input);
 
         // Channel 1 is only delayed by the two samples of lookahead.
         assert_close(&input.waveforms[1], &[0.0, 0.0, 1.0, 2.0], 1e-12);
@@ -365,7 +364,7 @@ mod tests {
         assert_close(&input.waveforms[0], &[0.0, 0.0, 0.0, 0.0], 1e-12);
 
         let mut input = chunk(vec![vec![0.0, 0.0, 0.0, 0.0], vec![5.0, 6.0, 7.0, 8.0]]);
-        limiter.process_chunk(&mut input).unwrap();
+        limiter.process_chunk(&mut input);
         assert_close(&input.waveforms[1], &[3.0, 4.0, 5.0, 6.0], 1e-12);
         assert_close(&input.waveforms[0], &[1.0, 0.0, 0.0, 0.0], 1e-12);
     }
@@ -378,7 +377,7 @@ mod tests {
         let mut limiter = LookaheadLimiter::from_config("test", config, 48000, 4);
 
         let mut input = chunk(vec![vec![0.0, 0.0, 2.0, 0.0], vec![1.0, 2.0, 3.0, 4.0]]);
-        limiter.process_chunk(&mut input).unwrap();
+        limiter.process_chunk(&mut input);
 
         // Channel 1 passes through without any delay.
         assert_close(&input.waveforms[1], &[1.0, 2.0, 3.0, 4.0], 1e-12);

--- a/src/processors/mod.rs
+++ b/src/processors/mod.rs
@@ -14,7 +14,6 @@
 // Mozilla Public License along with this program. If not, see
 // <https://www.gnu.org/licenses/> and <https://www.mozilla.org/MPL/2.0/>.
 
-use crate::Res;
 use crate::audiochunk::AudioChunk;
 use crate::config;
 
@@ -30,7 +29,13 @@ pub mod race;
 /// Trait implemented by all multi-channel audio processors.
 pub trait Processor {
     /// Apply the processor to all channels of `chunk` in place.
-    fn process_chunk(&mut self, chunk: &mut AudioChunk) -> Res<()>;
+    ///
+    /// Infallible, as [`Filter::process_waveform`](crate::filters::Filter::process_waveform)
+    /// is and for the same reason. A processor that was accepted at
+    /// construction cannot start failing on a later chunk, and nothing could
+    /// be done about it part way through a chunk in the processing thread if
+    /// it did.
+    fn process_chunk(&mut self, chunk: &mut AudioChunk);
 
     /// Hot-reload processor parameters from a new configuration without rebuilding.
     fn update_parameters(&mut self, config: config::Processor);

--- a/src/processors/noisegate.rs
+++ b/src/processors/noisegate.rs
@@ -144,14 +144,13 @@ impl Processor for NoiseGate {
     }
 
     /// Apply a NoiseGate to an AudioChunk, modifying it in-place.
-    fn process_chunk(&mut self, input: &mut AudioChunk) -> Res<()> {
+    fn process_chunk(&mut self, input: &mut AudioChunk) {
         self.sum_monitor_channels(input);
         self.estimate_loudness();
         self.calculate_linear_gain();
         for ch in self.process_channels.iter() {
             self.apply_gain(&mut input.waveforms[*ch]);
         }
-        Ok(())
     }
 
     fn update_parameters(&mut self, config: config::Processor) {

--- a/src/processors/race.rs
+++ b/src/processors/race.rs
@@ -117,12 +117,12 @@ impl Processor for RACE {
     }
 
     /// Apply a RACE processor to an AudioChunk, modifying it in-place.
-    fn process_chunk(&mut self, input: &mut AudioChunk) -> Res<()> {
+    fn process_chunk(&mut self, input: &mut AudioChunk) {
         let (first, second) = input.waveforms.split_at_mut(self.channel_b);
         let channel_a = &mut first[self.channel_a];
         let channel_b = &mut second[0];
         if channel_a.is_empty() || channel_b.is_empty() {
-            return Ok(());
+            return;
         }
         for (value_a, value_b) in channel_a.iter_mut().zip(channel_b.iter_mut()) {
             // todo math
@@ -135,7 +135,6 @@ impl Processor for RACE {
             *value_a = added_a;
             *value_b = added_b;
         }
-        Ok(())
     }
 
     fn update_parameters(&mut self, config: config::Processor) {


### PR DESCRIPTION
Split out of #516, extended to processors. Neither `Filter::process_waveform` nor
`Processor::process_chunk` could ever fail: every implementation ended in `Ok(())`, and the
pipeline unwrapped the result on every chunk.

- `Filter::process_waveform` is infallible, and so are `FilterGroup::process_chunk` and
  `ParallelFilters::process_chunk`.
- `Processor::process_chunk` is infallible, so the pipeline no longer unwraps either kind of
  step.
- The `validate_*` functions keep their `Res`, a bad configuration being a real failure.