### PR TITLE
Run biquads several at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ Bugfixes:
   would scale a small `chunksize` down to zero now keeps one frame instead.
 
 Changes:
+- Much faster biquad filtering. A biquad waits on its own feedback path, leaving the processor
+  idle, so several independent ones are now run at once: several channels side by side, and
+  several positions of a channel's cascade skewed against each other. A run of biquads in a
+  filter step is compiled into one cascade per channel, so the same trick reaches across the
+  filters inside the step. Measured per chunk at a chunksize of 1024: a pipeline of 16 biquads
+  on four channels followed by 16 more on two went from 249 to 39 us, sixteen channels of three
+  biquads went from 128 to 28 us, and a mixed pipeline of biquads and FIR filters went from 707
+  to 481 us. Results are bit-identical to running the filters one at a time.
+- Biquad filters are no longer sent to the thread pool when `multithreaded` is enabled, since
+  running them several at a time already keeps the processor busy. The same biquad pipeline
+  measured 39 us on the main thread against 222 us on the thread pool.
 - Biquads now use fused multiply-add on hardware that has it, about 18% faster on aarch64. The
   fused form rounds once instead of twice, so results can differ from 4.1.3 in the last few bits.
 - The `DiffEq` filter is now a direct form 2 transposed structure, the same form the biquads use,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,10 @@ name = "pipeline"
 harness = false
 
 [[bench]]
+name = "biquad_canon"
+harness = false
+
+[[bench]]
 name = "fftconv_kernels"
 harness = false
 required-features = ["bench"]

--- a/README.md
+++ b/README.md
@@ -1132,6 +1132,13 @@ A parameter marked (*) in any example is optional. If they are left out from the
   cannot be parallelized and are processed in the main thread.
   Therefore, only the filters between mixers and/or processors can be parallelized.
 
+  Biquad filters are also not sent to the thread pool.
+  They are run several channels and several cascade positions at a time on the main thread,
+  which already keeps the processor busy, so a thread pool on top only adds the cost of
+  handing the work over.
+  A pipeline of biquads measured about 5.7 times faster this way than the same pipeline
+  on the thread pool.
+
   Multithreaded processing is beneficial for configurations that require significant processing power,
   such as using very long FIR filters, high sample rates, or a large number of channels.
   It should only be enabled if necessary, as it typically should remain disabled.

--- a/benches/biquad_canon.rs
+++ b/benches/biquad_canon.rs
@@ -127,9 +127,10 @@ fn bench_split(
 /// stage-channels however it is divided, so these numbers are directly
 /// comparable and the shape of the curve is the answer.
 ///
-/// The shape is deliberately not tied to `MAX_DEPTH`. Eight stages is deeper
-/// than any single pass, so every split here also exercises the division into
-/// passes, and the shape stays comparable across runs if the constant moves.
+/// The shape is deliberately not tied to `MAX_DEPTH`. Every split of fewer than
+/// eight stages exercises the division into passes, while `S8` is the one column
+/// that fits in a single pass as long as `MAX_DEPTH` stays at eight. The numbers
+/// stay comparable across runs either way.
 const GRID_CHANNELS: usize = 4;
 const GRID_DEPTH: usize = 8;
 

--- a/benches/biquad_canon.rs
+++ b/benches/biquad_canon.rs
@@ -1,0 +1,240 @@
+//! Sizing for the biquad canon.
+//!
+//! The kernel keeps `C * S` independent recurrences in flight, `C` channels
+//! side by side and `S` cascade stages skewed in time. Both axes feed the same
+//! FP pipeline, so the question this bench answers is how wide it is worth
+//! going and how the width is best divided between the two. Everything else in
+//! the design reads its constants from what this measures.
+//!
+//! Two groups. `kernel_grid` holds the work fixed at four channels of eight
+//! biquads and sweeps every split of it, so the numbers compare scheduling and
+//! nothing else. `kernel_shapes` walks shapes real configurations have, from a
+//! deep stereo cascade to a wide multi-way system with a couple of biquads per
+//! channel, and puts the combined split next to each axis on its own.
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::time::Duration;
+
+use camillalib::CamillaFloat;
+use camillalib::config::{BiquadParameters, NotchWidth};
+use camillalib::filters::Filter;
+use camillalib::filters::biquad::{
+    Biquad, BiquadCoefficients, MAX_CHANNELS, MAX_DEPTH, choose_split, process_cascades_with_split,
+};
+
+const CHUNK: usize = 1024;
+const SAMPLERATE: usize = 44100;
+
+/// Allpass sections, so the magnitude response is flat and the signal neither
+/// grows nor decays as the bench feeds its own output back in for thousands of
+/// iterations. A peaking cascade would run away to infinity and start timing
+/// the hardware's handling of infinities instead of biquads.
+fn cascade(stages: usize, seed: usize) -> Vec<Biquad> {
+    (0..stages)
+        .map(|k| {
+            let conf = BiquadParameters::Allpass(NotchWidth::Q {
+                freq: 110.0 + 173.0 * ((k + 3 * seed) as f64),
+                q: 0.7 + 0.05 * (k as f64),
+            });
+            Biquad::new(
+                "b",
+                SAMPLERATE,
+                BiquadCoefficients::from_config(SAMPLERATE, conf),
+            )
+        })
+        .collect()
+}
+
+fn signal(seed: usize, frames: usize) -> Vec<CamillaFloat> {
+    (0..frames)
+        .map(|i| (0.017 * ((7 * i + 13 * seed) as CamillaFloat)).sin() * 0.5)
+        .collect()
+}
+
+/// What is being filtered: so many channels, so many biquads each, so many
+/// frames per chunk.
+#[derive(Clone, Copy)]
+struct Shape {
+    channels: usize,
+    depth: usize,
+    frames: usize,
+}
+
+impl Shape {
+    fn new(channels: usize, depth: usize, frames: usize) -> Self {
+        Shape {
+            channels,
+            depth,
+            frames,
+        }
+    }
+
+    fn build(&self) -> (Vec<Vec<Biquad>>, Vec<Vec<CamillaFloat>>) {
+        (
+            (0..self.channels).map(|c| cascade(self.depth, c)).collect(),
+            (0..self.channels).map(|c| signal(c, self.frames)).collect(),
+        )
+    }
+
+    fn id(&self) -> String {
+        format!("{}x{}", self.channels, self.depth)
+    }
+}
+
+/// One stage at a time over the whole waveform, which is what CamillaDSP does
+/// today and what every number here is measured against.
+fn bench_sequential(c: &mut Criterion, group_name: &str, shape: Shape) {
+    let (mut cascades, mut waves) = shape.build();
+    let mut group = c.benchmark_group(group_name);
+    group.bench_function(BenchmarkId::new(shape.id(), "sequential"), |b| {
+        b.iter(|| {
+            for (cascade, wave) in cascades.iter_mut().zip(waves.iter_mut()) {
+                for stage in cascade.iter_mut() {
+                    stage.process_waveform(wave);
+                }
+            }
+        })
+    });
+    group.finish();
+}
+
+/// The cascades, waveforms and index lists are all built outside `b.iter()` on
+/// purpose. Building them inside charges the kernel for allocation that
+/// production never does, which measured 2 to 5% and moved where the axes
+/// appeared to cross over.
+fn bench_split(
+    c: &mut Criterion,
+    group_name: &str,
+    shape: Shape,
+    label: String,
+    group_width: usize,
+    stages: usize,
+) {
+    let (mut cascades, mut waves) = shape.build();
+    // Cascade i filters waveform i and every channel is live, which is what a
+    // compiled step looks like when no capture channel is unused.
+    let ids: Vec<usize> = (0..shape.channels).collect();
+    let mut group = c.benchmark_group(group_name);
+    group.bench_function(BenchmarkId::new(shape.id(), label), |b| {
+        b.iter(|| {
+            process_cascades_with_split(&mut cascades, &mut waves, &ids, &ids, group_width, stages)
+        })
+    });
+    group.finish();
+}
+
+/// Fixed work, every split of it. Four channels of eight biquads is 32
+/// stage-channels however it is divided, so these numbers are directly
+/// comparable and the shape of the curve is the answer.
+///
+/// The shape is deliberately not tied to `MAX_DEPTH`. Eight stages is deeper
+/// than any single pass, so every split here also exercises the division into
+/// passes, and the shape stays comparable across runs if the constant moves.
+const GRID_CHANNELS: usize = 4;
+const GRID_DEPTH: usize = 8;
+
+fn bench_grid(c: &mut Criterion) {
+    let grid = Shape::new(GRID_CHANNELS, GRID_DEPTH, CHUNK);
+    bench_sequential(c, "kernel_grid", grid);
+    for group_width in 1..=MAX_CHANNELS {
+        for stages in 1..=MAX_DEPTH {
+            bench_split(
+                c,
+                "kernel_grid",
+                grid,
+                format!("C{group_width}_S{stages}"),
+                group_width,
+                stages,
+            );
+        }
+    }
+}
+
+/// Shapes real configurations have. A deep cascade on a couple of channels is
+/// the parametric equaliser case; sixteen channels of two or three biquads is
+/// a large multi-way active system, where the cascade axis alone has almost
+/// nothing to work with.
+fn bench_shapes(c: &mut Criterion) {
+    const SHAPES: [(usize, usize); 7] =
+        [(1, 16), (2, 16), (4, 16), (4, 4), (8, 3), (16, 2), (16, 4)];
+    for (channels, depth) in SHAPES {
+        let shape = Shape::new(channels, depth, CHUNK);
+        bench_sequential(c, "kernel_shapes", shape);
+        // Each axis on its own, then the split the pipeline would choose.
+        let cascade_only = depth.min(MAX_DEPTH);
+        bench_split(
+            c,
+            "kernel_shapes",
+            shape,
+            format!("cascade_only_S{cascade_only}"),
+            1,
+            cascade_only,
+        );
+        let channel_only = channels.min(MAX_CHANNELS);
+        bench_split(
+            c,
+            "kernel_shapes",
+            shape,
+            format!("channel_only_C{channel_only}"),
+            channel_only,
+            1,
+        );
+        let (group_width, stages) = choose_split(channels, depth);
+        bench_split(
+            c,
+            "kernel_shapes",
+            shape,
+            format!("split_C{group_width}_S{stages}"),
+            group_width,
+            stages,
+        );
+    }
+}
+
+/// Short budgets, following `benches/conv_parallel.rs`: criterion budgets by
+/// wall time, so the default settings would spend eight seconds per point
+/// repeating a result that settled immediately. The real threat to these
+/// numbers was never sampling noise, it was comparing runs taken under
+/// different power states, and a bench that finishes quickly is easier to
+/// repeat, which is the actual defence against that.
+fn config() -> Criterion {
+    Criterion::default()
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2))
+        .sample_size(50)
+        .without_plots()
+}
+
+/// The canon at a short chunk length.
+///
+/// Not a target to optimise: chunk sizes this small are inefficient for
+/// reasons that dwarf the biquads, and nothing in the kernel reads the chunk
+/// length. This is here to confirm the canon does not go backwards there. It
+/// should not be able to: every stage still sees every sample exactly once, so
+/// the ramp-up and drain add no arithmetic, they only leave fewer stages in
+/// flight at the edges. At 64 frames with a depth of 8 that is 57 of 71
+/// iterations at full width. Measure it rather than trusting the argument.
+fn bench_short_chunks(c: &mut Criterion) {
+    const SHORT: usize = 64;
+    for (channels, depth) in [(2usize, 16usize), (16, 2)] {
+        let shape = Shape::new(channels, depth, SHORT);
+        bench_sequential(c, "kernel_short_chunk", shape);
+        let (group_width, stages) = choose_split(channels, depth);
+        bench_split(
+            c,
+            "kernel_short_chunk",
+            shape,
+            format!("split_C{group_width}_S{stages}"),
+            group_width,
+            stages,
+        );
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = config();
+    targets = bench_grid, bench_shapes, bench_short_chunks
+}
+
+criterion_main!(benches);

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -243,6 +243,82 @@ fn build_pipeline(chunksize: usize, multithreaded: bool, conv: Conv) -> Pipeline
     Pipeline::from_config(conf, processing_params, filter_pool)
 }
 
+/// A large multi-way active system: many channels, a handful of biquads on
+/// each. The opposite shape to the parametric equaliser the bench above
+/// measures, and the one the cascade axis alone can do almost nothing with,
+/// since a three stage canon is only three recurrences wide.
+///
+/// It is here because measuring only the deep and narrow shape sizes the
+/// kernel around the wrong axis.
+const WIDE_CHANNELS: usize = 16;
+const WIDE_BIQUAD_PARAMS: [(f64, f64); 3] = [(90.0, 0.71), (1800.0, 1.05), (7500.0, 0.75)];
+
+fn build_wide_pipeline(chunksize: usize, multithreaded: bool) -> Pipeline {
+    let mut filters = HashMap::new();
+    let mut names = Vec::with_capacity(WIDE_BIQUAD_PARAMS.len());
+    for (index, (freq, q)) in WIDE_BIQUAD_PARAMS.iter().enumerate() {
+        let name = format!("wide_bq_{}", index + 1);
+        filters.insert(name.clone(), build_biquad_filter(*freq, *q));
+        names.push(name);
+    }
+
+    let conf = config::Configuration {
+        title: None,
+        description: None,
+        devices: config::Devices {
+            samplerate: 48000,
+            chunksize,
+            queuelimit: None,
+            silence_threshold: None,
+            silence_timeout_s: None,
+            capture: config::CaptureDevice::Stdin(config::CaptureDeviceStdin {
+                channels: WIDE_CHANNELS,
+                format: config::BinarySampleFormat::F32_LE,
+                extra_samples: None,
+                skip_bytes: None,
+                read_bytes: None,
+                labels: None,
+            }),
+            playback: config::PlaybackDevice::Stdout {
+                channels: WIDE_CHANNELS,
+                format: config::BinarySampleFormat::F32_LE,
+                wav_header: None,
+            },
+            enable_rate_adjust: None,
+            target_level: None,
+            adjust_interval_s: None,
+            resampler: None,
+            capture_samplerate: None,
+            stop_on_rate_change: None,
+            rate_measure_interval_s: None,
+            volume_ramp_time_ms: None,
+            volume_limit: None,
+            multithreaded: Some(multithreaded),
+            worker_threads: None,
+        },
+        mixers: None,
+        filters: Some(filters),
+        processors: None,
+        pipeline: Some(vec![config::PipelineStep::Filter(
+            config::PipelineStepFilter {
+                channels: None,
+                names,
+                description: None,
+                bypassed: Some(false),
+            },
+        )]),
+    };
+
+    let processing_params = Arc::new(ProcessingParameters::new(&[0.0_f32; 5], &[false; 5]));
+    let filter_pool = camillalib::processing::build_processing_threadpool(
+        multithreaded,
+        conf.devices.worker_threads(),
+        conf.devices.chunksize,
+        conf.devices.samplerate,
+    );
+    Pipeline::from_config(conf, processing_params, filter_pool)
+}
+
 fn make_chunk(channels: usize, frames: usize) -> AudioChunk {
     let mut waveforms = Vec::with_capacity(channels);
     for channel in 0..channels {
@@ -281,6 +357,18 @@ fn bench_complete_pipeline(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("variant", name), &name, |b, _| {
             b.iter_batched(
                 || make_chunk(4, CHUNK_SIZE),
+                |chunk| {
+                    let _out = pipeline.process_chunk(chunk);
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    for (name, multithreaded) in [("wide_single", false), ("wide_multi", true)] {
+        let mut pipeline = build_wide_pipeline(CHUNK_SIZE, multithreaded);
+        group.bench_with_input(BenchmarkId::new("variant", name), &name, |b, _| {
+            b.iter_batched(
+                || make_chunk(WIDE_CHANNELS, CHUNK_SIZE),
                 |chunk| {
                     let _out = pipeline.process_chunk(chunk);
                 },

--- a/src/filters/biquad.rs
+++ b/src/filters/biquad.rs
@@ -738,7 +738,7 @@ fn lengths_are_uniform(
 /// Turns a runtime `(channels, depth)` into a call to the kernel instantiated
 /// for it.
 ///
-/// The whole `MAX_CHANNELS` by `MAX_DEPTH` grid is instantiated, sixteen
+/// The whole `MAX_CHANNELS` by `MAX_DEPTH` grid is instantiated, thirty-two
 /// kernels. Every one of them is reachable: [`choose_split`] can ask for any depth up
 /// to `MAX_DEPTH`, and a cascade whose length is not a multiple of it ends on a
 /// shorter pass.

--- a/src/filters/biquad.rs
+++ b/src/filters/biquad.rs
@@ -405,7 +405,7 @@ impl BiquadCoefficients {
 /// filters, where the coefficients cluster close to the limits of what an f32
 /// mantissa resolves. Only the finished values cross into the processing
 /// precision, here.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 struct RuntimeCoefficients {
     a1: CamillaFloat,
     a2: CamillaFloat,
@@ -471,6 +471,14 @@ impl Biquad {
         }
     }
 
+    /// Replace the coefficients, keeping the filter state.
+    ///
+    /// A compiled cascade reloads through this so the coefficients are computed
+    /// once for the step rather than once per channel.
+    pub fn set_coefficients(&mut self, coefficients: BiquadCoefficients) {
+        self.coeffs = coefficients.into();
+    }
+
     /// Process a single sample.
     pub fn process_single(&mut self, input: CamillaFloat) -> CamillaFloat {
         let out = mul_add(self.coeffs.b0, input, self.s1);
@@ -513,13 +521,496 @@ impl Filter for Biquad {
             parameters: conf, ..
         } = conf
         {
-            let coeffs = BiquadCoefficients::from_config(self.samplerate, conf);
-            self.coeffs = coeffs.into();
+            self.set_coefficients(BiquadCoefficients::from_config(self.samplerate, conf));
         } else {
             // This should never happen unless there is a bug somewhere else
             panic!("Invalid config change!");
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// The canon
+// ---------------------------------------------------------------------------
+//
+// A biquad is latency-bound, not throughput-bound. Each output feeds the next
+// sample's state, so the core stalls on its own feedback path while the FP
+// units sit idle. The fix is to keep several independent recurrences in
+// flight, and there are exactly two places to find them:
+//
+// - Several channels at the same cascade position are independent.
+// - Stage `k` working on sample `n - k` is independent of stage `k + 1`
+//   working on sample `n - k - 1`. Skewing the stages that way gives one
+//   independent chain per stage, and it is the only axis available to a
+//   single channel.
+//
+// These are the same mechanism, `S` recurrences skewed in time against `C`
+// recurrences side by side, so one kernel runs both at once and keeps `C * S`
+// in flight. Treating them as alternatives caps the width at `max(C, S)`.
+//
+// It is called a canon after the musical form, where voices enter one after
+// another on the same line, as in the round Frère Jacques. The stages here do
+// exactly that: entering in turn during the ramp-up, all singing at once in
+// the steady state, and dropping out in turn as it drains. The literature more
+// often calls the shape a wavefront, as in wavefront parallelism or a
+// wavefront pipeline, and a compiler would call the transformation software
+// pipelining, where the three phases go by prologue, kernel and epilogue.
+//
+// Both are pure scheduling. Every stage still sees its samples in order with
+// identical arithmetic, so the output is bit-identical to running the stages
+// one at a time, whatever `C` and `S` are. That is what makes this safe to do
+// by default, and it is what `bit_identical_over_the_grid` pins down.
+
+/// Widest channel group the kernel is instantiated for.
+///
+/// This rarely decides anything: [`WIDTH_BUDGET`] caps the group at
+/// `budget / stages`, which is already four or fewer for every depth above
+/// one. It binds only on a run of single biquads across more than four
+/// channels, and there four measured better than eight, 0.71 us per
+/// stage-channel against 0.81, holding from 8 channels to 32.
+///
+/// That is the same finding as [`MAX_DEPTH`] from the other side. Width bought
+/// from channels costs more than width bought from depth, and eight channels
+/// wide costs 0.81 where eight stages deep costs 0.38, so there is nothing to
+/// be had by buying more of the dearer one.
+pub const MAX_CHANNELS: usize = 4;
+
+/// Deepest canon the kernel is instantiated for. Longer cascades are split
+/// into several passes.
+///
+/// Depth is the axis that pays. Measured over 1024 samples on a 32 stage
+/// cascade, cost per stage falls monotonically with no sign of a floor:
+///
+/// ```text
+///   S      1      2      3      4      5      6      7      8
+///  us   2.588  1.306  0.937  0.706  0.615  0.533  0.458  0.382
+/// ```
+///
+/// Eight is a cap, not a knee: the curve is still falling there. What lies
+/// past it is unmeasured here, and the two shapes the earlier notes tried
+/// disagreed, a 16 stage cascade gaining 5% at depth 16 while a 32 stage one
+/// preferred depth 12. Two costs do grow with depth for certain, a kernel
+/// instantiation apiece and a longer ramp-up and drain, so going deeper means
+/// measuring those too and not just the steady state.
+///
+/// Depth also beats the channel axis at equal width: eight stages of one
+/// channel costs 0.382 us per stage-channel where four stages of two channels
+/// costs 0.502. So [`choose_split`] spends depth first and only buys channels with
+/// what is left, which is what serves a cascade too shallow to fill the
+/// budget on its own.
+pub const MAX_DEPTH: usize = 8;
+
+/// Independent recurrences to keep in flight, counted as `C * S`.
+///
+/// The one number the rest of the sizing reads from. `benches/biquad_canon.rs`
+/// sweeps the whole `(C, S)` grid; set this from what that measures.
+///
+/// It is really a register budget, so it looked like it would have to differ
+/// per target: a width of eight wants around 64 live doubles, which aarch64's
+/// 32 registers already cannot hold and x86-64's 16 vector registers miss by
+/// far more. Measured, it does not. Zen 4 spills and still lands within about
+/// 10% of the throughput bound, because the spills hit L1 and that is cheap
+/// beside the feedback stall the width exists to hide. One value serves both.
+pub const WIDTH_BUDGET: usize = 8;
+
+/// Splits `channels` by `depth` into a group width and a canon depth.
+///
+/// Both axes fill the same FP pipeline, but not at the same price: at equal
+/// width, depth measured 1.3x better than channels, so it is spent first and
+/// channels only take up the slack. A cascade deep enough to fill the budget
+/// on its own therefore runs one channel at a time, and a shallow one, which
+/// is where the channel axis earns its keep, spreads across as many channels
+/// as the budget still allows.
+///
+/// Cheap enough to call per chunk, which is the point: `depth` changes on
+/// reload when a graphic equalizer band crosses flat or a crossover changes
+/// order, and a cached split would go stale.
+///
+/// Chunk length is deliberately not an input, though it could be. A canon pays
+/// `S - 1` iterations per pass to fill and drain, which is a larger share of
+/// the work the shorter the chunk, so a short chunk wants a shallower and
+/// wider split than this gives it. On 16 biquads per channel this choice costs
+/// 2x at 16 frames and 23% at 32, ties at 64 and wins from 128 up. Chunks that
+/// short are a fringe case, so this was left out on purpose rather than
+/// overlooked. Add it only with numbers from a configuration someone runs.
+pub fn choose_split(channels: usize, depth: usize) -> (usize, usize) {
+    let stages = depth.clamp(1, MAX_DEPTH);
+    let group = channels
+        .clamp(1, MAX_CHANNELS)
+        .min(WIDTH_BUDGET / stages)
+        .max(1);
+    (group, stages)
+}
+
+/// Runs one cascade per channel over one waveform per channel.
+///
+/// `channel_of[i]` names the waveform that `cascades[i]` filters, and `live`
+/// lists the cascades to actually run. Positions rather than references,
+/// because a caller cannot hand over several disjoint `&mut` into a
+/// `Vec<Vec<_>>` without somewhere to put them, and this runs on the audio path
+/// where that would mean allocating every chunk.
+///
+/// `live` is also how a channel carrying no audio is left out. An unused
+/// capture channel arrives as an empty waveform, and the kernel walks the
+/// channels of a group together, so one empty waveform among them would
+/// otherwise decide the length for all of them and silently leave the rest
+/// unfiltered.
+///
+/// Every cascade named in `live` must be the same length, and every waveform
+/// they name must be the same length. Both hold by construction for a compiled
+/// filter step: a config step applies one `names` list to all its channels, and
+/// a chunk's waveforms are either `frames` long or empty.
+///
+/// A cascade deeper than [`MAX_DEPTH`] runs as several passes, and each pass
+/// asks [`choose_split`] again for its own depth rather than inheriting the width the
+/// full depth asked for. A short final pass then has budget to spare and
+/// spends it on channels. Without that, a 9 stage cascade runs its last stage
+/// one channel at a time, which is the slowest point on either axis: four
+/// channels of 9 stages measured 23 us that way against 15 this way, over 1024
+/// frames. A depth that divides evenly is unaffected.
+pub fn process_cascades(
+    cascades: &mut [Vec<Biquad>],
+    waveforms: &mut [Vec<CamillaFloat>],
+    channel_of: &[usize],
+    live: &[usize],
+) {
+    debug_assert!(lengths_are_uniform(cascades, waveforms, channel_of, live));
+    let depth = live.first().map_or(0, |&i| cascades[i].len());
+    let (_, stages) = choose_split(live.len(), depth);
+    // Passes outside, channel groups inside, so a pass can be grouped
+    // differently from the one before it. Every channel still sees its stages
+    // in order, and the channels are independent, so this stays bit-identical.
+    let mut start = 0;
+    while start < depth {
+        let take = (depth - start).min(stages);
+        let (group, _) = choose_split(live.len(), take);
+        for members in live.chunks(group) {
+            dispatch_pass(cascades, waveforms, channel_of, members, start, take);
+        }
+        start += take;
+    }
+}
+
+/// [`process_cascades`] with the split given rather than chosen, and used for
+/// every pass. For sizing benchmarks, which need to ask for a split that
+/// [`choose_split`] would not pick.
+pub fn process_cascades_with_split(
+    cascades: &mut [Vec<Biquad>],
+    waveforms: &mut [Vec<CamillaFloat>],
+    channel_of: &[usize],
+    live: &[usize],
+    group: usize,
+    stages: usize,
+) {
+    debug_assert!((1..=MAX_CHANNELS).contains(&group));
+    debug_assert!((1..=MAX_DEPTH).contains(&stages));
+    debug_assert!(lengths_are_uniform(cascades, waveforms, channel_of, live));
+    for members in live.chunks(group) {
+        let depth = cascades[members[0]].len();
+        let mut start = 0;
+        while start < depth {
+            let take = (depth - start).min(stages);
+            dispatch_pass(cascades, waveforms, channel_of, members, start, take);
+            start += take;
+        }
+    }
+}
+
+/// The shape the kernel relies on: every live cascade the same length, and
+/// every waveform they name the same length.
+///
+/// `live[0]` is safe on an empty `live` because `all` returns without reaching
+/// the closure, not because of where this is called from. Only called from
+/// `debug_assert!`, so it costs nothing in a release build.
+fn lengths_are_uniform(
+    cascades: &[Vec<Biquad>],
+    waveforms: &[Vec<CamillaFloat>],
+    channel_of: &[usize],
+    live: &[usize],
+) -> bool {
+    live.iter()
+        .all(|&i| cascades[i].len() == cascades[live[0]].len())
+        && live
+            .iter()
+            .all(|&i| waveforms[channel_of[i]].len() == waveforms[channel_of[live[0]]].len())
+}
+
+/// Turns a runtime `(channels, depth)` into a call to the kernel instantiated
+/// for it.
+///
+/// The whole `MAX_CHANNELS` by `MAX_DEPTH` grid is instantiated, sixteen
+/// kernels. Every one of them is reachable: [`choose_split`] can ask for any depth up
+/// to `MAX_DEPTH`, and a cascade whose length is not a multiple of it ends on a
+/// shorter pass.
+fn dispatch_pass(
+    cascades: &mut [Vec<Biquad>],
+    waveforms: &mut [Vec<CamillaFloat>],
+    channel_of: &[usize],
+    members: &[usize],
+    start: usize,
+    depth: usize,
+) {
+    macro_rules! by_depth {
+        ($c:literal) => {
+            match depth {
+                1 => run_group::<$c, 1>(cascades, waveforms, channel_of, members, start),
+                2 => run_group::<$c, 2>(cascades, waveforms, channel_of, members, start),
+                3 => run_group::<$c, 3>(cascades, waveforms, channel_of, members, start),
+                4 => run_group::<$c, 4>(cascades, waveforms, channel_of, members, start),
+                5 => run_group::<$c, 5>(cascades, waveforms, channel_of, members, start),
+                6 => run_group::<$c, 6>(cascades, waveforms, channel_of, members, start),
+                7 => run_group::<$c, 7>(cascades, waveforms, channel_of, members, start),
+                8 => run_group::<$c, 8>(cascades, waveforms, channel_of, members, start),
+                _ => unreachable!("depth is clamped to MAX_DEPTH"),
+            }
+        };
+    }
+    match members.len() {
+        1 => by_depth!(1),
+        2 => by_depth!(2),
+        3 => by_depth!(3),
+        4 => by_depth!(4),
+        _ => unreachable!("chunks yields at most MAX_CHANNELS"),
+    }
+}
+
+/// Runs one cascade over one waveform.
+///
+/// The exception rather than the rule: for a filter that has only its own
+/// channel to work with, so all the width has to come from cascade depth. A
+/// step reaching several channels should use [`process_cascades`], which can
+/// spend the channel axis too.
+pub fn process_mono_cascade(stages: &mut [Biquad], waveform: &mut [CamillaFloat]) {
+    let (_, depth) = choose_split(1, stages.len());
+    for in_pass in stages.chunks_mut(depth) {
+        match in_pass.len() {
+            1 => run_mono::<1>(in_pass, waveform),
+            2 => run_mono::<2>(in_pass, waveform),
+            3 => run_mono::<3>(in_pass, waveform),
+            4 => run_mono::<4>(in_pass, waveform),
+            5 => run_mono::<5>(in_pass, waveform),
+            6 => run_mono::<6>(in_pass, waveform),
+            7 => run_mono::<7>(in_pass, waveform),
+            8 => run_mono::<8>(in_pass, waveform),
+            _ => unreachable!("depth is clamped to MAX_DEPTH"),
+        }
+    }
+}
+
+fn run_mono<const S: usize>(stages: &mut [Biquad], waveform: &mut [CamillaFloat]) {
+    let mut voices = Voices::<1, S>::default();
+    load(&mut voices, 0, stages);
+    let (s1, s2) = canon::<1, S>(voices, [waveform]);
+    store(&s1, &s2, 0, stages);
+}
+
+/// Loads one pass into registers, runs it, and stores the state back.
+///
+/// The load and store happen once per pass, never on the per-sample path, so
+/// the strided reads out of `cascades` cost nothing measurable. That is what
+/// leaves the buffer layout free to be chosen for the reload path instead.
+fn run_group<const C: usize, const S: usize>(
+    cascades: &mut [Vec<Biquad>],
+    waveforms: &mut [Vec<CamillaFloat>],
+    channel_of: &[usize],
+    members: &[usize],
+    start: usize,
+) {
+    let mut voices = Voices::<C, S>::default();
+    for c in 0..C {
+        load(&mut voices, c, &cascades[members[c]][start..start + S]);
+    }
+
+    // Handed over as a fixed-size array so the kernel subscripts it with a
+    // constant, which is what keeps the bounds checks out of the sample loop.
+    let channels: [usize; C] = std::array::from_fn(|c| channel_of[members[c]]);
+    let waves = waveforms
+        .get_disjoint_mut(channels)
+        .expect("each cascade of a group filters a different channel")
+        .map(|w| &mut w[..]);
+
+    let (s1, s2) = canon::<C, S>(voices, waves);
+
+    for c in 0..C {
+        store(&s1, &s2, c, &mut cascades[members[c]][start..start + S]);
+    }
+}
+
+fn load<const C: usize, const S: usize>(voices: &mut Voices<C, S>, c: usize, stages: &[Biquad]) {
+    for (k, stage) in stages.iter().enumerate().take(S) {
+        voices.b0[c][k] = stage.coeffs.b0;
+        voices.b1[c][k] = stage.coeffs.b1;
+        voices.b2[c][k] = stage.coeffs.b2;
+        voices.a1[c][k] = stage.coeffs.a1;
+        voices.a2[c][k] = stage.coeffs.a2;
+        voices.s1[c][k] = stage.s1;
+        voices.s2[c][k] = stage.s2;
+    }
+}
+
+fn store<const C: usize, const S: usize>(
+    s1: &[[CamillaFloat; S]; C],
+    s2: &[[CamillaFloat; S]; C],
+    c: usize,
+    stages: &mut [Biquad],
+) {
+    for (k, stage) in stages.iter_mut().enumerate().take(S) {
+        stage.s1 = s1[c][k];
+        stage.s2 = s2[c][k];
+        stage.flush_subnormals();
+    }
+}
+
+/// The voices of one canon: every stage of every channel in the pass, held by
+/// value so the whole thing can live in registers.
+///
+/// One array per coefficient rather than one array of whole stages.
+/// Holding a canon takes seven floats per stage and aarch64 has 32 FP
+/// registers to hold them in, so past a width of four something has to live in
+/// memory and the layout decides what. Measured either way it came out the
+/// same, so this is not the reason the kernel is fast; it is kept because it
+/// leaves the choice to the compiler a value at a time rather than a stage at
+/// a time, which is the shape that cannot get worse.
+struct Voices<const C: usize, const S: usize> {
+    s1: [[CamillaFloat; S]; C],
+    s2: [[CamillaFloat; S]; C],
+    b0: [[CamillaFloat; S]; C],
+    b1: [[CamillaFloat; S]; C],
+    b2: [[CamillaFloat; S]; C],
+    a1: [[CamillaFloat; S]; C],
+    a2: [[CamillaFloat; S]; C],
+}
+
+impl<const C: usize, const S: usize> Default for Voices<C, S> {
+    fn default() -> Self {
+        let zeros = [[0.0 as CamillaFloat; S]; C];
+        Voices {
+            s1: zeros,
+            s2: zeros,
+            b0: zeros,
+            b1: zeros,
+            b2: zeros,
+            a1: zeros,
+            a2: zeros,
+        }
+    }
+}
+
+/// The sample loop, on values rather than on anything the caller can reach.
+///
+/// State and coefficients arrive and leave by value so nothing in the loop
+/// sits behind a pointer the compiler has to reason about. Reaching the stages
+/// through a trait object here instead measured 10.28 us against 6.39 us for a
+/// 16 stage cascade over 1024 samples, a 60% penalty for two opaque calls that
+/// run once per pass.
+///
+/// `pipe[c][k]` holds stage `k`'s output from the previous iteration, which
+/// stage `k + 1` consumes in this one. Walking the stages downwards leaves
+/// that value unread until it has been used, so one array serves as the whole
+/// skew buffer.
+///
+/// The canon takes `n + S - 1` iterations for `n` samples: a ramp-up while
+/// the deeper stages have not been reached, a steady state with every stage
+/// busy, and a drain once the input is exhausted. Stages not yet or no longer
+/// active must be **skipped, not fed zeros**, or their state advances past the
+/// end of the chunk. That is the one bug here that would be silent and
+/// cumulative.
+///
+/// Neither loop counter here is a plain subscript, which is why the lint is
+/// off for the whole function. `i` is the canon position and doubles as
+/// the bound on how many stages have been reached, and `c` steps several
+/// arrays plus a waveform in lockstep. Iterating any one of them, which is
+/// what the lint asks for, would walk the wrong axis and undo the scheduling.
+#[allow(clippy::needless_range_loop)]
+fn canon<const C: usize, const S: usize>(
+    voices: Voices<C, S>,
+    waveforms: [&mut [CamillaFloat]; C],
+) -> ([[CamillaFloat; S]; C], [[CamillaFloat; S]; C]) {
+    let Voices {
+        mut s1,
+        mut s2,
+        b0,
+        b1,
+        b2,
+        a1,
+        a2,
+    } = voices;
+
+    // One stage of one channel advanced by one sample. Identical arithmetic to
+    // `Biquad::process_single`, on locals that stay in registers.
+    macro_rules! stage {
+        ($c:expr, $k:expr, $x:expr) => {{
+            let (c, k) = ($c, $k);
+            let input = $x;
+            let out = mul_add(b0[c][k], input, s1[c][k]);
+            s1[c][k] = mul_add(-a1[c][k], out, mul_add(b1[c][k], input, s2[c][k]));
+            s2[c][k] = mul_add(-a2[c][k], out, b2[c][k] * input);
+            out
+        }};
+    }
+
+    let n = waveforms[0].len();
+    // Reborrowing at exactly `n` is what tells the compiler that every
+    // `waves[c][i]` with `i < n` is in range.
+    let waves = waveforms.map(|w| &mut w[..n]);
+    let mut pipe = [[0.0 as CamillaFloat; S]; C];
+
+    // The bounds below read like special cases for a waveform shorter than the
+    // cascade, and they are, but they are also what keeps this fast. They are
+    // how the loops tell the compiler their indices are inside the slice:
+    // `(S - 1).min(n)` says `i < n`, and the guarded store says the same for
+    // the drain. Rewriting them into the form a guaranteed minimum length
+    // would allow, an unguarded `waveform[n - S + first]`, measured 6.40 us
+    // against 13.35 for a 16 stage cascade over 1024 samples. The indices stop
+    // being provably in range, and the panic paths that appear block the
+    // optimisation of everything around them. Stating `assert!(n >= S)`
+    // instead recovers only part of it, 10.15 us. Leave them alone.
+    //
+    // Ramp-up: stage `k` has seen no sample yet while `k > i`.
+    let ramp = (S - 1).min(n);
+    for i in 0..ramp {
+        for k in (1..=i).rev() {
+            for c in 0..C {
+                pipe[c][k] = stage!(c, k, pipe[c][k - 1]);
+            }
+        }
+        for c in 0..C {
+            pipe[c][0] = stage!(c, 0, waves[c][i]);
+        }
+    }
+
+    // Steady state: every stage busy on a different sample.
+    for i in (S - 1)..n {
+        for k in (1..S).rev() {
+            for c in 0..C {
+                pipe[c][k] = stage!(c, k, pipe[c][k - 1]);
+            }
+        }
+        for c in 0..C {
+            pipe[c][0] = stage!(c, 0, waves[c][i]);
+        }
+        for c in 0..C {
+            waves[c][i - (S - 1)] = pipe[c][S - 1];
+        }
+    }
+
+    // Drain: stage `k` is finished once `i - k` reaches `n`.
+    for i in n..(n + S - 1) {
+        let first = i - n + 1;
+        let last = (S - 1).min(i);
+        for k in (first..=last).rev() {
+            for c in 0..C {
+                pipe[c][k] = stage!(c, k, pipe[c][k - 1]);
+            }
+        }
+        if i >= S - 1 {
+            for c in 0..C {
+                waves[c][i - (S - 1)] = pipe[c][S - 1];
+            }
+        }
+    }
+
+    (s1, s2)
 }
 
 pub fn validate_config(samplerate: usize, parameters: &config::BiquadParameters) -> Res<()> {
@@ -638,7 +1129,10 @@ mod tests {
         BiquadParameters, GeneralNotchParams, NotchWidth, PeakingWidth, ShelfSteepness,
     };
     use crate::filters::Filter;
-    use crate::filters::biquad::{Biquad, BiquadCoefficients, validate_config};
+    use crate::filters::biquad::{
+        Biquad, BiquadCoefficients, MAX_CHANNELS, MAX_DEPTH, WIDTH_BUDGET, choose_split,
+        process_cascades, process_cascades_with_split, validate_config,
+    };
     use num_complex::Complex;
 
     fn is_close(left: f64, right: f64, maxdiff: f64) -> bool {
@@ -1114,5 +1608,250 @@ mod tests {
             gain: 1.23,
         });
         assert!(validate_config(fs, &badconf2).is_err());
+    }
+
+    // ---------------------------------------------------------------------
+    // The canon
+    // ---------------------------------------------------------------------
+
+    /// A cascade of `stages` biquads, each with different coefficients so a
+    /// stage running out of order or twice cannot go unnoticed.
+    fn cascade(stages: usize, seed: usize) -> Vec<Biquad> {
+        (0..stages)
+            .map(|k| {
+                let conf = BiquadParameters::Peaking(PeakingWidth::Q {
+                    freq: 100.0 + 137.0 * ((k + 3 * seed) as f64),
+                    q: 0.7 + 0.05 * (k as f64),
+                    gain: 1.5 + 0.25 * (seed as f64),
+                });
+                Biquad::new("t", 44100, BiquadCoefficients::from_config(44100, conf))
+            })
+            .collect()
+    }
+
+    fn signal(n: usize, seed: usize) -> Vec<CamillaFloat> {
+        (0..n)
+            .map(|i| (0.017 * ((7 * i + 13 * seed) as CamillaFloat)).sin() * 0.5)
+            .collect()
+    }
+
+    /// Cascade `i` filters waveform `i`, and every channel is live. The shape a
+    /// compiled step has when no capture channel is unused.
+    fn straight(channels: usize) -> Vec<usize> {
+        (0..channels).collect()
+    }
+
+    /// What the kernel has to reproduce exactly: every stage run over the whole
+    /// waveform in order, one at a time.
+    fn sequential(cascades: &mut [Vec<Biquad>], waveforms: &mut [Vec<CamillaFloat>]) {
+        for (cascade, waveform) in cascades.iter_mut().zip(waveforms.iter_mut()) {
+            for stage in cascade.iter_mut() {
+                stage.process_waveform(waveform);
+            }
+        }
+    }
+
+    /// Bit equality, not float equality: `-0.0 == 0.0` compares equal but is a
+    /// different value, and this test exists to catch exactly that kind of drift.
+    fn assert_same(left: &[Vec<CamillaFloat>], right: &[Vec<CamillaFloat>], what: &str) {
+        assert_eq!(left.len(), right.len(), "{what}: channel count");
+        for (ch, (l, r)) in left.iter().zip(right.iter()).enumerate() {
+            assert_eq!(l.len(), r.len(), "{what}: length of channel {ch}");
+            for (i, (a, b)) in l.iter().zip(r.iter()).enumerate() {
+                assert_eq!(
+                    a.to_bits(),
+                    b.to_bits(),
+                    "{what}: channel {ch} sample {i}, {a} against {b}"
+                );
+            }
+        }
+    }
+
+    fn assert_same_state(left: &[Vec<Biquad>], right: &[Vec<Biquad>], what: &str) {
+        for (ch, (l, r)) in left.iter().zip(right.iter()).enumerate() {
+            for (k, (a, b)) in l.iter().zip(r.iter()).enumerate() {
+                assert_eq!(
+                    (a.s1.to_bits(), a.s2.to_bits()),
+                    (b.s1.to_bits(), b.s2.to_bits()),
+                    "{what}: state of channel {ch} stage {k}"
+                );
+            }
+        }
+    }
+
+    /// The whole point of the kernel: whatever `(C, S)` it is dispatched at, the
+    /// output and the leftover state match running the stages one at a time.
+    /// This is what makes the scheduling safe to apply by default.
+    #[test]
+    fn bit_identical_over_the_grid() {
+        for channels in 1..=MAX_CHANNELS {
+            // Depths past MAX_DEPTH exercise the split into several passes.
+            for depth in 1..=(MAX_DEPTH + 3) {
+                for n in [0, 1, 2, 3, 7, 8, 9, 64, 257] {
+                    let mut want_c: Vec<Vec<Biquad>> =
+                        (0..channels).map(|c| cascade(depth, c)).collect();
+                    let mut want_w: Vec<Vec<CamillaFloat>> =
+                        (0..channels).map(|c| signal(n, c)).collect();
+                    sequential(&mut want_c, &mut want_w);
+
+                    for group in 1..=MAX_CHANNELS {
+                        for stages in 1..=MAX_DEPTH {
+                            let mut got_c: Vec<Vec<Biquad>> =
+                                (0..channels).map(|c| cascade(depth, c)).collect();
+                            let mut got_w: Vec<Vec<CamillaFloat>> =
+                                (0..channels).map(|c| signal(n, c)).collect();
+                            let ids = straight(channels);
+                            process_cascades_with_split(
+                                &mut got_c, &mut got_w, &ids, &ids, group, stages,
+                            );
+                            let what = format!(
+                                "channels {channels} depth {depth} n {n} at C {group} S {stages}"
+                            );
+                            assert_same(&got_w, &want_w, &what);
+                            assert_same_state(&got_c, &want_c, &what);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// The split the pipeline will actually ask for has to agree too.
+    ///
+    /// The depths past `MAX_DEPTH` are the ones that run as several passes, and
+    /// 9, 10 and 12 are there because their last pass is shallower than the
+    /// ones before it and so gets grouped across more channels. That is the
+    /// case where two passes of the same cascade run at different widths.
+    #[test]
+    fn chosen_split_is_bit_identical() {
+        for channels in 1..=8 {
+            for depth in [1, 2, 3, 4, 7, 8, 9, 10, 12, 16, 31] {
+                let mut want_c: Vec<Vec<Biquad>> =
+                    (0..channels).map(|c| cascade(depth, c)).collect();
+                let mut want_w: Vec<Vec<CamillaFloat>> =
+                    (0..channels).map(|c| signal(1024, c)).collect();
+                sequential(&mut want_c, &mut want_w);
+
+                let mut got_c: Vec<Vec<Biquad>> =
+                    (0..channels).map(|c| cascade(depth, c)).collect();
+                let mut got_w: Vec<Vec<CamillaFloat>> =
+                    (0..channels).map(|c| signal(1024, c)).collect();
+                let ids = straight(channels);
+                process_cascades(&mut got_c, &mut got_w, &ids, &ids);
+                let what = format!("channels {channels} depth {depth}");
+                assert_same(&got_w, &want_w, &what);
+                assert_same_state(&got_c, &want_c, &what);
+            }
+        }
+    }
+
+    /// The drain has to leave the state exactly where a sequential run would, or
+    /// the error accumulates from one chunk to the next instead of showing up
+    /// once. Depth 12 also puts a pass boundary inside every chunk, so this
+    /// crosses both boundaries at the same time.
+    #[test]
+    fn state_survives_chunk_boundaries() {
+        const DEPTH: usize = 12;
+        const CHANNELS: usize = 3;
+        const CHUNK: usize = 5;
+        const CHUNKS: usize = 9;
+
+        let mut want_c: Vec<Vec<Biquad>> = (0..CHANNELS).map(|c| cascade(DEPTH, c)).collect();
+        let mut want_w: Vec<Vec<CamillaFloat>> =
+            (0..CHANNELS).map(|c| signal(CHUNK * CHUNKS, c)).collect();
+        sequential(&mut want_c, &mut want_w);
+
+        let mut got_c: Vec<Vec<Biquad>> = (0..CHANNELS).map(|c| cascade(DEPTH, c)).collect();
+        let source: Vec<Vec<CamillaFloat>> =
+            (0..CHANNELS).map(|c| signal(CHUNK * CHUNKS, c)).collect();
+        let ids = straight(CHANNELS);
+        let mut got_w: Vec<Vec<CamillaFloat>> = vec![Vec::new(); CHANNELS];
+        for chunk in 0..CHUNKS {
+            let mut piece: Vec<Vec<CamillaFloat>> = source
+                .iter()
+                .map(|w| w[chunk * CHUNK..(chunk + 1) * CHUNK].to_vec())
+                .collect();
+            process_cascades(&mut got_c, &mut piece, &ids, &ids);
+            for (whole, part) in got_w.iter_mut().zip(piece) {
+                whole.extend(part);
+            }
+        }
+        assert_same(&got_w, &want_w, "chunked");
+        assert_same_state(&got_c, &want_c, "chunked");
+    }
+
+    /// An unused capture channel arrives as an empty waveform. The kernel walks
+    /// the channels of a group together, so leaving one in would decide the
+    /// length for the whole group; `live` is how the caller keeps it out, and
+    /// the channels that do carry audio must come out filtered anyway.
+    #[test]
+    fn an_empty_channel_does_not_silence_its_group() {
+        const CHANNELS: usize = 4;
+        // Channels 1 and 3 carry no audio, as they would ahead of a mixer that
+        // only reads 0 and 2.
+        let live = vec![0usize, 2];
+
+        let mut want_c: Vec<Vec<Biquad>> = (0..CHANNELS).map(|c| cascade(6, c)).collect();
+        let mut want_w: Vec<Vec<CamillaFloat>> = (0..CHANNELS)
+            .map(|c| {
+                if live.contains(&c) {
+                    signal(64, c)
+                } else {
+                    Vec::new()
+                }
+            })
+            .collect();
+        sequential(&mut want_c, &mut want_w);
+
+        let mut got_c: Vec<Vec<Biquad>> = (0..CHANNELS).map(|c| cascade(6, c)).collect();
+        let mut got_w: Vec<Vec<CamillaFloat>> = (0..CHANNELS)
+            .map(|c| {
+                if live.contains(&c) {
+                    signal(64, c)
+                } else {
+                    Vec::new()
+                }
+            })
+            .collect();
+        process_cascades(&mut got_c, &mut got_w, &straight(CHANNELS), &live);
+
+        assert_same(&got_w, &want_w, "one empty channel in the group");
+        for &c in &live {
+            assert_same_state(&got_c[c..=c], &want_c[c..=c], "live channel");
+        }
+        // The channels that were left out must not have advanced at all.
+        for c in [1usize, 3] {
+            for stage in &got_c[c] {
+                assert_eq!(stage.s1, 0.0, "channel {c} was left out but ran");
+                assert_eq!(stage.s2, 0.0, "channel {c} was left out but ran");
+            }
+        }
+    }
+
+    /// A graphic equalizer with every band flat contributes no stages at all.
+    #[test]
+    fn an_empty_cascade_passes_audio_through() {
+        let mut cascades: Vec<Vec<Biquad>> = vec![Vec::new(), Vec::new()];
+        let mut waves: Vec<Vec<CamillaFloat>> = (0..2).map(|c| signal(64, c)).collect();
+        let want = waves.clone();
+        let ids = straight(2);
+        process_cascades(&mut cascades, &mut waves, &ids, &ids);
+        assert_same(&waves, &want, "empty cascade");
+    }
+
+    #[test]
+    fn split_stays_inside_the_budget() {
+        for channels in 1..=16 {
+            for depth in 0..=40 {
+                let (group, stages) = choose_split(channels, depth);
+                assert!((1..=MAX_CHANNELS).contains(&group), "{channels} {depth}");
+                assert!((1..=MAX_DEPTH).contains(&stages), "{channels} {depth}");
+                assert!(group <= channels.max(1), "{channels} {depth}");
+                assert!(
+                    group * stages <= WIDTH_BUDGET,
+                    "{channels} by {depth} gave {group} by {stages}"
+                );
+            }
+        }
     }
 }

--- a/src/filters/biquadcombo.rs
+++ b/src/filters/biquadcombo.rs
@@ -23,225 +23,206 @@ use crate::filters::biquad;
 use crate::CamillaFloat;
 use crate::Res;
 
-#[derive(Clone, Debug)]
-pub struct BiquadCombo {
-    samplerate: usize,
-    pub name: String,
-    filters: Vec<biquad::Biquad>,
+/// A biquad combo is a cascade, so it has no runtime form of its own. It is
+/// expanded into stages at build time and compiled into the cascade of the
+/// filter step around it, which is what lets a combo and the loose biquads
+/// beside it share one canon.
+fn butterworth_q(order: usize) -> Vec<f64> {
+    let odd = !order.is_multiple_of(2);
+    let pi = std::f64::consts::PI;
+    let n_so = order / 2;
+    let mut qvalues = Vec::with_capacity(n_so + usize::from(odd));
+    for n in 0..n_so {
+        let q = 1.0 / (2.0 * (pi / (order as f64) * (n as f64 + 0.5)).sin());
+        qvalues.push(q);
+    }
+    if odd {
+        qvalues.push(-1.0);
+    }
+    qvalues
 }
 
-impl BiquadCombo {
-    fn butterworth_q(order: usize) -> Vec<f64> {
-        let odd = !order.is_multiple_of(2);
-        let pi = std::f64::consts::PI;
-        let n_so = order / 2;
-        let mut qvalues = Vec::with_capacity(n_so + usize::from(odd));
-        for n in 0..n_so {
-            let q = 1.0 / (2.0 * (pi / (order as f64) * (n as f64 + 0.5)).sin());
-            qvalues.push(q);
-        }
-        if odd {
-            qvalues.push(-1.0);
-        }
-        qvalues
-    }
-
-    fn make_highpass(fs: usize, freq: f64, qvalues: Vec<f64>) -> Vec<biquad::Biquad> {
-        let mut filters = Vec::with_capacity(qvalues.len());
-        for q in qvalues.iter() {
-            let filtconf = if q >= &0.0 {
-                config::BiquadParameters::Highpass { freq, q: *q }
-            } else {
-                config::BiquadParameters::HighpassFO { freq }
-            };
-            let coeffs = biquad::BiquadCoefficients::from_config(fs, filtconf);
-            let filt = biquad::Biquad::new("", fs, coeffs);
-            filters.push(filt);
-        }
-        filters
-    }
-
-    fn make_lowpass(fs: usize, freq: f64, qvalues: Vec<f64>) -> Vec<biquad::Biquad> {
-        let mut filters = Vec::with_capacity(qvalues.len());
-        for q in qvalues.iter() {
-            let filtconf = if q >= &0.0 {
-                config::BiquadParameters::Lowpass { freq, q: *q }
-            } else {
-                config::BiquadParameters::LowpassFO { freq }
-            };
-            let coeffs = biquad::BiquadCoefficients::from_config(fs, filtconf);
-            let filt = biquad::Biquad::new("", fs, coeffs);
-            filters.push(filt);
-        }
-        filters
-    }
-
-    fn linkwitzriley_q(order: usize) -> Vec<f64> {
-        let mut q_temp = BiquadCombo::butterworth_q(order / 2);
-        let mut qvalues;
-        if !order.is_multiple_of(4) {
-            q_temp.pop();
-            qvalues = q_temp.clone();
-            qvalues.append(&mut q_temp);
-            qvalues.push(0.5);
+fn make_highpass(fs: usize, freq: f64, qvalues: Vec<f64>) -> Vec<biquad::Biquad> {
+    let mut filters = Vec::with_capacity(qvalues.len());
+    for q in qvalues.iter() {
+        let filtconf = if q >= &0.0 {
+            config::BiquadParameters::Highpass { freq, q: *q }
         } else {
-            qvalues = q_temp.clone();
-            qvalues.append(&mut q_temp);
+            config::BiquadParameters::HighpassFO { freq }
+        };
+        let coeffs = biquad::BiquadCoefficients::from_config(fs, filtconf);
+        let filt = biquad::Biquad::new("", fs, coeffs);
+        filters.push(filt);
+    }
+    filters
+}
+
+fn make_lowpass(fs: usize, freq: f64, qvalues: Vec<f64>) -> Vec<biquad::Biquad> {
+    let mut filters = Vec::with_capacity(qvalues.len());
+    for q in qvalues.iter() {
+        let filtconf = if q >= &0.0 {
+            config::BiquadParameters::Lowpass { freq, q: *q }
+        } else {
+            config::BiquadParameters::LowpassFO { freq }
+        };
+        let coeffs = biquad::BiquadCoefficients::from_config(fs, filtconf);
+        let filt = biquad::Biquad::new("", fs, coeffs);
+        filters.push(filt);
+    }
+    filters
+}
+
+fn linkwitzriley_q(order: usize) -> Vec<f64> {
+    let mut q_temp = butterworth_q(order / 2);
+    let mut qvalues;
+    if !order.is_multiple_of(4) {
+        q_temp.pop();
+        qvalues = q_temp.clone();
+        qvalues.append(&mut q_temp);
+        qvalues.push(0.5);
+    } else {
+        qvalues = q_temp.clone();
+        qvalues.append(&mut q_temp);
+    }
+    qvalues
+}
+
+fn make_tilt(fs: usize, gain: f64) -> Vec<biquad::Biquad> {
+    let gain_low = -gain / 2.0;
+    let gain_high = gain / 2.0;
+    let lsconf = config::BiquadParameters::Lowshelf(config::ShelfSteepness::Q {
+        freq: 110.0,
+        q: 0.35,
+        gain: gain_low,
+    });
+    let hsconf = config::BiquadParameters::Highshelf(config::ShelfSteepness::Q {
+        freq: 3500.0,
+        q: 0.35,
+        gain: gain_high,
+    });
+    let mut filters = Vec::with_capacity(2);
+    let lscoeffs = biquad::BiquadCoefficients::from_config(fs, lsconf);
+    let lsfilt = biquad::Biquad::new("", fs, lscoeffs);
+    filters.push(lsfilt);
+    let hscoeffs = biquad::BiquadCoefficients::from_config(fs, hsconf);
+    let hsfilt = biquad::Biquad::new("", fs, hscoeffs);
+    filters.push(hsfilt);
+    filters
+}
+
+fn make_npeq(samplerate: usize, bands: &[config::PeqBand]) -> Vec<biquad::Biquad> {
+    let sections = npeq_sections(bands);
+    let mut filters = Vec::with_capacity(sections.len());
+    for (params, band) in sections.into_iter().zip(bands.iter()) {
+        // A band with no significant gain does nothing, so leave it out.
+        if band.gain.abs() <= 0.001 {
+            continue;
         }
-        qvalues
+        let coeffs = biquad::BiquadCoefficients::from_config(samplerate, params);
+        filters.push(biquad::Biquad::new("", samplerate, coeffs));
     }
+    filters
+}
 
-    fn make_tilt(fs: usize, gain: f64) -> Vec<biquad::Biquad> {
-        let gain_low = -gain / 2.0;
-        let gain_high = gain / 2.0;
-        let lsconf = config::BiquadParameters::Lowshelf(config::ShelfSteepness::Q {
-            freq: 110.0,
-            q: 0.35,
-            gain: gain_low,
-        });
-        let hsconf = config::BiquadParameters::Highshelf(config::ShelfSteepness::Q {
-            freq: 3500.0,
-            q: 0.35,
-            gain: gain_high,
-        });
-        let mut filters = Vec::with_capacity(2);
-        let lscoeffs = biquad::BiquadCoefficients::from_config(fs, lsconf);
-        let lsfilt = biquad::Biquad::new("", fs, lscoeffs);
-        filters.push(lsfilt);
-        let hscoeffs = biquad::BiquadCoefficients::from_config(fs, hsconf);
-        let hsfilt = biquad::Biquad::new("", fs, hscoeffs);
-        filters.push(hsfilt);
-        filters
-    }
+fn make_graphic(
+    samplerate: usize,
+    freq_min: f32,
+    freq_max: f32,
+    gains: &[f32],
+) -> Vec<biquad::Biquad> {
+    let bands = gains.len();
+    let mut filters = Vec::with_capacity(bands);
 
-    fn make_npeq(samplerate: usize, bands: &[config::PeqBand]) -> Vec<biquad::Biquad> {
-        let sections = npeq_sections(bands);
-        let mut filters = Vec::with_capacity(sections.len());
-        for (params, band) in sections.into_iter().zip(bands.iter()) {
-            // A band with no significant gain does nothing, so leave it out.
-            if band.gain.abs() <= 0.001 {
-                continue;
-            }
-            let coeffs = biquad::BiquadCoefficients::from_config(samplerate, params);
-            filters.push(biquad::Biquad::new("", samplerate, coeffs));
+    let f_min_log = freq_min.log2();
+    let f_max_log = freq_max.log2();
+    let bw = (f_max_log - f_min_log) / bands as f32;
+    for (band, gain) in gains.iter().enumerate() {
+        if gain.abs() > 0.001 {
+            let freq_log = f_min_log + (band as f32 + 0.5) * bw;
+            let freq = 2.0_f32.powf(freq_log);
+            let filtconf = config::BiquadParameters::Peaking(config::PeakingWidth::Bandwidth {
+                freq: freq as f64,
+                bandwidth: bw as f64,
+                gain: *gain as f64,
+            });
+            let coeffs = biquad::BiquadCoefficients::from_config(samplerate, filtconf);
+            let filt = biquad::Biquad::new("", samplerate, coeffs);
+            filters.push(filt);
         }
-        filters
     }
+    filters
+}
 
-    fn make_graphic(
-        samplerate: usize,
-        freq_min: f32,
-        freq_max: f32,
-        gains: &[f32],
-    ) -> Vec<biquad::Biquad> {
-        let bands = gains.len();
-        let mut filters = Vec::with_capacity(bands);
-
-        let f_min_log = freq_min.log2();
-        let f_max_log = freq_max.log2();
-        let bw = (f_max_log - f_min_log) / bands as f32;
-        for (band, gain) in gains.iter().enumerate() {
-            if gain.abs() > 0.001 {
-                let freq_log = f_min_log + (band as f32 + 0.5) * bw;
-                let freq = 2.0_f32.powf(freq_log);
-                let filtconf = config::BiquadParameters::Peaking(config::PeakingWidth::Bandwidth {
-                    freq: freq as f64,
-                    bandwidth: bw as f64,
-                    gain: *gain as f64,
-                });
-                let coeffs = biquad::BiquadCoefficients::from_config(samplerate, filtconf);
-                let filt = biquad::Biquad::new("", samplerate, coeffs);
-                filters.push(filt);
-            }
+/// The biquad stages this combo expands to.
+///
+/// The count depends on the parameters, and can be zero: `make_graphic`
+/// drops any band that is flat. It also changes on reload, since
+/// `config_diff` only rebuilds the pipeline when a filter changes type.
+pub fn stages(samplerate: usize, parameters: config::BiquadComboParameters) -> Vec<biquad::Biquad> {
+    match parameters {
+        config::BiquadComboParameters::LinkwitzRileyHighpass { order, freq } => {
+            let qvalues = linkwitzriley_q(order);
+            make_highpass(samplerate, freq, qvalues)
         }
-        filters
+        config::BiquadComboParameters::LinkwitzRileyLowpass { order, freq } => {
+            let qvalues = linkwitzriley_q(order);
+            make_lowpass(samplerate, freq, qvalues)
+        }
+        config::BiquadComboParameters::ButterworthHighpass { order, freq } => {
+            let qvalues = butterworth_q(order);
+            make_highpass(samplerate, freq, qvalues)
+        }
+        config::BiquadComboParameters::ButterworthLowpass { order, freq } => {
+            let qvalues = butterworth_q(order);
+            make_lowpass(samplerate, freq, qvalues)
+        }
+        config::BiquadComboParameters::Tilt { gain } => make_tilt(samplerate, gain),
+        config::BiquadComboParameters::NPointPeq { bands } => make_npeq(samplerate, &bands),
+        config::BiquadComboParameters::GraphicEqualizer(params) => make_graphic(
+            samplerate,
+            params.freq_min(),
+            params.freq_max(),
+            &params.gains,
+        ),
     }
+}
 
-    pub fn from_config(
-        name: &str,
-        samplerate: usize,
-        parameters: config::BiquadComboParameters,
-    ) -> Self {
-        let name = name.to_string();
-        match parameters {
-            config::BiquadComboParameters::LinkwitzRileyHighpass { order, freq } => {
-                let qvalues = BiquadCombo::linkwitzriley_q(order);
-                let filters = BiquadCombo::make_highpass(samplerate, freq, qvalues);
-                BiquadCombo {
-                    samplerate,
-                    name,
-                    filters,
-                }
-            }
-            config::BiquadComboParameters::LinkwitzRileyLowpass { order, freq } => {
-                let qvalues = BiquadCombo::linkwitzriley_q(order);
-                let filters = BiquadCombo::make_lowpass(samplerate, freq, qvalues);
-                BiquadCombo {
-                    samplerate,
-                    name,
-                    filters,
-                }
-            }
-            config::BiquadComboParameters::ButterworthHighpass { order, freq } => {
-                let qvalues = BiquadCombo::butterworth_q(order);
-                let filters = BiquadCombo::make_highpass(samplerate, freq, qvalues);
-                BiquadCombo {
-                    samplerate,
-                    name,
-                    filters,
-                }
-            }
-            config::BiquadComboParameters::ButterworthLowpass { order, freq } => {
-                let qvalues = BiquadCombo::butterworth_q(order);
-                let filters = BiquadCombo::make_lowpass(samplerate, freq, qvalues);
-                BiquadCombo {
-                    samplerate,
-                    name,
-                    filters,
-                }
-            }
-            config::BiquadComboParameters::Tilt { gain } => {
-                let filters = BiquadCombo::make_tilt(samplerate, gain);
-                BiquadCombo {
-                    samplerate,
-                    name,
-                    filters,
-                }
-            }
-            config::BiquadComboParameters::NPointPeq { bands } => {
-                let filters = BiquadCombo::make_npeq(samplerate, &bands);
-                BiquadCombo {
-                    samplerate,
-                    name,
-                    filters,
-                }
-            }
-            config::BiquadComboParameters::GraphicEqualizer(params) => {
-                let filters = BiquadCombo::make_graphic(
-                    samplerate,
-                    params.freq_min(),
-                    params.freq_max(),
-                    &params.gains,
-                );
-                BiquadCombo {
-                    samplerate,
-                    name,
-                    filters,
-                }
-            }
+/// A combo as a filter of its own, rather than compiled into the cascade of
+/// its step.
+///
+/// It is still a cascade, so it runs as its own canon. It only misses the
+/// depth it would have gained from the biquads either side of it, and the
+/// channel axis, which needs a step that reaches several channels at once.
+///
+/// Nothing in `Pipeline::from_config` builds one: a combo is biquad-based, so
+/// it always lands in a run that compiles, and the per-channel chains that
+/// would hold this are only built for runs that do not. It exists because
+/// `FilterGroup::from_config` is public and a library user can hand it a combo
+/// directly. Do not read its presence as a pipeline path that is still taken.
+#[derive(Clone, Debug)]
+pub struct Combo {
+    name: String,
+    samplerate: usize,
+    stages: Vec<biquad::Biquad>,
+}
+
+impl Combo {
+    pub fn new(name: &str, samplerate: usize, stages: Vec<biquad::Biquad>) -> Self {
+        Combo {
+            name: name.to_string(),
+            samplerate,
+            stages,
         }
     }
 }
 
-impl Filter for BiquadCombo {
+impl Filter for Combo {
     fn name(&self) -> &str {
         &self.name
     }
 
     fn process_waveform(&mut self, waveform: &mut [CamillaFloat]) {
-        for filter in self.filters.iter_mut() {
-            filter.process_waveform(waveform);
-        }
+        biquad::process_mono_cascade(&mut self.stages, waveform);
     }
 
     fn update_parameters(&mut self, conf: config::Filter) {
@@ -249,8 +230,7 @@ impl Filter for BiquadCombo {
             parameters: conf, ..
         } = conf
         {
-            let name = self.name.clone();
-            *self = BiquadCombo::from_config(&name, self.samplerate, conf);
+            self.stages = stages(self.samplerate, conf);
         } else {
             // This should never happen unless there is a bug somewhere else
             panic!("Invalid config change!");
@@ -391,7 +371,7 @@ mod tests {
     }
     #[test]
     fn make_butterworth_2() {
-        let q = biquadcombo::BiquadCombo::butterworth_q(2);
+        let q = biquadcombo::butterworth_q(2);
         let expect = vec![0.707];
         assert!(q.len() == 1);
         assert!(compare_vecs(q, expect, 0.01));
@@ -399,7 +379,7 @@ mod tests {
 
     #[test]
     fn make_butterworth_5() {
-        let q = biquadcombo::BiquadCombo::butterworth_q(5);
+        let q = biquadcombo::butterworth_q(5);
         let expect = vec![1.62, 0.62, -1.0];
         assert!(q.len() == 3);
         assert!(compare_vecs(q, expect, 0.01));
@@ -407,7 +387,7 @@ mod tests {
 
     #[test]
     fn make_butterworth_8() {
-        let q = biquadcombo::BiquadCombo::butterworth_q(8);
+        let q = biquadcombo::butterworth_q(8);
         let expect = vec![2.56, 0.9, 0.6, 0.51];
         assert!(q.len() == 4);
         assert!(compare_vecs(q, expect, 0.01));
@@ -415,7 +395,7 @@ mod tests {
 
     #[test]
     fn make_lr4() {
-        let q = biquadcombo::BiquadCombo::linkwitzriley_q(4);
+        let q = biquadcombo::linkwitzriley_q(4);
         let expect = vec![0.707, 0.707];
         assert!(q.len() == 2);
         assert!(compare_vecs(q, expect, 0.01));
@@ -423,7 +403,7 @@ mod tests {
 
     #[test]
     fn make_lr6() {
-        let q = biquadcombo::BiquadCombo::linkwitzriley_q(10);
+        let q = biquadcombo::linkwitzriley_q(10);
         let expect = vec![1.62, 0.62, 1.62, 0.62, 0.5];
         assert!(q.len() == 5);
         assert!(compare_vecs(q, expect, 0.01));
@@ -545,8 +525,7 @@ mod tests {
             band(2500.0, -0.25),
             band(8000.0, 0.5),
         ]);
-        let combo = biquadcombo::BiquadCombo::from_config("test", 44100, conf);
-        assert_eq!(combo.filters.len(), 5);
+        assert_eq!(biquadcombo::stages(44100, conf).len(), 5);
     }
 
     #[test]
@@ -558,25 +537,20 @@ mod tests {
             band(1000.0, 0.0005),
             band(8000.0, 0.0),
         ]);
-        let combo = biquadcombo::BiquadCombo::from_config("test", 44100, conf);
-        assert_eq!(combo.filters.len(), 1);
+        assert_eq!(biquadcombo::stages(44100, conf).len(), 1);
     }
 
     #[test]
     fn npeq_zero_gain_band_keeps_the_roles_of_the_others() {
         // Dropping a zero gain band must not promote its neighbour to a shelf.
         let bands = vec![band(100.0, 1.0), band(1000.0, 1.0), band(8000.0, 0.0)];
-        let with_zero = biquadcombo::BiquadCombo::from_config("a", 44100, npeq(bands));
+        let with_zero = biquadcombo::stages(44100, npeq(bands));
         // The same two active bands, but now the peak really is the last band.
-        let as_listed = biquadcombo::BiquadCombo::from_config(
-            "b",
-            44100,
-            npeq(vec![band(100.0, 1.0), band(1000.0, 1.0)]),
-        );
-        assert_eq!(with_zero.filters.len(), 2);
-        assert_eq!(as_listed.filters.len(), 2);
-        let mut with_zero = with_zero;
-        let mut as_listed = as_listed;
+        let as_listed = biquadcombo::stages(44100, npeq(vec![band(100.0, 1.0), band(1000.0, 1.0)]));
+        assert_eq!(with_zero.len(), 2);
+        assert_eq!(as_listed.len(), 2);
+        let mut with_zero = biquadcombo::Combo::new("a", 44100, with_zero);
+        let mut as_listed = biquadcombo::Combo::new("b", 44100, as_listed);
         let mut wave_a = vec![0.0; 256];
         wave_a[0] = 1.0;
         let mut wave_b = wave_a.clone();
@@ -593,8 +567,9 @@ mod tests {
             band(1000.0, -0.0),
             band(8000.0, 0.0),
         ]);
-        let mut combo = biquadcombo::BiquadCombo::from_config("test", 44100, conf);
-        assert!(combo.filters.is_empty());
+        let built = biquadcombo::stages(44100, conf);
+        assert!(built.is_empty());
+        let mut combo = biquadcombo::Combo::new("test", 44100, built);
         let mut wave = vec![1.0, 0.5, -0.25, 0.0];
         let expected = wave.clone();
         combo.process_waveform(&mut wave);
@@ -611,7 +586,7 @@ mod tests {
             band(2500.0, -0.25),
             band(8000.0, 0.5),
         ]);
-        let mut combo = biquadcombo::BiquadCombo::from_config("test", fs, conf);
+        let mut combo = biquadcombo::Combo::new("test", fs, biquadcombo::stages(fs, conf));
         // The same equalizer, spelled out as separate biquads in the same order.
         let separate = [
             config::BiquadParameters::Lowshelf(config::ShelfSteepness::Q {

--- a/src/filters/loudness.rs
+++ b/src/filters/loudness.rs
@@ -36,8 +36,9 @@ pub struct Loudness {
     low_freq: f64,
     high_q: f64,
     low_q: f64,
-    high_biquad: biquad::Biquad,
-    low_biquad: biquad::Biquad,
+    /// The high and low shelf, in that order, so they can be run as a two
+    /// stage cascade rather than one after the other.
+    shelves: [biquad::Biquad; 2],
     fader: usize,
     active: bool,
     gain: Option<Gain>,
@@ -93,11 +94,18 @@ impl Loudness {
             None
         };
 
-        let high_biquad_coeffs =
-            biquad::BiquadCoefficients::from_config(samplerate, highshelf_conf);
-        let low_biquad_coeffs = biquad::BiquadCoefficients::from_config(samplerate, lowshelf_conf);
-        let high_biquad = biquad::Biquad::new("highshelf", samplerate, high_biquad_coeffs);
-        let low_biquad = biquad::Biquad::new("lowshelf", samplerate, low_biquad_coeffs);
+        let shelves = [
+            biquad::Biquad::new(
+                "highshelf",
+                samplerate,
+                biquad::BiquadCoefficients::from_config(samplerate, highshelf_conf),
+            ),
+            biquad::Biquad::new(
+                "lowshelf",
+                samplerate,
+                biquad::BiquadCoefficients::from_config(samplerate, lowshelf_conf),
+            ),
+        ];
         Loudness {
             name: name.to_string(),
             current_volume: current_volume as CamillaFloat,
@@ -108,8 +116,7 @@ impl Loudness {
             low_freq: conf.low_freq(),
             high_q: conf.high_q(),
             low_q: conf.low_q(),
-            high_biquad,
-            low_biquad,
+            shelves,
             processing_params,
             fader,
             active,
@@ -143,11 +150,11 @@ impl Filter for Loudness {
             );
             let highshelf_conf = highshelf_conf(self.high_freq, self.high_q, high_boost);
             let lowshelf_conf = lowshelf_conf(self.low_freq, self.low_q, low_boost);
-            self.high_biquad.update_parameters(config::Filter::Biquad {
+            self.shelves[0].update_parameters(config::Filter::Biquad {
                 parameters: highshelf_conf,
                 description: None,
             });
-            self.low_biquad.update_parameters(config::Filter::Biquad {
+            self.shelves[1].update_parameters(config::Filter::Biquad {
                 parameters: lowshelf_conf,
                 description: None,
             });
@@ -167,8 +174,9 @@ impl Filter for Loudness {
         }
         if self.active {
             trace!("Applying loudness biquads");
-            self.high_biquad.process_waveform(waveform);
-            self.low_biquad.process_waveform(waveform);
+            // Two stages, run as one canon rather than one after the
+            // other, so the second is not waiting on the first.
+            biquad::process_mono_cascade(&mut self.shelves, waveform);
             if let Some(gain) = &mut self.gain {
                 gain.process_waveform(waveform);
             }
@@ -188,11 +196,11 @@ impl Filter for Loudness {
             self.active = relboost > 0.001;
             let highshelf_conf = highshelf_conf(conf.high_freq(), conf.high_q(), high_boost);
             let lowshelf_conf = lowshelf_conf(conf.low_freq(), conf.low_q(), low_boost);
-            self.high_biquad.update_parameters(config::Filter::Biquad {
+            self.shelves[0].update_parameters(config::Filter::Biquad {
                 parameters: highshelf_conf,
                 description: None,
             });
-            self.low_biquad.update_parameters(config::Filter::Biquad {
+            self.shelves[1].update_parameters(config::Filter::Biquad {
                 parameters: lowshelf_conf,
                 description: None,
             });
@@ -266,9 +274,14 @@ pub fn validate_config(samplerate: usize, conf: &config::LoudnessParameters) -> 
 
 #[cfg(test)]
 mod tests {
+    use super::{Loudness, rel_boost};
+    use crate::CamillaFloat;
+    use crate::ProcessingParameters;
     use crate::config::{BiquadParameters, LoudnessParameters, ShelfSteepness};
-    use crate::filters::biquad::BiquadCoefficients;
+    use crate::filters::Filter;
+    use crate::filters::biquad::{self, BiquadCoefficients};
     use crate::filters::loudness::validate_config;
+    use std::sync::Arc;
 
     fn params() -> LoudnessParameters {
         LoudnessParameters {
@@ -359,5 +372,77 @@ mod tests {
         assert!(validate_config(44100, &conf).is_err());
         conf.high_q = Some(1.5);
         assert!(validate_config(44100, &conf).is_ok());
+    }
+
+    /// The two shelves run as one two stage canon rather than one after the
+    /// other. That is a scheduling change only, so the output has to stay
+    /// bit-identical to applying the highshelf and then the lowshelf, and the
+    /// highshelf has to stay first.
+    #[test]
+    fn the_shelves_match_running_them_one_at_a_time() {
+        const FS: usize = 44100;
+        const VOLUME: f32 = -30.0;
+        let conf = LoudnessParameters {
+            reference_level: -10.0,
+            high_boost: Some(8.0),
+            low_boost: Some(6.0),
+            ..params()
+        };
+        // Below the reference level, or the filter does nothing at all and the
+        // comparison would pass on two untouched waveforms.
+        let relboost = rel_boost(VOLUME, conf.reference_level);
+        assert!(relboost > 0.01, "the filter has to be active to be tested");
+
+        let processing = Arc::new(ProcessingParameters::default());
+        processing.set_target_volume(0, VOLUME);
+        processing.sync_volumes_to_target();
+        let mut loudness = Loudness::from_config("l", conf.clone(), FS, processing);
+
+        let signal: Vec<CamillaFloat> = (0..512)
+            .map(|i| (0.017 * (i as CamillaFloat)).sin() * 0.5)
+            .collect();
+        let mut got = signal.clone();
+        loudness.process_waveform(&mut got);
+
+        let high_boost = (relboost * conf.high_boost()) as f64;
+        let low_boost = (relboost * conf.low_boost()) as f64;
+        let mut shelves = [
+            biquad::Biquad::new(
+                "highshelf",
+                FS,
+                BiquadCoefficients::from_config(
+                    FS,
+                    BiquadParameters::Highshelf(ShelfSteepness::Q {
+                        freq: conf.high_freq(),
+                        q: conf.high_q(),
+                        gain: high_boost,
+                    }),
+                ),
+            ),
+            biquad::Biquad::new(
+                "lowshelf",
+                FS,
+                BiquadCoefficients::from_config(
+                    FS,
+                    BiquadParameters::Lowshelf(ShelfSteepness::Q {
+                        freq: conf.low_freq(),
+                        q: conf.low_q(),
+                        gain: low_boost,
+                    }),
+                ),
+            ),
+        ];
+        let mut want = signal.clone();
+        for shelf in shelves.iter_mut() {
+            shelf.process_waveform(&mut want);
+        }
+
+        assert!(
+            want.iter().zip(signal.iter()).any(|(a, b)| a != b),
+            "the reference did not filter anything"
+        );
+        for (i, (a, b)) in got.iter().zip(want.iter()).enumerate() {
+            assert_eq!(a.to_bits(), b.to_bits(), "sample {i}, {a} against {b}");
+        }
     }
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -68,9 +68,15 @@ impl FilterGroup {
                         filters::biquad::BiquadCoefficients::from_config(sample_freq, parameters),
                     ))
                 }
-                config::Filter::BiquadCombo { parameters, .. } => Box::new(
-                    filters::biquadcombo::BiquadCombo::from_config(name, sample_freq, parameters),
-                ),
+                // A combo in a step that is not all biquads cannot join a
+                // compiled cascade, so it runs as a cascade of its own.
+                config::Filter::BiquadCombo { parameters, .. } => {
+                    Box::new(filters::biquadcombo::Combo::new(
+                        name,
+                        sample_freq,
+                        filters::biquadcombo::stages(sample_freq, parameters),
+                    ))
+                }
                 config::Filter::Delay { parameters, .. } => Box::new(
                     filters::basicfilters::Delay::from_config(name, sample_freq, parameters),
                 ),
@@ -182,12 +188,215 @@ impl ParallelFilters {
     }
 }
 
+/// A consecutive run of names in a filter step that are all biquad-based, or
+/// all not.
+struct FilterRun {
+    biquads: bool,
+    names: std::ops::Range<usize>,
+}
+
+/// Split a step's filter names into consecutive runs by whether they are
+/// biquad-based.
+///
+/// One pass over the names and no cross-channel comparison, because a filter
+/// step applies the same list to every channel it reaches, so a name that is a
+/// biquad is a biquad on all of them. Comparing every position of every channel
+/// instead only becomes necessary after the steps have been merged, where that
+/// no longer holds, which is why this runs before the merge.
+fn biquad_runs(
+    names: &[String],
+    filter_configs: &HashMap<String, config::Filter>,
+) -> Vec<FilterRun> {
+    let mut runs: Vec<FilterRun> = Vec::new();
+    for (index, name) in names.iter().enumerate() {
+        let biquads = matches!(
+            filter_configs[name],
+            config::Filter::Biquad { .. } | config::Filter::BiquadCombo { .. }
+        );
+        match runs.last_mut() {
+            Some(run) if run.biquads == biquads => run.names.end = index + 1,
+            _ => runs.push(FilterRun {
+                biquads,
+                names: index..index + 1,
+            }),
+        }
+    }
+    runs
+}
+
+/// A run of biquad-based filters from one config filter step, compiled into
+/// one cascade per channel.
+///
+/// A config filter step applies one `names` list to every channel it reaches,
+/// so every channel here has the same shape and the same number of stages. That
+/// rectangle is what lets the kernel take several channels at once, and it is
+/// why compiling happens per config step rather than after the steps have been
+/// merged.
+///
+/// The cascade runs across the filter boundaries inside the run, so eight
+/// one-biquad filters reach the same depth as one eight stage combo.
+pub struct BiquadStep {
+    /// The chunk channel that `cascades[i]` filters.
+    channel_of: Vec<usize>,
+    /// One cascade per entry in `channel_of`, all the same length.
+    cascades: Vec<Vec<filters::biquad::Biquad>>,
+    /// One entry per config filter name, in order, shared by every channel.
+    sections: Vec<Section>,
+    samplerate: usize,
+    /// The cascades that have audio to process this chunk. Held here and
+    /// refilled in place so the audio path does not allocate.
+    live: Vec<usize>,
+}
+
+/// One config filter's worth of stages inside a compiled cascade.
+///
+/// `len` can be zero, and can change on a reload: a graphic equalizer drops any
+/// band that is flat, and `config_diff` only rebuilds the pipeline when a
+/// filter changes type, so a slider crossing flat arrives here as a resize.
+struct Section {
+    name: String,
+    len: usize,
+}
+
+/// The stages a config filter expands to, or `None` if it is not biquad-based.
+fn biquad_stages(
+    name: &str,
+    conf: &config::Filter,
+    samplerate: usize,
+) -> Option<Vec<filters::biquad::Biquad>> {
+    match conf {
+        config::Filter::Biquad { parameters, .. } => {
+            let coeffs =
+                filters::biquad::BiquadCoefficients::from_config(samplerate, parameters.clone());
+            Some(vec![filters::biquad::Biquad::new(name, samplerate, coeffs)])
+        }
+        config::Filter::BiquadCombo { parameters, .. } => {
+            Some(filters::biquadcombo::stages(samplerate, parameters.clone()))
+        }
+        _ => None,
+    }
+}
+
+impl BiquadStep {
+    /// Compiles a run of biquad-based filters into one cascade per channel.
+    ///
+    /// `names` must be a run that [`biquad_runs`] marked as biquads, which is
+    /// what makes `biquad_stages` infallible here, and `channels` must not be
+    /// empty. Both are the caller's to hold up.
+    fn from_config(
+        channels: &[usize],
+        names: &[String],
+        filter_configs: &HashMap<String, config::Filter>,
+        samplerate: usize,
+    ) -> Self {
+        // Built once and cloned per channel, so the coefficient maths runs once
+        // for the step rather than once for every channel of it.
+        let mut stages = Vec::new();
+        let mut sections = Vec::with_capacity(names.len());
+        for name in names {
+            let expanded = biquad_stages(name, &filter_configs[name], samplerate)
+                .expect("a biquad run holds only biquad-based filters");
+            sections.push(Section {
+                name: name.clone(),
+                len: expanded.len(),
+            });
+            stages.extend(expanded);
+        }
+        debug!(
+            "Compiled filter step with filters {:?} to {} biquads on each of {} channels",
+            names,
+            stages.len(),
+            channels.len()
+        );
+        BiquadStep {
+            channel_of: channels.to_vec(),
+            cascades: vec![stages; channels.len()],
+            sections,
+            samplerate,
+            live: Vec::with_capacity(channels.len()),
+        }
+    }
+
+    /// Hot-reload parameters for any filters whose names appear in `changed`.
+    ///
+    /// The sections are walked in order with a running offset, so a section
+    /// that resizes carries the new offset to the ones after it. Only the
+    /// section that changed is rebuilt, so the biquads around it keep their
+    /// state.
+    fn update_parameters(
+        &mut self,
+        filterconfigs: &HashMap<String, config::Filter>,
+        changed: &[String],
+    ) {
+        let Self {
+            cascades,
+            sections,
+            samplerate,
+            ..
+        } = self;
+        let mut start = 0;
+        for section in sections.iter_mut() {
+            if changed.iter().any(|n| n == &section.name) {
+                match &filterconfigs[&section.name] {
+                    // Always one stage, and coefficients only, so the filter
+                    // state survives exactly as it does for a lone biquad.
+                    config::Filter::Biquad { parameters, .. } => {
+                        let coeffs = filters::biquad::BiquadCoefficients::from_config(
+                            *samplerate,
+                            parameters.clone(),
+                        );
+                        for cascade in cascades.iter_mut() {
+                            cascade[start].set_coefficients(coeffs);
+                        }
+                    }
+                    // The stage count can change, so splice. State resets for
+                    // this section, which is what rebuilding a combo has always
+                    // done.
+                    config::Filter::BiquadCombo { parameters, .. } => {
+                        let rebuilt = filters::biquadcombo::stages(*samplerate, parameters.clone());
+                        for cascade in cascades.iter_mut() {
+                            cascade.splice(start..start + section.len, rebuilt.iter().cloned());
+                        }
+                        section.len = rebuilt.len();
+                    }
+                    _ => unreachable!("only biquad-based filters are compiled into a cascade"),
+                }
+            }
+            start += section.len;
+        }
+    }
+
+    /// Apply the cascades to an AudioChunk.
+    fn process_chunk(&mut self, input: &mut AudioChunk) {
+        // An unused capture channel arrives as an empty waveform, and the
+        // kernel walks the channels of a group together. Leaving one in would
+        // let it decide the length for the whole group and silently leave the
+        // others unfiltered, so it is kept out of the grouping entirely.
+        self.live.clear();
+        for (position, &channel) in self.channel_of.iter().enumerate() {
+            if !input.waveforms[channel].is_empty() {
+                self.live.push(position);
+            }
+        }
+        if self.live.is_empty() {
+            return;
+        }
+        filters::biquad::process_cascades(
+            &mut self.cascades,
+            &mut input.waveforms,
+            &self.channel_of,
+            &self.live,
+        );
+    }
+}
+
 /// A Pipeline is made up of a series of PipelineSteps,
 /// each one can be a single Mixer or a group of Filters
 pub enum PipelineStep {
     MixerStep(mixer::Mixer),
     FilterStep(FilterGroup),
     ParallelFiltersStep(ParallelFilters),
+    BiquadStep(BiquadStep),
     ProcessorStep(Box<dyn Processor>),
 }
 
@@ -249,17 +458,49 @@ impl Pipeline {
                             );
                             Box::new(0..num_channels) as Box<dyn Iterator<Item = usize>>
                         };
-                        for channel in channels_iter {
-                            let fltgrp = FilterGroup::from_config(
-                                channel,
-                                &step.names,
-                                conf.filters.as_ref().unwrap().clone(),
-                                conf.devices.chunksize,
-                                conf.devices.samplerate,
-                                processing_params.clone(),
-                                &mut coeff_cache,
-                            );
-                            steps.push(PipelineStep::FilterStep(fltgrp));
+                        let channels: Vec<usize> = channels_iter.collect();
+                        // A step can name an empty list of channels, which
+                        // makes it a step that does nothing.
+                        if channels.is_empty() {
+                            continue;
+                        }
+                        let filter_configs = conf.filters.as_ref().unwrap();
+                        // Runs of biquad-based filters compile into one cascade
+                        // per channel, so the canon reaches across the
+                        // filter boundaries inside a run. Everything else keeps
+                        // the per-channel chains. A run is decided by the names
+                        // alone, since the step applies the same list to every
+                        // channel it reaches.
+                        //
+                        // Splitting a step this way runs all of one run's
+                        // channels before any of the next run's, where the
+                        // whole step used to run channel by channel. Each
+                        // channel still sees its filters in the configured
+                        // order; only filters that share state across channels
+                        // can tell, which `parallelize_filters` describes.
+                        for run in biquad_runs(&step.names, filter_configs) {
+                            let names = &step.names[run.names.clone()];
+                            if run.biquads {
+                                steps.push(PipelineStep::BiquadStep(BiquadStep::from_config(
+                                    &channels,
+                                    names,
+                                    filter_configs,
+                                    conf.devices.samplerate,
+                                )));
+                                continue;
+                            }
+                            for &channel in &channels {
+                                let fltgrp = FilterGroup::from_config(
+                                    channel,
+                                    names,
+                                    filter_configs.clone(),
+                                    conf.devices.chunksize,
+                                    conf.devices.samplerate,
+                                    processing_params.clone(),
+                                    &mut coeff_cache,
+                                );
+                                steps.push(PipelineStep::FilterStep(fltgrp));
+                            }
                         }
                     }
                 }
@@ -373,6 +614,9 @@ impl Pipeline {
                         &mut coeff_cache,
                     );
                 }
+                PipelineStep::BiquadStep(flt) => {
+                    flt.update_parameters(conf.filters.as_ref().unwrap(), filters);
+                }
                 PipelineStep::ProcessorStep(proc) => {
                     if processors.iter().any(|n| n == proc.name()) {
                         proc.update_parameters(
@@ -397,6 +641,9 @@ impl Pipeline {
                     flt.process_chunk(&mut chunk);
                 }
                 PipelineStep::ParallelFiltersStep(flt) => {
+                    flt.process_chunk(&mut chunk);
+                }
+                PipelineStep::BiquadStep(flt) => {
                     flt.process_chunk(&mut chunk);
                 }
                 PipelineStep::ProcessorStep(comp) => {
@@ -439,6 +686,11 @@ impl Pipeline {
 /// moving. Both on the same channel is not affected, the chain there keeping
 /// the order the configuration gave.
 ///
+/// This is not only the pool's doing. A compiled biquad run splits a step for
+/// every channel at once, so a biquad between a `Volume` and a `Loudness` puts
+/// the same cross-channel interleaving in the default single threaded path.
+/// The pool widens the reordering, it does not introduce it.
+///
 /// The cost is one chunk of lag on a compensation curve that moves over
 /// hundreds of milliseconds, which is not audible. Before giving up the
 /// parallelism to preserve the order exactly, check that there is a listener
@@ -463,12 +715,12 @@ fn parallelize_filters(
                 debug!("Append mixer step to pipeline");
                 new_steps.push(step);
             }
-            PipelineStep::ProcessorStep(_) => {
+            PipelineStep::ProcessorStep(_) | PipelineStep::BiquadStep(_) => {
                 if parfilt.is_some() {
                     debug!("Append parallel filter step to pipeline");
                     new_steps.push(PipelineStep::ParallelFiltersStep(parfilt.take().unwrap()));
                 }
-                debug!("Append processor step to pipeline");
+                debug!("Append step to pipeline without merging it");
                 new_steps.push(step);
             }
             PipelineStep::ParallelFiltersStep(_) => {
@@ -511,11 +763,553 @@ fn parallelize_filters(
 
 #[cfg(test)]
 mod tests {
-    use super::Pipeline;
+    use super::{Pipeline, PipelineStep};
     use crate::CamillaFloat;
     use crate::ProcessingParameters;
     use crate::audiochunk::AudioChunk;
+    use crate::filters::Filter;
     use std::sync::Arc;
+
+    /// Filters shared by the tests below. Distinct coefficients, so a stage
+    /// that runs out of order or twice cannot go unnoticed, and a graphic
+    /// equalizer in the middle whose stage count depends on its gains.
+    const FILTERS: &str = "
+filters:
+  bq_a:
+    type: Biquad
+    parameters:
+      type: Peaking
+      freq: 120
+      q: 1.1
+      gain: 3.0
+  bq_b:
+    type: Biquad
+    parameters:
+      type: Lowshelf
+      freq: 400
+      q: 0.7
+      gain: -2.5
+  combo:
+    type: BiquadCombo
+    parameters:
+      type: ButterworthHighpass
+      freq: 80
+      order: 4
+  geq:
+    type: BiquadCombo
+    parameters:
+      type: GraphicEqualizer
+      gains: [1.0, 0.0, -2.0, 0.0, 3.0]
+  bq_c:
+    type: Biquad
+    parameters:
+      type: Highshelf
+      freq: 5000
+      q: 0.8
+      gain: 1.5
+";
+
+    fn config_with(
+        pipeline: &str,
+        channels: usize,
+        chunksize: usize,
+    ) -> crate::config::Configuration {
+        let text = format!(
+            "
+devices:
+  samplerate: 44100
+  chunksize: {chunksize}
+  capture:
+    type: SignalGenerator
+    channels: {channels}
+    signal:
+      type: Sine
+      freq: 1000
+      level: 0.0
+  playback:
+    type: Stdout
+    channels: {channels}
+    format: S16_LE
+{FILTERS}
+{pipeline}
+"
+        );
+        yaml_serde::from_str(&text).unwrap()
+    }
+
+    fn test_signal(n: usize, seed: usize) -> Vec<CamillaFloat> {
+        (0..n)
+            .map(|i| (0.017 * ((7 * i + 13 * seed) as CamillaFloat)).sin() * 0.5)
+            .collect()
+    }
+
+    /// The stages a named filter expands to, built straight from the config so
+    /// the reference does not go through any of the code under test.
+    fn reference_stages(
+        conf: &crate::config::Configuration,
+        name: &str,
+    ) -> Vec<crate::filters::biquad::Biquad> {
+        let fs = conf.devices.samplerate;
+        super::biquad_stages(name, &conf.filters.as_ref().unwrap()[name], fs).unwrap()
+    }
+
+    fn assert_bit_equal(left: &[Vec<CamillaFloat>], right: &[Vec<CamillaFloat>], what: &str) {
+        assert_eq!(left.len(), right.len(), "{what}: channels");
+        for (ch, (l, r)) in left.iter().zip(right.iter()).enumerate() {
+            assert_eq!(l.len(), r.len(), "{what}: length of channel {ch}");
+            for (i, (a, b)) in l.iter().zip(r.iter()).enumerate() {
+                assert_eq!(a.to_bits(), b.to_bits(), "{what}: channel {ch} sample {i}");
+            }
+        }
+    }
+
+    /// A compiled step has to produce exactly what the same filters produce run
+    /// one at a time. This is the property that makes compiling them safe, and
+    /// the reference here is genuinely sequential: every stage over the whole
+    /// waveform, through `Biquad::process_waveform`.
+    ///
+    /// The master volume sits ahead of the steps, but at 0 dB with no ramp it
+    /// multiplies by exactly 1.0, so it does not disturb the comparison.
+    #[test]
+    fn compiled_step_matches_sequential() {
+        const CHANNELS: usize = 2;
+        const CHUNK: usize = 256;
+        const NAMES: [&str; 5] = ["bq_a", "combo", "bq_b", "geq", "bq_c"];
+        let conf = config_with(
+            "
+pipeline:
+  - type: Filter
+    names: [bq_a, combo, bq_b, geq, bq_c]
+",
+            CHANNELS,
+            CHUNK,
+        );
+
+        let params = Arc::new(ProcessingParameters::default());
+        let mut pipeline = Pipeline::from_config(conf.clone(), params, None);
+        assert!(
+            matches!(pipeline.steps[0], PipelineStep::BiquadStep(_)),
+            "an all-biquad step should compile"
+        );
+
+        let waveforms: Vec<Vec<CamillaFloat>> =
+            (0..CHANNELS).map(|c| test_signal(CHUNK, c)).collect();
+        let chunk = AudioChunk::new(waveforms.clone(), 1.0, -1.0, CHUNK, CHUNK);
+        let out = pipeline.process_chunk(chunk);
+
+        let mut want = waveforms;
+        for waveform in want.iter_mut() {
+            for name in NAMES {
+                for stage in reference_stages(&conf, name).iter_mut() {
+                    stage.process_waveform(waveform);
+                }
+            }
+        }
+        assert_bit_equal(&out.waveforms, &want, "compiled against sequential");
+    }
+
+    /// A channel the capture step does not use arrives as an empty waveform.
+    /// The kernel walks the channels of a group together, so an empty one left
+    /// in would decide the length for the whole group and silently leave the
+    /// others unfiltered.
+    #[test]
+    fn an_unused_channel_does_not_silence_the_others() {
+        const CHANNELS: usize = 4;
+        const CHUNK: usize = 128;
+        let conf = config_with(
+            "
+pipeline:
+  - type: Filter
+    names: [bq_a, bq_b, bq_c]
+",
+            CHANNELS,
+            CHUNK,
+        );
+
+        let params = Arc::new(ProcessingParameters::default());
+        let mut pipeline = Pipeline::from_config(conf.clone(), params, None);
+
+        // Only 0 and 2 carry audio, as they would ahead of a mixer that reads
+        // just those two of four capture channels.
+        let live = [0usize, 2];
+        let waveforms: Vec<Vec<CamillaFloat>> = (0..CHANNELS)
+            .map(|c| {
+                if live.contains(&c) {
+                    test_signal(CHUNK, c)
+                } else {
+                    Vec::new()
+                }
+            })
+            .collect();
+        let chunk = AudioChunk::new(waveforms.clone(), 1.0, -1.0, CHUNK, CHUNK);
+        let out = pipeline.process_chunk(chunk);
+
+        let mut want = waveforms;
+        for waveform in want.iter_mut() {
+            for name in ["bq_a", "bq_b", "bq_c"] {
+                for stage in reference_stages(&conf, name).iter_mut() {
+                    stage.process_waveform(waveform);
+                }
+            }
+        }
+        assert_bit_equal(&out.waveforms, &want, "with two unused channels");
+        for &c in &live {
+            assert!(
+                out.waveforms[c].iter().any(|v| *v != 0.0),
+                "channel {c} came out silent"
+            );
+        }
+    }
+
+    /// A graphic equalizer resizes whenever a band crosses flat, and
+    /// `config_diff` sends that through as an in-place parameter update rather
+    /// than a rebuild. The section has to be spliced without disturbing the
+    /// biquads on either side of it, which keep their filter state.
+    #[test]
+    fn a_resizing_combo_leaves_its_neighbours_alone() {
+        const CHUNK: usize = 128;
+        let conf = config_with(
+            "
+pipeline:
+  - type: Filter
+    names: [bq_a, geq, bq_c]
+",
+            2,
+            CHUNK,
+        );
+        let params = Arc::new(ProcessingParameters::default());
+        let mut pipeline = Pipeline::from_config(conf.clone(), params, None);
+
+        // Run a chunk so every stage has state worth preserving.
+        let waveforms: Vec<Vec<CamillaFloat>> = (0..2).map(|c| test_signal(CHUNK, c)).collect();
+        pipeline.process_chunk(AudioChunk::new(waveforms, 1.0, -1.0, CHUNK, CHUNK));
+
+        let PipelineStep::BiquadStep(step) = &pipeline.steps[0] else {
+            panic!("expected a compiled step");
+        };
+        // Three active bands out of five, plus one biquad either side.
+        assert_eq!(
+            step.sections.iter().map(|s| s.len).collect::<Vec<_>>(),
+            vec![1, 3, 1]
+        );
+        let before: Vec<_> = step.cascades[0]
+            .iter()
+            .map(|b| (b.s1.to_bits(), b.s2.to_bits()))
+            .collect();
+        let first_before = before[0];
+        let last_before = *before.last().unwrap();
+
+        // Two more bands come off flat, so the section grows from three to five.
+        let mut newconf = conf.clone();
+        newconf.filters.as_mut().unwrap().insert(
+            "geq".to_string(),
+            yaml_serde::from_str(
+                "
+type: BiquadCombo
+parameters:
+  type: GraphicEqualizer
+  gains: [1.0, 2.0, -2.0, -1.0, 3.0]
+",
+            )
+            .unwrap(),
+        );
+        pipeline.update_parameters(newconf, &["geq".to_string()], &[], &[]);
+
+        let PipelineStep::BiquadStep(step) = &pipeline.steps[0] else {
+            panic!("expected a compiled step");
+        };
+        assert_eq!(
+            step.sections.iter().map(|s| s.len).collect::<Vec<_>>(),
+            vec![1, 5, 1],
+            "the section should have grown"
+        );
+        assert_eq!(step.cascades[0].len(), 7, "and the cascade with it");
+        let after: Vec<_> = step.cascades[0]
+            .iter()
+            .map(|b| (b.s1.to_bits(), b.s2.to_bits()))
+            .collect();
+        assert_eq!(
+            after[0], first_before,
+            "the biquad before it lost its state"
+        );
+        assert_eq!(
+            *after.last().unwrap(),
+            last_before,
+            "the biquad after it lost its state"
+        );
+
+        // The spliced cascade also has to still process correctly. Take the
+        // stages as they now stand, run the next chunk through the pipeline,
+        // and check it against those same stages run one at a time from the
+        // same state.
+        let mut reference = step.cascades.clone();
+        let next: Vec<Vec<CamillaFloat>> = (0..2).map(|c| test_signal(CHUNK, c + 7)).collect();
+        let out = pipeline.process_chunk(AudioChunk::new(next.clone(), 1.0, -1.0, CHUNK, CHUNK));
+        let mut want = next;
+        for (cascade, waveform) in reference.iter_mut().zip(want.iter_mut()) {
+            for stage in cascade.iter_mut() {
+                stage.process_waveform(waveform);
+            }
+        }
+        assert_bit_equal(&out.waveforms, &want, "processing after the resize");
+        let peak = out
+            .waveforms
+            .iter()
+            .flat_map(|w| w.iter())
+            .fold(0.0 as CamillaFloat, |m, v| m.max(v.abs()));
+        assert!(
+            peak > 1e-6,
+            "silence after the resize, the test proves nothing"
+        );
+    }
+
+    /// A step that mixes biquads with anything else splits into runs: the
+    /// biquad runs compile, the rest keeps the per-channel chains. Each channel
+    /// still sees its filters in the order the configuration listed them, which
+    /// is what this checks by running the same filters by hand.
+    #[test]
+    fn a_mixed_step_splits_into_runs() {
+        const CHANNELS: usize = 2;
+        const CHUNK: usize = 128;
+        let mut conf = config_with(
+            "
+pipeline:
+  - type: Filter
+    names: [bq_a, combo, gain, bq_b, bq_c]
+",
+            CHANNELS,
+            CHUNK,
+        );
+        conf.filters.as_mut().unwrap().insert(
+            "gain".to_string(),
+            yaml_serde::from_str(
+                "
+type: Gain
+parameters:
+  gain: -6.0
+",
+            )
+            .unwrap(),
+        );
+
+        let params = Arc::new(ProcessingParameters::default());
+        let mut pipeline = Pipeline::from_config(conf.clone(), params, None);
+
+        // Two biquads either side of the gain compile; the gain does not.
+        let shape: Vec<&str> = pipeline
+            .steps
+            .iter()
+            .map(|s| match s {
+                PipelineStep::BiquadStep(_) => "biquad",
+                PipelineStep::FilterStep(_) => "chain",
+                _ => "other",
+            })
+            .collect();
+        assert_eq!(
+            shape,
+            vec!["biquad", "chain", "chain", "biquad"],
+            "expected a compiled run, the gain on each channel, then another run"
+        );
+
+        let waveforms: Vec<Vec<CamillaFloat>> =
+            (0..CHANNELS).map(|c| test_signal(CHUNK, c)).collect();
+        let chunk = AudioChunk::new(waveforms.clone(), 1.0, -1.0, CHUNK, CHUNK);
+        let out = pipeline.process_chunk(chunk);
+
+        let gain_conf = conf.filters.as_ref().unwrap()["gain"].clone();
+        let crate::config::Filter::Gain { parameters, .. } = gain_conf else {
+            unreachable!()
+        };
+        let mut want = waveforms;
+        for waveform in want.iter_mut() {
+            for stage in reference_stages(&conf, "bq_a").iter_mut() {
+                stage.process_waveform(waveform);
+            }
+            for stage in reference_stages(&conf, "combo").iter_mut() {
+                stage.process_waveform(waveform);
+            }
+            crate::filters::basicfilters::Gain::from_config("gain", parameters.clone())
+                .process_waveform(waveform);
+            for stage in reference_stages(&conf, "bq_b").iter_mut() {
+                stage.process_waveform(waveform);
+            }
+            for stage in reference_stages(&conf, "bq_c").iter_mut() {
+                stage.process_waveform(waveform);
+            }
+        }
+        assert_bit_equal(&out.waveforms, &want, "mixed step split into runs");
+    }
+
+    /// Runs one chunk through a pipeline built from `conf`, with or without a
+    /// thread pool, and hands back the waveforms.
+    fn process_once(
+        conf: crate::config::Configuration,
+        multithreaded: bool,
+        channels: usize,
+    ) -> Vec<Vec<CamillaFloat>> {
+        let chunksize = conf.devices.chunksize;
+        let pool = crate::processing::build_processing_threadpool(
+            multithreaded,
+            conf.devices.worker_threads(),
+            chunksize,
+            conf.devices.samplerate,
+        );
+        let params = Arc::new(ProcessingParameters::default());
+        let mut pipeline = Pipeline::from_config(conf, params, pool);
+        let waveforms: Vec<Vec<CamillaFloat>> =
+            (0..channels).map(|c| test_signal(chunksize, c)).collect();
+        let chunk = AudioChunk::new(waveforms, 1.0, -1.0, chunksize, chunksize);
+        pipeline.process_chunk(chunk).waveforms
+    }
+
+    /// A step can name the channels it applies to, so different channels end up
+    /// with different chains. That is the crossover idiom the README documents,
+    /// and it means the pipeline as a whole is ragged even though each
+    /// individual step is not.
+    #[test]
+    fn channel_selectors_give_each_channel_its_own_chain() {
+        const CHANNELS: usize = 4;
+        const CHUNK: usize = 128;
+        let conf = config_with(
+            "
+pipeline:
+  - type: Filter
+    names: [bq_a, combo]
+  - type: Filter
+    channels: [0, 1]
+    names: [bq_b, geq]
+  - type: Filter
+    channels: [2, 3]
+    names: [bq_c]
+",
+            CHANNELS,
+            CHUNK,
+        );
+        let got = process_once(conf.clone(), false, CHANNELS);
+
+        // Every channel takes the first step; only its own pair takes the rest.
+        let per_channel: [&[&str]; CHANNELS] = [
+            &["bq_a", "combo", "bq_b", "geq"],
+            &["bq_a", "combo", "bq_b", "geq"],
+            &["bq_a", "combo", "bq_c"],
+            &["bq_a", "combo", "bq_c"],
+        ];
+        let mut want: Vec<Vec<CamillaFloat>> =
+            (0..CHANNELS).map(|c| test_signal(CHUNK, c)).collect();
+        for (channel, names) in per_channel.iter().enumerate() {
+            for name in *names {
+                for stage in reference_stages(&conf, name).iter_mut() {
+                    stage.process_waveform(&mut want[channel]);
+                }
+            }
+        }
+        assert_bit_equal(&got, &want, "channel selectors");
+
+        // Guards against a vacuous pass: the chains really do differ, and the
+        // pipeline really did produce audio.
+        assert!(
+            got[0] != got[2],
+            "channels 0 and 2 took different chains but came out identical"
+        );
+        let peak = got
+            .iter()
+            .flat_map(|w| w.iter())
+            .fold(0.0 as CamillaFloat, |m, v| m.max(v.abs()));
+        assert!(
+            peak > 1e-6,
+            "pipeline produced silence, the test proves nothing"
+        );
+    }
+
+    /// Compiled cascades stay on the calling thread, because running several
+    /// biquads at a time already keeps the processor busy. Everything else
+    /// still goes to the pool when one is configured, which is what heavy
+    /// convolution wants.
+    #[test]
+    fn the_pool_takes_everything_except_the_cascades() {
+        let mut conf = config_with(
+            "
+pipeline:
+  - type: Filter
+    names: [bq_a, bq_b]
+  - type: Filter
+    names: [conv]
+",
+            2,
+            64,
+        );
+        conf.filters.as_mut().unwrap().insert(
+            "conv".to_string(),
+            yaml_serde::from_str(
+                "
+type: Conv
+parameters:
+  type: Values
+  values: [0.5, 0.25, 0.125]
+",
+            )
+            .unwrap(),
+        );
+        let pool = crate::processing::build_processing_threadpool(true, 2, 64, 44100);
+        assert!(pool.is_some(), "the test needs a pool to be built");
+        let params = Arc::new(ProcessingParameters::default());
+        let pipeline = Pipeline::from_config(conf, params, pool);
+
+        let shape: Vec<&str> = pipeline
+            .steps
+            .iter()
+            .map(|s| match s {
+                PipelineStep::BiquadStep(_) => "cascade",
+                PipelineStep::ParallelFiltersStep(_) => "pool",
+                PipelineStep::FilterStep(_) => "chain",
+                _ => "other",
+            })
+            .collect();
+        assert_eq!(
+            shape,
+            vec!["cascade", "pool"],
+            "biquads should stay off the pool and the convolution should go on it"
+        );
+    }
+
+    /// Running on the pool must not change the audio. The merging that happens
+    /// when a pool is configured reorders filters across channels, so this
+    /// pins that it stays unobservable for a pipeline with no shared state
+    /// between channels.
+    #[test]
+    fn the_pool_does_not_change_the_audio() {
+        const CHANNELS: usize = 4;
+        let pipeline = "
+pipeline:
+  - type: Filter
+    names: [bq_a, combo]
+  - type: Filter
+    channels: [0, 1]
+    names: [bq_b]
+  - type: Filter
+    names: [geq, bq_c]
+";
+        let single = process_once(config_with(pipeline, CHANNELS, 128), false, CHANNELS);
+        let pooled = process_once(config_with(pipeline, CHANNELS, 128), true, CHANNELS);
+        assert_bit_equal(&pooled, &single, "pooled against single threaded");
+    }
+
+    /// A cascade too shallow to fill the width budget on its own has to spend
+    /// what is left on channels, which is the whole reason the kernel carries
+    /// a channel axis at all.
+    #[test]
+    fn a_shallow_cascade_spends_the_rest_of_the_budget_on_channels() {
+        use crate::filters::biquad::{MAX_CHANNELS, MAX_DEPTH, choose_split};
+        // Deep enough to fill the budget alone: one channel at a time.
+        assert_eq!(choose_split(8, 32), (1, MAX_DEPTH));
+        assert_eq!(choose_split(2, 16), (1, MAX_DEPTH));
+        // Too shallow: the channel axis takes up the slack.
+        assert_eq!(choose_split(8, 2), (MAX_CHANNELS, 2));
+        assert_eq!(choose_split(8, 1), (MAX_CHANNELS, 1));
+        // And it cannot ask for more channels than the step actually has.
+        assert_eq!(choose_split(2, 1), (2, 1));
+        assert_eq!(choose_split(1, 1), (1, 1));
+    }
 
     // Regression test: volume set before config load must be applied to the very first chunk.
     // Set volume to -100 dB, then load a config,


### PR DESCRIPTION
Schedules biquads so several independent recurrences run at once, taken from
cascade depth and from channel count. A biquad-heavy pipeline went from 249 to
39 us per chunk. Output is bit-identical to running the filters one at a time.

- New wavefront kernel, generic over channel group and cascade depth
- Runs of biquad filters in a step compile into one cascade per channel at build time
- `BiquadCombo` becomes a builder returning stages, so a combo fuses with the biquads beside it
- Biquad work no longer goes to the thread pool
- Sizing bench in `benches/biquad_canon.rs`, plus a wide-and-shallow case in `benches/pipeline.rs`