### PR TITLE
Make the loudness shelf frequencies and Q configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ New features:
 - RF64 support for reading and writing wav files larger than 4 GB (`use_rf64` for File playback).
 - New `LookaheadLimiter`, as a single-channel filter and as a multichannel processor with
   configurable monitor and process channels.
+- The corner frequency and Q of the two `Loudness` shelves can be set with the new `high_freq`,
+  `low_freq`, `high_q` and `low_q` parameters. They were previously fixed.
 
 Bugfixes:
 - ASIO: size the ring buffer and prefill from the driver's actual buffer size instead of just

--- a/README.md
+++ b/README.md
@@ -1767,6 +1767,8 @@ That makes the loudness filter attenuate the midband instead of boosting the ext
 The method is the same as the one implemented by the [RME ADI-2 DAC FS](https://www.rme-audio.de/adi-2-dac.html).
 The loudness correction is done as shelving filters that boost the high (above 3500 Hz) and low (below 70 Hz) frequencies.
 The amount of boost is adjustable with the `high_boost` and `low_boost` parameters. If left out, they default to 10 dB.
+The corner frequencies and the Q of the two shelves can be changed with `high_freq`, `low_freq`,
+`high_q` and `low_q`. The defaults give the same shelves as earlier versions, which had them fixed.
 - When the volume is above the `reference_level`, only gain is applied.
 - When the volume is below `reference_level` - 20, the full correction is applied.
 - In the range between `reference_level` and `reference_level`-20, the boost value is scaled linearly.
@@ -1788,12 +1790,20 @@ filters:
       reference_level: -25.0
       high_boost: 7.0 (*)
       low_boost: 7.0 (*)
+      high_freq: 3500.0 (*)
+      low_freq: 70.0 (*)
+      high_q: 0.707 (*)
+      low_q: 0.707 (*)
       attenuate_mid: false (*)
 ```
 Allowed ranges:
 - reference_level: -100 to +20
 - high_boost: 0 to 20
 - low_boost: 0 to 20
+- high_freq: above `low_freq`, and below half the samplerate
+- low_freq: above 0
+- high_q: 0.1 to 2.0
+- low_q: 0.1 to 2.0
 
 ### Delay
 The delay filter provides a delay in seconds, milliseconds, microseconds, millimetres or samples.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1191,6 +1191,14 @@ pub struct LoudnessParameters {
     #[serde(default)]
     pub low_boost: Option<f32>,
     #[serde(default)]
+    pub high_freq: Option<f64>,
+    #[serde(default)]
+    pub low_freq: Option<f64>,
+    #[serde(default)]
+    pub high_q: Option<f64>,
+    #[serde(default)]
+    pub low_q: Option<f64>,
+    #[serde(default)]
     pub fader: Option<LoudnessFader>,
     #[serde(default)]
     pub attenuate_mid: Option<bool>,
@@ -1203,6 +1211,24 @@ impl LoudnessParameters {
 
     pub fn low_boost(&self) -> f32 {
         self.low_boost.unwrap_or(10.0)
+    }
+
+    pub fn high_freq(&self) -> f64 {
+        self.high_freq.unwrap_or(3500.0)
+    }
+
+    pub fn low_freq(&self) -> f64 {
+        self.low_freq.unwrap_or(70.0)
+    }
+
+    /// The default Q gives the same shelves as the fixed slope of 12 dB/octave
+    /// that earlier versions used, for any boost value.
+    pub fn high_q(&self) -> f64 {
+        self.high_q.unwrap_or(std::f64::consts::FRAC_1_SQRT_2)
+    }
+
+    pub fn low_q(&self) -> f64 {
+        self.low_q.unwrap_or(std::f64::consts::FRAC_1_SQRT_2)
     }
 
     pub fn fader(&self) -> usize {

--- a/src/filters/loudness.rs
+++ b/src/filters/loudness.rs
@@ -32,6 +32,10 @@ pub struct Loudness {
     reference_level: f32,
     high_boost: f32,
     low_boost: f32,
+    high_freq: f64,
+    low_freq: f64,
+    high_q: f64,
+    low_q: f64,
     high_biquad: biquad::Biquad,
     low_biquad: biquad::Biquad,
     fader: usize,
@@ -39,9 +43,25 @@ pub struct Loudness {
     gain: Option<Gain>,
 }
 
+/// Below this the shelf spreads out so far that it no longer reaches its
+/// nominal boost within the audio band.
+const MIN_Q: f64 = 0.1;
+/// Above this the shelf overshoots badly at the corner frequency. At the
+/// largest allowed boost of 20 dB, a Q of 2.0 already peaks 5.6 dB above the
+/// shelf level.
+const MAX_Q: f64 = 2.0;
+
 fn rel_boost(level: f32, reference: f32) -> f32 {
     let rel_boost = (reference - level) / 20.0;
     rel_boost.clamp(0.0, 1.0)
+}
+
+fn highshelf_conf(freq: f64, q: f64, gain: f64) -> config::BiquadParameters {
+    config::BiquadParameters::Highshelf(config::ShelfSteepness::Q { freq, q, gain })
+}
+
+fn lowshelf_conf(freq: f64, q: f64, gain: f64) -> config::BiquadParameters {
+    config::BiquadParameters::Lowshelf(config::ShelfSteepness::Q { freq, q, gain })
 }
 
 impl Loudness {
@@ -58,16 +78,8 @@ impl Loudness {
         let active = relboost > 0.01;
         let high_boost = (relboost * conf.high_boost()) as f64;
         let low_boost = (relboost * conf.low_boost()) as f64;
-        let highshelf_conf = config::BiquadParameters::Highshelf(config::ShelfSteepness::Slope {
-            freq: 3500.0,
-            slope: 12.0,
-            gain: high_boost,
-        });
-        let lowshelf_conf = config::BiquadParameters::Lowshelf(config::ShelfSteepness::Slope {
-            freq: 70.0,
-            slope: 12.0,
-            gain: low_boost,
-        });
+        let highshelf_conf = highshelf_conf(conf.high_freq(), conf.high_q(), high_boost);
+        let lowshelf_conf = lowshelf_conf(conf.low_freq(), conf.low_q(), low_boost);
         let gain = if conf.attenuate_mid() {
             let max_gain = low_boost.max(high_boost);
             let gain_params = config::GainParameters {
@@ -92,6 +104,10 @@ impl Loudness {
             reference_level: conf.reference_level,
             high_boost: conf.high_boost(),
             low_boost: conf.low_boost(),
+            high_freq: conf.high_freq(),
+            low_freq: conf.low_freq(),
+            high_q: conf.high_q(),
+            low_q: conf.low_q(),
             high_biquad,
             low_biquad,
             processing_params,
@@ -125,17 +141,8 @@ impl Filter for Loudness {
                 "Updating loudness biquads, relative boost {}%",
                 100.0 * relboost
             );
-            let highshelf_conf =
-                config::BiquadParameters::Highshelf(config::ShelfSteepness::Slope {
-                    freq: 3500.0,
-                    slope: 12.0,
-                    gain: high_boost,
-                });
-            let lowshelf_conf = config::BiquadParameters::Lowshelf(config::ShelfSteepness::Slope {
-                freq: 70.0,
-                slope: 12.0,
-                gain: low_boost,
-            });
+            let highshelf_conf = highshelf_conf(self.high_freq, self.high_q, high_boost);
+            let lowshelf_conf = lowshelf_conf(self.low_freq, self.low_q, low_boost);
             self.high_biquad.update_parameters(config::Filter::Biquad {
                 parameters: highshelf_conf,
                 description: None,
@@ -179,17 +186,8 @@ impl Filter for Loudness {
             let high_boost = (relboost * conf.high_boost()) as f64;
             let low_boost = (relboost * conf.low_boost()) as f64;
             self.active = relboost > 0.001;
-            let highshelf_conf =
-                config::BiquadParameters::Highshelf(config::ShelfSteepness::Slope {
-                    freq: 3500.0,
-                    slope: 12.0,
-                    gain: high_boost,
-                });
-            let lowshelf_conf = config::BiquadParameters::Lowshelf(config::ShelfSteepness::Slope {
-                freq: 70.0,
-                slope: 12.0,
-                gain: low_boost,
-            });
+            let highshelf_conf = highshelf_conf(conf.high_freq(), conf.high_q(), high_boost);
+            let lowshelf_conf = lowshelf_conf(conf.low_freq(), conf.low_q(), low_boost);
             self.high_biquad.update_parameters(config::Filter::Biquad {
                 parameters: highshelf_conf,
                 description: None,
@@ -221,6 +219,10 @@ impl Filter for Loudness {
             self.reference_level = conf.reference_level;
             self.high_boost = conf.high_boost();
             self.low_boost = conf.low_boost();
+            self.high_freq = conf.high_freq();
+            self.low_freq = conf.low_freq();
+            self.high_q = conf.high_q();
+            self.low_q = conf.low_q();
         } else {
             // This should never happen unless there is a bug somewhere else
             panic!("Invalid config change!");
@@ -229,7 +231,7 @@ impl Filter for Loudness {
 }
 
 /// Validate a Loudness config.
-pub fn validate_config(conf: &config::LoudnessParameters) -> Res<()> {
+pub fn validate_config(samplerate: usize, conf: &config::LoudnessParameters) -> Res<()> {
     if conf.reference_level > 20.0 {
         return Err(config::ConfigError::new("Reference level must be less than 20").into());
     } else if conf.reference_level < -100.0 {
@@ -242,6 +244,120 @@ pub fn validate_config(conf: &config::LoudnessParameters) -> Res<()> {
         return Err(config::ConfigError::new("High boost cannot be larger than 20").into());
     } else if conf.low_boost() > 20.0 {
         return Err(config::ConfigError::new("Low boost cannot be larger than 20").into());
+    } else if conf.low_freq() <= 0.0 {
+        return Err(config::ConfigError::new("Low freq must be > 0").into());
+    } else if conf.high_freq() >= samplerate as f64 / 2.0 {
+        return Err(config::ConfigError::new("High freq must be < samplerate/2").into());
+    } else if conf.high_freq() <= conf.low_freq() {
+        return Err(config::ConfigError::new("High freq must be higher than low freq").into());
+    } else if !(MIN_Q..=MAX_Q).contains(&conf.high_q()) {
+        return Err(config::ConfigError::new(&format!(
+            "High Q must be between {MIN_Q:.1} and {MAX_Q:.1}"
+        ))
+        .into());
+    } else if !(MIN_Q..=MAX_Q).contains(&conf.low_q()) {
+        return Err(config::ConfigError::new(&format!(
+            "Low Q must be between {MIN_Q:.1} and {MAX_Q:.1}"
+        ))
+        .into());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{BiquadParameters, LoudnessParameters, ShelfSteepness};
+    use crate::filters::biquad::BiquadCoefficients;
+    use crate::filters::loudness::validate_config;
+
+    fn params() -> LoudnessParameters {
+        LoudnessParameters {
+            reference_level: -25.0,
+            high_boost: None,
+            low_boost: None,
+            high_freq: None,
+            low_freq: None,
+            high_q: None,
+            low_q: None,
+            fader: None,
+            attenuate_mid: None,
+        }
+    }
+
+    fn is_close(left: f64, right: f64) -> bool {
+        println!("{left} - {right}");
+        (left - right).abs() <= 1e-12 * right.abs().max(1.0)
+    }
+
+    /// The shelves used to be specified with a fixed slope of 12 dB/octave.
+    /// The default Q must give the same coefficients at any boost, so that
+    /// existing configs keep sounding the same. The two formulas reach the
+    /// same value by different arithmetic, so they can differ in the last bit.
+    #[test]
+    fn default_q_matches_the_old_slope() {
+        let conf = params();
+        for gain in [0.0, 1.0, 5.0, 10.0, 20.0] {
+            let from_q = BiquadCoefficients::from_config(
+                44100,
+                BiquadParameters::Highshelf(ShelfSteepness::Q {
+                    freq: conf.high_freq(),
+                    q: conf.high_q(),
+                    gain,
+                }),
+            );
+            let from_slope = BiquadCoefficients::from_config(
+                44100,
+                BiquadParameters::Highshelf(ShelfSteepness::Slope {
+                    freq: 3500.0,
+                    slope: 12.0,
+                    gain,
+                }),
+            );
+            assert!(is_close(from_q.a1, from_slope.a1));
+            assert!(is_close(from_q.a2, from_slope.a2));
+            assert!(is_close(from_q.b0, from_slope.b0));
+            assert!(is_close(from_q.b1, from_slope.b1));
+            assert!(is_close(from_q.b2, from_slope.b2));
+        }
+    }
+
+    #[test]
+    fn defaults_are_valid() {
+        assert!(validate_config(44100, &params()).is_ok());
+    }
+
+    #[test]
+    fn shelves_must_not_cross() {
+        let mut conf = params();
+        conf.low_freq = Some(4000.0);
+        assert!(validate_config(44100, &conf).is_err());
+        conf.high_freq = Some(8000.0);
+        assert!(validate_config(44100, &conf).is_ok());
+    }
+
+    #[test]
+    fn freq_must_be_below_nyquist() {
+        let mut conf = params();
+        conf.high_freq = Some(9000.0);
+        assert!(validate_config(44100, &conf).is_ok());
+        assert!(validate_config(16000, &conf).is_err());
+    }
+
+    #[test]
+    fn freq_must_be_positive() {
+        let mut conf = params();
+        conf.low_freq = Some(0.0);
+        assert!(validate_config(44100, &conf).is_err());
+    }
+
+    #[test]
+    fn q_must_be_within_limits() {
+        let mut conf = params();
+        conf.high_q = Some(0.0);
+        assert!(validate_config(44100, &conf).is_err());
+        conf.high_q = Some(1e10);
+        assert!(validate_config(44100, &conf).is_err());
+        conf.high_q = Some(1.5);
+        assert!(validate_config(44100, &conf).is_ok());
+    }
 }

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -257,7 +257,7 @@ pub fn validate_filter(fs: usize, filter_config: &config::Filter) -> Res<()> {
         config::Filter::Volume { parameters, .. } => {
             basicfilters::validate_volume_config(parameters)
         }
-        config::Filter::Loudness { parameters, .. } => loudness::validate_config(parameters),
+        config::Filter::Loudness { parameters, .. } => loudness::validate_config(fs, parameters),
         config::Filter::BiquadCombo { parameters, .. } => {
             biquadcombo::validate_config(fs, parameters)
         }


### PR DESCRIPTION
Adds `high_freq`, `low_freq`, `high_q` and `low_q` to the Loudness filter. See #514.

- The shelves are specified by Q instead of the previous fixed slope of 12 dB/octave. The default Q
  gives the same shelves as before at any boost, so existing configs are unchanged.
- Frequencies must be positive, below half the samplerate, and the high one above the low one.
  Q is limited to 0.1 to 2.0.
- `validate_filter` now passes the samplerate through to the loudness validation, which it dropped
  before.
