### PR TITLE
PipeWire: fix autoconnect_to for sinks, and don't fall back to the default device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,15 @@ New features:
   configurable monitor and process channels.
 - The corner frequency and Q of the two `Loudness` shelves can be set with the new `high_freq`,
   `low_freq`, `high_q` and `low_q` parameters. They were previously fixed.
+- PipeWire capture has a new `loopback` parameter for capturing from the output of a sink instead
+  of from a source, matching the `loopback` parameter of the WASAPI backend. This is also what
+  makes `autoconnect_to` accept the name of a sink, since WirePlumber only considers sources when
+  it resolves a capture target by name.
 
 Bugfixes:
-- PipeWire: `autoconnect_to` now works when the target is given as the name of a sink to capture
-  the monitor of. WirePlumber only considers sources when it resolves a `target.object` name for
-  a capture stream, so CamillaDSP now looks the target up in the graph and sets
-  `stream.capture.sink` when it is a sink.
 - PipeWire: an `autoconnect_to` target that cannot be found now leaves the node unconnected,
   instead of falling back to the default device and capturing from or playing to the wrong node.
-  The node is connected automatically if the target appears later, except for a capture device
-  pointed at a sink, which needs the sink to exist when CamillaDSP starts.
+  The node is connected automatically if the target appears later.
 - ASIO: size the ring buffer and prefill from the driver's actual buffer size instead of just
   `chunksize`, fixing continuous underruns when the driver requests a larger buffer than `chunksize`.
 - A convolution filter with an empty inline `values` list is now rejected by the config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ New features:
   `low_freq`, `high_q` and `low_q` parameters. They were previously fixed.
 
 Bugfixes:
+- PipeWire: `autoconnect_to` now works when the target is given as the name of a sink to capture
+  the monitor of. WirePlumber only considers sources when it resolves a `target.object` name for
+  a capture stream, so CamillaDSP now looks the target up in the graph and sets
+  `stream.capture.sink` when it is a sink.
+- PipeWire: an `autoconnect_to` target that cannot be found now leaves the node unconnected,
+  instead of falling back to the default device and capturing from or playing to the wrong node.
+  The node is connected automatically if the target appears later, except for a capture device
+  pointed at a sink, which needs the sink to exist when CamillaDSP starts.
 - ASIO: size the ring buffer and prefill from the driver's actual buffer size instead of just
   `chunksize`, fixing continuous underruns when the driver requests a larger buffer than `chunksize`.
 - A convolution filter with an empty inline `values` list is now rejected by the config

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,10 @@ path = "src/bin.rs"
 alsa = "0.9.0"
 alsa-sys = "0.3.1"
 nix = { version = "0.30", features = ["poll", "signal"] }
-pipewire = { version = "0.9", optional = true }
+# The v0_3_44 feature unlocks the key constants added up to PipeWire 0.3.44, among them
+# PW_KEY_OBJECT_SERIAL and PW_KEY_TARGET_OBJECT. It sets the minimum PipeWire version to build
+# against, which is well below what any distro that ships PipeWire has.
+pipewire = { version = "0.9", optional = true, features = ["v0_3_44"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 coreaudio-rs = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,9 @@ path = "src/bin.rs"
 alsa = "0.9.0"
 alsa-sys = "0.3.1"
 nix = { version = "0.30", features = ["poll", "signal"] }
-# The v0_3_44 feature unlocks the key constants added up to PipeWire 0.3.44, among them
-# PW_KEY_OBJECT_SERIAL and PW_KEY_TARGET_OBJECT. It sets the minimum PipeWire version to build
-# against, which is well below what any distro that ships PipeWire has.
+# The v0_3_44 feature unlocks the key constants added up to PipeWire 0.3.44, of which we need
+# PW_KEY_TARGET_OBJECT. It sets the minimum PipeWire version to build against, which is well
+# below what any distro that ships PipeWire has.
 pipewire = { version = "0.9", optional = true, features = ["v0_3_44"] }
 
 [target.'cfg(target_os="macos")'.dependencies]

--- a/backend_pipewire.md
+++ b/backend_pipewire.md
@@ -73,6 +73,18 @@ If given, CamillaDSP will ask PipeWire to try connect the CamillaDSP capture or 
 This enables basic routing to be set up without any additional tools,
 and is useful when both the source and sink nodes already exist.
 
+A capture device can also be pointed at a sink, in which case it captures from the monitor of that sink.
+CamillaDSP looks the target up in the PipeWire graph at startup to determine whether it is a sink or a source,
+so no extra configuration is needed for this.
+
+If the target node does not exist, the CamillaDSP node is left unconnected
+instead of being connected to the default device,
+and gets connected automatically if the target appears later.
+
+Note that a capture device can only connect to a target that appears later if that target is a source.
+Whether the target is a sink or a source is determined when CamillaDSP starts,
+so a sink must already exist at that point to be captured from.
+
 For anything more advanced, it is recommended to leave this parameter at the default `null`,
 and instead set up routing with WirePlumber rules.
 

--- a/backend_pipewire.md
+++ b/backend_pipewire.md
@@ -4,6 +4,26 @@ The PipeWire backend creates filter nodes in the PipeWire graph.
 Unlike other backends that connect directly to devices,
 PipeWire nodes are meant to be connected via WirePlumber rules or tools like Helvum.
 
+## Sources and sinks
+
+PipeWire describes every node by the direction the audio flows,
+not by whether the node is a piece of hardware or an application.
+
+- A *source* produces audio and feeds it into the graph.
+  Microphones and line inputs are sources, and so is a music player sending out its audio.
+- A *sink* consumes audio from the graph.
+  Speakers and headphones are sinks, and so is an application that is recording.
+
+The CamillaDSP capture device takes audio from a source,
+and the CamillaDSP playback device sends audio to a sink.
+
+Every sink additionally has a set of *monitor* ports that carry whatever that sink is receiving.
+Capturing from those is how to process audio that something else is playing,
+see [Loopback capture](#loopback-capture).
+
+`wpctl status` lists the sources and sinks on the system,
+with applications shown under "Streams".
+
 ## Build requirements
 
 The PipeWire backend requires the PipeWire development libraries:
@@ -30,6 +50,7 @@ capture:
   node_description: CamillaDSP Capture (*)
   node_group_name: camilladsp (*)
   autoconnect_to: null (*)
+  loopback: false (*)
 ```
 
 ### Playback device
@@ -55,6 +76,7 @@ These are used if the parameters are set to `null` or left out from the configur
 | `node_description` | PipeWire node description, shown in tools such as Helvum (optional, defaults to `CamillaDSP Capture` or `CamillaDSP Playback`) |
 | `node_group_name` | PipeWire node group name (optional, defaults to `camilladsp`) |
 | `autoconnect_to`| PipeWire name or serial (given as a string with quotes, `"123"`) of a node to autoconnect to (optional) |
+| `loopback` | Capture from a sink instead of from a source, capture only (optional, defaults to `false`) |
 
 #### Node groups
 
@@ -73,17 +95,13 @@ If given, CamillaDSP will ask PipeWire to try connect the CamillaDSP capture or 
 This enables basic routing to be set up without any additional tools,
 and is useful when both the source and sink nodes already exist.
 
-A capture device can also be pointed at a sink, in which case it captures from the monitor of that sink.
-CamillaDSP looks the target up in the PipeWire graph at startup to determine whether it is a sink or a source,
-so no extra configuration is needed for this.
+A capture device connects to a source, and a playback device to a sink.
+To capture the output of a sink instead, see [Loopback capture](#loopback-capture).
 
 If the target node does not exist, the CamillaDSP node is left unconnected
 instead of being connected to the default device,
 and gets connected automatically if the target appears later.
-
-Note that a capture device can only connect to a target that appears later if that target is a source.
-Whether the target is a sink or a source is determined when CamillaDSP starts,
-so a sink must already exist at that point to be captured from.
+This means that a wrong or misspelled name gives silence rather than audio from an unexpected device.
 
 For anything more advanced, it is recommended to leave this parameter at the default `null`,
 and instead set up routing with WirePlumber rules.
@@ -96,6 +114,33 @@ pw-cli ls Node
 Example of node names for audio playback devices:
 - Intel HD Audio headphone output: `alsa_output.pci-0000_00_1f.3-platform-skl_hda_dsp_generic.HiFi__Headphones__sink`
 - MOTU M4: `alsa_output.hw_M4_0`
+
+
+#### Loopback capture
+
+A capture device normally connects to a source.
+Setting `loopback` to `true` makes it capture from the output of a sink instead,
+via the monitor ports that PipeWire provides for every sink.
+This is how to process the audio that some other application is playing,
+and corresponds to loopback capture in the WASAPI backend.
+
+Combine it with `autoconnect_to` to pick which sink to capture from:
+```yaml
+capture:
+  type: PipeWire
+  channels: 2
+  autoconnect_to: alsa_output.pci-0000_00_1f.3.analog-stereo
+  loopback: true
+```
+
+The flag is needed even when the sink is named explicitly.
+WirePlumber only considers sources when it looks up an `autoconnect_to` name for a capture device,
+so without `loopback: true` a sink name matches nothing and the node stays unconnected.
+This does not apply when the sink is given as a serial number,
+but a name is usually the better choice since serial numbers change when a node is recreated.
+
+Sinks are the nodes with a `media.class` of `Audio/Sink`.
+`wpctl status` lists them under "Sinks".
 
 
 ## WirePlumber routing

--- a/src/audiodevice.rs
+++ b/src/audiodevice.rs
@@ -293,12 +293,14 @@ pub fn new_capture_device(conf: config::Devices) -> Box<dyn CaptureDevice> {
             ref node_description,
             ref node_group_name,
             ref autoconnect_to,
+            loopback,
             ..
         } => Box::new(pipewiredevice::PipeWireCaptureDevice {
             node_name: node_name.clone(),
             node_description: node_description.clone(),
             node_group_name: node_group_name.clone(),
             autoconnect_to: autoconnect_to.clone(),
+            loopback: loopback.unwrap_or_default(),
             samplerate: conf.samplerate,
             resampler_config: conf.resampler,
             capture_samplerate,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -348,6 +348,8 @@ pub enum CaptureDevice {
         labels: Option<Vec<Option<String>>>,
         #[serde(default)]
         autoconnect_to: Option<String>,
+        #[serde(default)]
+        loopback: Option<bool>,
     },
     RawFile(CaptureDeviceRawFile),
     WavFile(CaptureDeviceWavFile),

--- a/src/pipewire_backend/device.rs
+++ b/src/pipewire_backend/device.rs
@@ -38,7 +38,7 @@ use crate::utils::rate_controller::PIRateController;
 use crate::utils::resampling::{ChunkResampler, new_resampler, resampler_is_async};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use ringbuf::{HeapRb, traits::*};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
@@ -78,6 +78,134 @@ impl MainLoopQuitter {
     fn quit(&self) {
         unsafe {
             pw::sys::pw_main_loop_quit(self.raw as *mut pw::sys::pw_main_loop);
+        }
+    }
+}
+
+/// How long to wait for the PipeWire server to describe the graph.
+const GRAPH_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Look up the `media.class` of the node that `autoconnect_to` points at.
+///
+/// The value is matched the same way WirePlumber matches `target.object`:
+/// a value that parses as a number is an `object.serial`, anything else is a `node.name`.
+/// Returns `None` if no node in the graph matches.
+fn target_media_class(
+    core: &pw::core::Core,
+    mainloop: &pw::main_loop::MainLoop,
+    target: &str,
+) -> Option<String> {
+    let registry = match core.get_registry() {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("Failed to get the PipeWire registry: {:?}", e);
+            return None;
+        }
+    };
+
+    // The sync answer arrives after the server has sent every global it knows about,
+    // so a single roundtrip is enough to see the whole graph.
+    let pending = match core.sync(0) {
+        Ok(seq) => seq,
+        Err(e) => {
+            warn!("Failed to sync with the PipeWire core: {:?}", e);
+            return None;
+        }
+    };
+
+    let media_class = Rc::new(RefCell::new(None));
+    let media_class_cb = media_class.clone();
+    let wanted = target.to_string();
+    let _registry_listener = registry
+        .add_listener_local()
+        .global(move |global| {
+            if global.type_ != pw::types::ObjectType::Node {
+                return;
+            }
+            let Some(props) = global.props else {
+                return;
+            };
+            let matches = match wanted.parse::<u64>() {
+                Ok(serial) => {
+                    props
+                        .get(*pw::keys::OBJECT_SERIAL)
+                        .and_then(|s| s.parse::<u64>().ok())
+                        == Some(serial)
+                }
+                Err(_) => props.get(*pw::keys::NODE_NAME) == Some(wanted.as_str()),
+            };
+            if matches {
+                *media_class_cb.borrow_mut() = Some(
+                    props
+                        .get(*pw::keys::MEDIA_CLASS)
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+            }
+        })
+        .register();
+
+    let done = Rc::new(Cell::new(false));
+    let done_cb = done.clone();
+    let _core_listener = core
+        .add_listener_local()
+        .done(move |id, seq| {
+            if id == pw::core::PW_ID_CORE && seq == pending {
+                done_cb.set(true);
+            }
+        })
+        .register();
+
+    // Iterate the loop directly instead of running it, to keep the roundtrip time bounded
+    // in case the server never answers.
+    let deadline = std::time::Instant::now() + GRAPH_QUERY_TIMEOUT;
+    while !done.get() {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            warn!("Timed out while querying the PipeWire graph");
+            return None;
+        }
+        mainloop.loop_().iterate(remaining);
+    }
+
+    media_class.take()
+}
+
+/// Add the properties that make PipeWire connect a stream to the node given as `autoconnect_to`.
+///
+/// `capture` selects the capture side, where the target may be the monitor of a sink.
+/// WirePlumber only considers sources when it resolves a `target.object` name for a capture
+/// stream, so a sink target additionally needs `stream.capture.sink` to be found at all.
+///
+/// The direction is decided here, from the graph as it looks at startup. A target that appears
+/// later is therefore only picked up by a capture device if it is a source.
+fn insert_autoconnect_props(
+    props: &mut pw::properties::PropertiesBox,
+    core: &pw::core::Core,
+    mainloop: &pw::main_loop::MainLoop,
+    target: &str,
+    capture: bool,
+) {
+    props.insert(*pw::keys::TARGET_OBJECT, target);
+    // Leave the node unconnected when the target cannot be found, instead of falling back to
+    // the default device, and connect it later if the target shows up.
+    // Neither key exists in pw::keys.
+    props.insert("node.dont-fallback", "true");
+    props.insert("node.linger", "true");
+
+    match target_media_class(core, mainloop, target) {
+        Some(class) => {
+            debug!("PipeWire autoconnect target '{}' is a {}", target, class);
+            if capture && class.ends_with("/Sink") {
+                debug!("Capturing from the monitor of sink '{}'", target);
+                props.insert(*pw::keys::STREAM_CAPTURE_SINK, "true");
+            }
+        }
+        None => {
+            warn!(
+                "No PipeWire node matches autoconnect_to '{}', the node will stay unconnected until it appears",
+                target
+            );
         }
     }
 }
@@ -330,8 +458,7 @@ impl PlaybackDevice for PipeWirePlaybackDevice {
                     *pw::keys::NODE_GROUP => node_group_name,
                 };
                 if let Some(ref target) = autoconnect_to {
-                    // the key PW_KEY_TARGET_OBJECT doesn not (yet?) exist in pw::keys
-                    props.insert("target.object", target.as_str());
+                    insert_autoconnect_props(&mut props, &core, &mainloop, target, false);
                 }
 
                 let stream = match pw::stream::StreamBox::new(&core, "CamillaDSP-Playback", props) {
@@ -810,8 +937,7 @@ impl CaptureDevice for PipeWireCaptureDevice {
                     *pw::keys::NODE_GROUP => node_group_name,
                 };
                 if let Some(ref target) = autoconnect_to {
-                    // the key PW_KEY_TARGET_OBJECT doesn not (yet?) exist in pw::keys
-                    props.insert("target.object", target.as_str());
+                    insert_autoconnect_props(&mut props, &core, &mainloop, target, true);
                 }
 
                 let stream = match pw::stream::StreamBox::new(&core, "CamillaDSP-Capture", props) {

--- a/src/pipewire_backend/device.rs
+++ b/src/pipewire_backend/device.rs
@@ -38,7 +38,7 @@ use crate::utils::rate_controller::PIRateController;
 use crate::utils::resampling::{ChunkResampler, new_resampler, resampler_is_async};
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use ringbuf::{HeapRb, traits::*};
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
@@ -82,132 +82,14 @@ impl MainLoopQuitter {
     }
 }
 
-/// How long to wait for the PipeWire server to describe the graph.
-const GRAPH_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-
-/// Look up the `media.class` of the node that `autoconnect_to` points at.
-///
-/// The value is matched the same way WirePlumber matches `target.object`:
-/// a value that parses as a number is an `object.serial`, anything else is a `node.name`.
-/// Returns `None` if no node in the graph matches.
-fn target_media_class(
-    core: &pw::core::Core,
-    mainloop: &pw::main_loop::MainLoop,
-    target: &str,
-) -> Option<String> {
-    let registry = match core.get_registry() {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("Failed to get the PipeWire registry: {:?}", e);
-            return None;
-        }
-    };
-
-    // The sync answer arrives after the server has sent every global it knows about,
-    // so a single roundtrip is enough to see the whole graph.
-    let pending = match core.sync(0) {
-        Ok(seq) => seq,
-        Err(e) => {
-            warn!("Failed to sync with the PipeWire core: {:?}", e);
-            return None;
-        }
-    };
-
-    let media_class = Rc::new(RefCell::new(None));
-    let media_class_cb = media_class.clone();
-    let wanted = target.to_string();
-    let _registry_listener = registry
-        .add_listener_local()
-        .global(move |global| {
-            if global.type_ != pw::types::ObjectType::Node {
-                return;
-            }
-            let Some(props) = global.props else {
-                return;
-            };
-            let matches = match wanted.parse::<u64>() {
-                Ok(serial) => {
-                    props
-                        .get(*pw::keys::OBJECT_SERIAL)
-                        .and_then(|s| s.parse::<u64>().ok())
-                        == Some(serial)
-                }
-                Err(_) => props.get(*pw::keys::NODE_NAME) == Some(wanted.as_str()),
-            };
-            if matches {
-                *media_class_cb.borrow_mut() = Some(
-                    props
-                        .get(*pw::keys::MEDIA_CLASS)
-                        .unwrap_or_default()
-                        .to_string(),
-                );
-            }
-        })
-        .register();
-
-    let done = Rc::new(Cell::new(false));
-    let done_cb = done.clone();
-    let _core_listener = core
-        .add_listener_local()
-        .done(move |id, seq| {
-            if id == pw::core::PW_ID_CORE && seq == pending {
-                done_cb.set(true);
-            }
-        })
-        .register();
-
-    // Iterate the loop directly instead of running it, to keep the roundtrip time bounded
-    // in case the server never answers.
-    let deadline = std::time::Instant::now() + GRAPH_QUERY_TIMEOUT;
-    while !done.get() {
-        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        if remaining.is_zero() {
-            warn!("Timed out while querying the PipeWire graph");
-            return None;
-        }
-        mainloop.loop_().iterate(remaining);
-    }
-
-    media_class.take()
-}
-
 /// Add the properties that make PipeWire connect a stream to the node given as `autoconnect_to`.
-///
-/// `capture` selects the capture side, where the target may be the monitor of a sink.
-/// WirePlumber only considers sources when it resolves a `target.object` name for a capture
-/// stream, so a sink target additionally needs `stream.capture.sink` to be found at all.
-///
-/// The direction is decided here, from the graph as it looks at startup. A target that appears
-/// later is therefore only picked up by a capture device if it is a source.
-fn insert_autoconnect_props(
-    props: &mut pw::properties::PropertiesBox,
-    core: &pw::core::Core,
-    mainloop: &pw::main_loop::MainLoop,
-    target: &str,
-    capture: bool,
-) {
+fn insert_autoconnect_props(props: &mut pw::properties::PropertiesBox, target: &str) {
     props.insert(*pw::keys::TARGET_OBJECT, target);
     // Leave the node unconnected when the target cannot be found, instead of falling back to
     // the default device, and connect it later if the target shows up.
     // Neither key exists in pw::keys.
     props.insert("node.dont-fallback", "true");
     props.insert("node.linger", "true");
-
-    match target_media_class(core, mainloop, target) {
-        Some(class) => {
-            debug!("PipeWire autoconnect target '{}' is a {}", target, class);
-            if capture && class.ends_with("/Sink") {
-                debug!("Capturing from the monitor of sink '{}'", target);
-                props.insert(*pw::keys::STREAM_CAPTURE_SINK, "true");
-            }
-        }
-        None => {
-            warn!(
-                "No PipeWire node matches autoconnect_to '{}', the node will stay unconnected until it appears",
-                target
-            );
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -255,6 +137,7 @@ pub struct PipeWireCaptureDevice {
     pub node_description: Option<String>,
     pub node_group_name: Option<String>,
     pub autoconnect_to: Option<String>,
+    pub loopback: bool,
     pub samplerate: usize,
     pub resampler_config: Option<config::Resampler>,
     pub capture_samplerate: usize,
@@ -458,7 +341,7 @@ impl PlaybackDevice for PipeWirePlaybackDevice {
                     *pw::keys::NODE_GROUP => node_group_name,
                 };
                 if let Some(ref target) = autoconnect_to {
-                    insert_autoconnect_props(&mut props, &core, &mainloop, target, false);
+                    insert_autoconnect_props(&mut props, target);
                 }
 
                 let stream = match pw::stream::StreamBox::new(&core, "CamillaDSP-Playback", props) {
@@ -866,6 +749,7 @@ impl CaptureDevice for PipeWireCaptureDevice {
             .clone()
             .unwrap_or("camilladsp".to_string());
         let autoconnect_to = self.autoconnect_to.clone();
+        let loopback = self.loopback;
         let samplerate = self.samplerate;
         let capture_samplerate = self.capture_samplerate;
         let chunksize = self.chunksize;
@@ -936,8 +820,14 @@ impl CaptureDevice for PipeWireCaptureDevice {
                     *pw::keys::NODE_LATENCY => latency_str,
                     *pw::keys::NODE_GROUP => node_group_name,
                 };
+                if loopback {
+                    // Capture from the monitor of a sink instead of from a source.
+                    // WirePlumber only considers sources when it resolves a target by name,
+                    // so this is also what makes a sink name match at all.
+                    props.insert(*pw::keys::STREAM_CAPTURE_SINK, "true");
+                }
                 if let Some(ref target) = autoconnect_to {
-                    insert_autoconnect_props(&mut props, &core, &mainloop, target, true);
+                    insert_autoconnect_props(&mut props, target);
                 }
 
                 let stream = match pw::stream::StreamBox::new(&core, "CamillaDSP-Capture", props) {


### PR DESCRIPTION
Fixes #520.

Two changes to `autoconnect_to` in the PipeWire backend.

**A new `loopback` option for capture.** Setting it makes the capture device take audio from the monitor ports of a sink instead of from a source, the same idea as `loopback` in the WASAPI backend, and it uses the same parameter name and default. This is also what makes `autoconnect_to` accept the name of a sink at all: WirePlumber only considers sources when it resolves a capture target by name, which is why naming a sink silently connected to the wrong node.

**`node.dont-fallback` and `node.linger` whenever `autoconnect_to` is given.** A target that cannot be found now leaves the node unconnected instead of grabbing the default device, and gets connected automatically if the target appears later. A misspelled name gives silence rather than audio from an unexpected device.

Also enables the pipewire crate's `v0_3_44` feature for `PW_KEY_TARGET_OBJECT`, which sets the minimum PipeWire version to build against. `backend_pipewire.md` gains a section explaining sources and sinks, since the terminology is not obvious, and one on loopback capture.

Verified against a live PipeWire session:

| Scenario | Result |
|---|---|
| sink by name + `loopback: true` | captures the monitor ports |
| sink by name, `loopback` omitted | stays unconnected, no fallback |
| sink appears 2 s after startup, `loopback: true` | connects when it appears |
| source by name, `loopback` omitted | unchanged |
| playback to a sink by name | unchanged |